### PR TITLE
[WIP] bug with node=None in schema_topology

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open("README.md", 'r') as readme:
 
 setup(
     name='vivarium-core',
-    version='0.0.16',
+    version='0.0.17',
     packages=[
         'vivarium',
         'vivarium.core',

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open("README.md", 'r') as readme:
 
 setup(
     name='vivarium-core',
-    version='0.0.18',
+    version='0.0.19',
     packages=[
         'vivarium',
         'vivarium.core',

--- a/vivarium/core/experiment.py
+++ b/vivarium/core/experiment.py
@@ -44,9 +44,15 @@ from vivarium.core.registry import (
 
 INFINITY = float('inf')
 VERBOSE = False
+EMPTY_UPDATES = None, None, None
 
 log.basicConfig(level=os.environ.get("LOGLEVEL", log.WARNING))
 
+
+def starts_with(l, sub):
+    return len(sub) <= len(l) and all(
+        l[i] == el
+        for i, el in enumerate(sub))
 
 # Store
 def key_for_value(d, looking):
@@ -95,6 +101,35 @@ def dissoc(d, removing):
         key: value
         for key, value in d.items()
         if key not in removing}
+
+
+def delete_in(d, path):
+    if len(path) > 0:
+        head = path[0]
+        if len(path) == 1:
+            # at the node to be deleted
+            del d[head]
+        elif head in d:
+            down = d[head]
+            delete_in(d[head], path[1:])
+
+
+def depth(tree, path=()):
+    '''
+    Create a mapping of every path in the tree to the node living at
+    that path in the tree.
+    '''
+
+    base = {}
+
+    for key, inner in tree.items():
+        down = tuple(path + (key,))
+        if isinstance(inner, dict):
+            base.update(depth(inner, down))
+        else:
+            base[down] = inner
+
+    return base
 
 
 def without(d, removing):
@@ -167,7 +202,6 @@ class Store(object):
         self.divider = None
         self.emit = False
         self.sources = {}
-        self.deleted = False
         self.leaf = False
         self.serializer = None
 
@@ -418,11 +452,11 @@ class Store(object):
         '''
 
         if path:
-            first_step = path[0]
-            if first_step == '..':
+            step = path[0]
+            if step == '..':
                 child = self.outer
             else:
-                child = self.inner.get(first_step)
+                child = self.inner.get(step)
 
             if child:
                 return child.get_path(path[1:])
@@ -481,17 +515,6 @@ class Store(object):
                     else:
                         return self.value
 
-    def mark_deleted(self):
-        '''
-        When nodes are removed from the tree, they are marked as deleted
-        in case something else has a reference to them.
-        '''
-
-        self.deleted = True
-        if self.inner:
-            for child in self.inner.values():
-                child.mark_deleted()
-
     def delete_path(self, path):
         '''
         Delete the subtree at the given path.
@@ -507,7 +530,6 @@ class Store(object):
             if remove in target.inner:
                 lost = target.inner[remove]
                 del target.inner[remove]
-                lost.mark_deleted()
                 return lost
 
     def divide_value(self):
@@ -624,12 +646,14 @@ class Store(object):
         '''
 
         if self.inner or self.subschema:
-            topology_updates = {}
+            process_updates, topology_updates, deletions = {}, {}, []
 
             if '_delete' in update:
                 # delete a list of paths
+                here = self.path_for()
                 for path in update['_delete']:
                     self.delete_path(path)
+                    deletions.append(tuple(here + path))
 
                 update = dissoc(update, ['_delete'])
 
@@ -653,10 +677,17 @@ class Store(object):
                         generate['processes'],
                         generate['topology'],
                         generate['initial_state'])
+
+                    assoc_path(
+                        process_updates,
+                        generate['path'],
+                        generate['processes'])
+
                     assoc_path(
                         topology_updates,
                         generate['path'],
                         generate['topology'])
+
                 self.apply_subschemas()
                 self.apply_defaults()
 
@@ -685,6 +716,12 @@ class Store(object):
                         daughter['processes'],
                         daughter['topology'],
                         daughter['initial_state'])
+
+                    assoc_path(
+                        process_updates,
+                        daughter['path'],
+                        daughter['processes'])
+
                     assoc_path(
                         topology_updates,
                         daughter['path'],
@@ -693,25 +730,34 @@ class Store(object):
                     self.apply_subschemas()
                     self.inner[daughter_id].set_value(initial_state)
                     self.apply_defaults()
-                self.delete_path((mother,))
+
+                here = self.path_for()
+                mother_path = (mother,)
+                self.delete_path(mother_path)
+                deletions.append(tuple(here + mother_path))
 
                 update = dissoc(update, '_divide')
 
             for key, value in update.items():
                 if key in self.inner:
-                    child = self.inner[key]
-                    inner_updates = child.apply_update(
+                    inner = self.inner[key]
+                    inner_topology, inner_processes, inner_deletions = inner.apply_update(
                         value, process_topology, state)
-                    if inner_updates:
+
+                    if inner_topology:
                         topology_updates = deep_merge(
                             topology_updates,
-                            {key: inner_updates})
-                # elif self.subschema:
-                #     self.inner[key] = Store(self.subschema, self)
-                #     self.inner[key].set_value(value)
-                #     self.inner[key].apply_defaults()
+                            {key: inner_topology})
 
-            return topology_updates
+                    if inner_processes:
+                        process_updates = deep_merge(
+                            process_updates,
+                            {key: inner_processes})
+
+                    if inner_deletions:
+                        deletions += inner_deletions
+
+            return topology_updates, process_updates, deletions
 
         else:
             updater, port_mapping = self.get_updater(update)
@@ -732,12 +778,14 @@ class Store(object):
             if port_mapping is not None:
                 updater_topology = {
                     updater_port: process_topology[proc_port]
-                    for updater_port, proc_port in port_mapping.items()
-                }
+                    for updater_port, proc_port in port_mapping.items()}
+
                 state_dict = state.outer.topology_state(
                     updater_topology)
 
             self.value = updater(self.value, update, state_dict)
+
+            return EMPTY_UPDATES
 
     def inner_value(self, key):
         '''
@@ -1235,6 +1283,11 @@ class Experiment(object):
         self.invoke = config.get('invoke', InvokeProcess)
         self.parallel = {}
 
+        # get a mapping of all paths to processes
+        self.process_paths = {}
+        self.deriver_paths = {}
+        self.find_process_paths(self.processes)
+
         self.state = generate_state(
             self.processes,
             self.topology,
@@ -1269,6 +1322,14 @@ class Experiment(object):
         log.info('\nCONFIG:')
         log.info(pf(self.state.get_config(True)))
 
+    def find_process_paths(self, processes):
+        tree = depth(processes)
+        for path, process in tree.items():
+            if process.is_deriver():
+                self.deriver_paths[path] = process
+            else:
+                self.process_paths[path] = process
+
     def emit_configuration(self):
         data = {
             'time_created': timestamp(),
@@ -1297,8 +1358,8 @@ class Experiment(object):
             # if not parallel, perform a normal invocation
             return self.invoke(process, interval, states)
 
-    def process_update(self, path, state, interval):
-        process = state.value
+    def process_update(self, path, process, interval):
+        state = self.state.get_path(path)
         process_topology = get_in(self.topology, path)
 
         # translate the values from the tree structure into the form
@@ -1316,16 +1377,40 @@ class Experiment(object):
         return absolute, process_topology, state
 
     def apply_update(self, update, process_topology, state):
-        topology_updates = self.state.apply_update(
+        topology_updates, process_updates, deletions = self.state.apply_update(
             update, process_topology, state)
+
         if topology_updates:
             self.topology = deep_merge(self.topology, topology_updates)
 
-    def run_derivers(self, derivers):
+        if process_updates:
+            self.processes = deep_merge(self.processes, process_updates)
+            self.find_process_paths(process_updates)
+
+        if deletions:
+            for deletion in deletions:
+                self.delete_path(deletion)
+
+    def delete_path(self, deletion):
+        delete_in(self.processes, deletion)
+        delete_in(self.topology, deletion)
+
+        for path in list(self.process_paths.keys()):
+            if starts_with(path, deletion):
+                del self.process_paths[path]
+
+        for path in list(self.deriver_paths.keys()):
+            if starts_with(path, deletion):
+                del self.deriver_paths[path]
+
+    def run_derivers(self):
         updates = []
-        for path, deriver in derivers.items():
-            # timestep shouldn't influence derivers
-            if not deriver.deleted:
+        paths = list(self.deriver_paths.keys())
+        for path in paths:
+            # deriver could have been deleted by another deriver
+            deriver = self.deriver_paths.get(path)
+            if deriver:
+                # timestep shouldn't influence derivers
                 update, process_topology, state = self.process_update(
                     path, deriver, 0)
                 self.apply_update(update.get(), process_topology, state)
@@ -1336,22 +1421,15 @@ class Experiment(object):
             'time': self.local_time})
         emit_config = {
             'table': 'history',
-            'data': serialize_dictionary(data),
-        }
+            'data': serialize_dictionary(data)}
         self.emitter.emit(emit_config)
 
-    def send_updates(self, update_tuples, derivers=None):
+    def send_updates(self, update_tuples):
         for update_tuple in update_tuples:
             update, process_topology, state = update_tuple
             self.apply_update(update.get(), process_topology, state)
 
-        if derivers is None:
-            derivers = {
-                path: state
-                for path, state in self.state.depth()
-                if state.value is not None and isinstance(state.value, Process) and state.value.is_deriver()}
-
-        self.run_derivers(derivers)
+        self.run_derivers()
 
     def update(self, interval):
         """ Run each process for the given interval and update the related states. """
@@ -1374,41 +1452,30 @@ class Experiment(object):
                 for state_id in self.states:
                     print('{}: {}'.format(time, self.states[state_id].to_dict()))
 
-            # find all existing processes and derivers in the tree
-            processes = {}
-            derivers = {}
-            for path, state in self.state.depth():
-                if state.value is not None and isinstance(state.value, Process):
-                    if state.value.is_deriver():
-                        derivers[path] = state
-                    else:
-                        processes[path] = state
-
             # find any parallel processes that were removed and terminate them
-            for terminated in self.parallel.keys() - processes.keys():
+            for terminated in self.parallel.keys() - self.process_paths.keys():
                 self.parallel[terminated].end()
                 del self.parallel[terminated]
 
             # setup a way to track how far each process has simulated in time
             front = {
-                path: process
-                for path, process in front.items()
-                if path in processes}
+                path: progress
+                for path, progress in front.items()
+                if path in self.process_paths}
 
             # go through each process and find those that are able to update
             # based on their current time being less than the global time.
-            for path, state in processes.items():
+            for path, process in self.process_paths.items():
                 if not path in front:
                     front[path] = empty_front(time)
                 process_time = front[path]['time']
 
                 if process_time <= time:
-                    process = state.value
                     future = min(process_time + process.local_timestep(), interval)
                     timestep = future - process_time
 
                     # calculate the update for this process
-                    update = self.process_update(path, state, timestep)
+                    update = self.process_update(path, process, timestep)
 
                     # store the update to apply at its projected time
                     if timestep < full_step:
@@ -1437,7 +1504,7 @@ class Experiment(object):
                         advance['update'] = {}
                         paths.append(path)
 
-                self.send_updates(updates, derivers)
+                self.send_updates(updates)
 
                 time = future
                 self.local_time += full_step
@@ -1992,6 +2059,33 @@ class TestUpdateIn:
             'a': 'updated',
         }
         assert updated == expected
+
+
+def test_depth():
+    nested = {
+        'A': {
+            'AA': 5,
+            'AB': {
+                'ABC': 11}},
+        'B': {
+            'BA': 6}}
+
+    dissected = depth(nested)
+    assert len(dissected) == 3
+    assert dissected[('A', 'AB', 'ABC')] == 11
+
+
+def test_depth():
+    nested = {
+        'A': {
+            'AA': 5,
+            'AB': {
+                'ABC': 11}},
+        'B': {
+            'BA': 6}}
+
+    delete_in(nested, ('A', 'AA'))
+    assert 'AA' not in nested['A']
 
 
 def test_sine():

--- a/vivarium/core/experiment.py
+++ b/vivarium/core/experiment.py
@@ -811,7 +811,6 @@ class Store(object):
                     else:
                         # node is None, it was likely deleted
                         print('{} is None'.format(path))
-                        # import ipdb; ipdb.set_trace()
 
         return state
 

--- a/vivarium/core/experiment.py
+++ b/vivarium/core/experiment.py
@@ -418,16 +418,17 @@ class Store(object):
         '''
 
         if path:
-            step = path[0]
-            if step == '..':
+            first_step = path[0]
+            if first_step == '..':
                 child = self.outer
             else:
-                child = self.inner.get(step)
+                child = self.inner.get(first_step)
 
             if child:
                 return child.get_path(path[1:])
             else:
                 # TODO: more handling for bad paths?
+                # TODO: check deleted?
                 return None
         else:
             return self
@@ -805,7 +806,12 @@ class Store(object):
                     if path is None:
                         path = (key,)
                     node = self.get_path(path)
-                    state[key] = node.schema_topology(subschema, {})
+                    if node:
+                        state[key] = node.schema_topology(subschema, {})
+                    else:
+                        # node is None, it was likely deleted
+                        print('{} is None'.format(path))
+                        # import ipdb; ipdb.set_trace()
 
         return state
 

--- a/vivarium/core/experiment.py
+++ b/vivarium/core/experiment.py
@@ -2075,7 +2075,7 @@ def test_depth():
     assert dissected[('A', 'AB', 'ABC')] == 11
 
 
-def test_depth():
+def test_deletion():
     nested = {
         'A': {
             'AA': 5,

--- a/vivarium/processes/nonspatial_environment.py
+++ b/vivarium/processes/nonspatial_environment.py
@@ -18,6 +18,7 @@ class NonSpatialEnvironment(Deriver):
     name = 'nonspatial_environment'
     defaults = {
         'volume': 1e-12 * units.L,
+        'concentrations': {},
     }
 
     def __init__(self, parameters=None):
@@ -25,14 +26,13 @@ class NonSpatialEnvironment(Deriver):
         volume = parameters.get('volume', self.defaults['volume'])
         self.mmol_to_counts = (AVOGADRO.to('1/mmol') * volume).to('L/mmol')
 
-
     def ports_schema(self):
         bin_x = 1 * units.um
         bin_y = 1 * units.um
         depth = self.parameters['volume'] / bin_x / bin_y
         n_bin_x = 1
         n_bin_y = 1
-        return {
+        schema = {
             'external': {
                 '*': {
                     '_value': 0,
@@ -40,7 +40,7 @@ class NonSpatialEnvironment(Deriver):
             },
             'fields': {
                 '*': {
-                    '_value': np.ones((1, 1)),
+                    '_default': np.ones((1, 1)),
                 },
             },
             'dimensions': {
@@ -66,6 +66,13 @@ class NonSpatialEnvironment(Deriver):
                 }
             },
         }
+        # add field concentrations
+        field_schema = {
+            field_id: {
+                '_value': np.array([[conc]])
+            } for field_id, conc in self.parameters['concentrations'].items()}
+        schema['fields'].update(field_schema)
+        return schema
 
     def next_update(self, timestep, states):
         fields = states['fields']


### PR DESCRIPTION
In running some chemotaxis experiments, I came across a bug in which the environment attempts to update an agent that has already been deleted.  The ```schema_topology``` in ```Store``` uses ```node = self.get_path(path)``` with this agent's path, and retrieves a ```None```. As a partial fix, I have it skip the update if the node is ```None```. Though with this fix, the environment still continues to try updating the agent for the remained of the experiment. Maybe we should check if a node has been marked as deleted and update the environment's subschema?