### PR TITLE
Apply subschema to only paths that have been added

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open("README.md", 'r') as readme:
 
 setup(
     name='vivarium-core',
-    version='0.0.19',
+    version='0.0.20',
     packages=[
         'vivarium',
         'vivarium.core',


### PR DESCRIPTION
We were calling `apply_subschemas` and `apply_defaults` as a kind of bludgeon across every inner of a given node (and all of their inners etc etc etc) each time we added a single element with `_add`, `_generate` and `_divide`.... needless to say this introduced a large amount of unneeded computation, especially if the subtree was large. Thanks to running ecoli models with realistic state we now have large subtrees, which revealed this problem. 

After this change subschemas are applied with surgical accuracy! Runtime is greatly improved.

All tests pass in `-core`, `-cell`, `-chemotaxis` and `-ecoli`, so I assume this works, though I would like to make some general tests for various subschema situations at some point to make sure we aren't missing any cases. 