### PR TITLE
Inverse topology fixes and tests

### DIFF
--- a/vivarium/library/dict_utils.py
+++ b/vivarium/library/dict_utils.py
@@ -22,7 +22,7 @@ def deep_merge_check(dct, merge_dct):
 
     for k, v in merge_dct.items():
         if (k in dct and isinstance(dct[k], dict)
-                and isinstance(merge_dct[k], collections.Mapping)):
+                and isinstance(merge_dct[k], collections.abc.Mapping)):
             try:
                 deep_merge_check(dct[k], merge_dct[k])
             except:
@@ -40,7 +40,7 @@ def deep_merge_combine_lists(dct, merge_dct):
     If you want to keep dct you could call it like deep_merge(dict(dct), merge_dct)'''
     for k, v in merge_dct.items():
         if (k in dct and isinstance(dct[k], dict)
-                and isinstance(merge_dct[k], collections.Mapping)):
+                and isinstance(merge_dct[k], collections.abc.Mapping)):
             deep_merge(dct[k], merge_dct[k])
         elif k in dct and isinstance(dct[k], list) and isinstance(v, list):
             dct[k].extend(v)
@@ -59,7 +59,7 @@ def deep_merge(dct, merge_dct):
         merge_dct = {}
     for k, v in merge_dct.items():
         if (k in dct and isinstance(dct[k], dict)
-                and isinstance(merge_dct[k], collections.Mapping)):
+                and isinstance(merge_dct[k], collections.abc.Mapping)):
             deep_merge(dct[k], merge_dct[k])
         else:
             dct[k] = merge_dct[k]


### PR DESCRIPTION
While testing support for creating topologies with partial name overrides (in anticipation of the `vivarium-bioscrape` workshop) I found a couple oversights in the `inverse_topology` implementation:

* If the update had values that weren't explicitly alongside a topology with a `_path` specification, the updates for those values were dropped.
* If the update had multiple different ports that mapped to the same key in the topology, only the last updates would be kept. 

I fixed these issues and made a more comprehensive test for `inverse_topology` to ensure this behavior is maintained. Several asserts were added. Tests again are crucial here, especially for edge cases like this and more subtle topology behaviors. 