### PR TITLE
Release 0.0.12 and Release Script

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -1,0 +1,42 @@
+# Create and publish a new version by creating and pushing a git tag for
+# the version and publishing the version to PyPI. Also perform some
+# basic checks to avoid mistakes in releases, for example tags not
+# matching PyPI.
+# Usage: ./release.sh 0.0.1
+
+set -e
+
+version="$1"
+
+# Check version is valid
+setup_py_version="$(python setup.py --version)"
+if [ "$setup_py_version" != "$version" ]; then
+    echo "setup.py has version $setup_py_version, not $version."
+    echo "Aborting."
+    exit 1
+fi
+
+# Check working directory is clean
+if [ ! -z "$(git status --untracked-files=no --porcelain)" ]; then
+    echo "You have changes that have yet to be committed."
+    echo "Aborting."
+    exit 1
+fi
+
+# Check that we are on master
+branch="$(git rev-parse --abbrev-ref HEAD)"
+if [ "$branch" != "master" ]; then
+    echo "You are on $branch but should be on master for releases."
+    echo "Aborting."
+    exit 1
+fi
+
+# Create and push git tag
+git tag -m "Version v$version" "v$version"
+git push --tags
+
+# Create and publish package
+python setup.py sdist
+twine upload dist/*
+
+echo "Version v$version has been published on PyPI and has a git tag."

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open("README.md", 'r') as readme:
 
 setup(
     name='vivarium-core',
-    version='0.0.11',
+    version='0.0.12',
     packages=[
         'vivarium',
         'vivarium.core',


### PR DESCRIPTION
To create a release for version 1.2.3 using the release script:

```console
./release.sh 1.2.3
```

The script checks that:
* Your working directory is clean (so that the git tag and PyPI versions match)
* You are on master (so that the version history is linear)
* The version in `setup.py` matches the script argument (so that you don't release a version without updating `setup.py`)

Then, the script:
* Creates a git tag with the version number and pushes the tag to GitHub
* Publishes the version to PyPI