### PR TITLE
Support Upload and Download Scripts

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     license='MIT',
     entry_points={
         'console_scripts': []},
-    short_description=(
+    description=(
         'Engine for composing and simulating computational biology '
         'models with the Vivarium interface.'
     ),

--- a/vivarium/core/emitter.py
+++ b/vivarium/core/emitter.py
@@ -315,6 +315,25 @@ def data_from_database(experiment_id, client):
     }
     return data, environment_config
 
+
+def data_to_database(data, environment_config, client):
+    history_collection = client.history
+    reshaped_data = []
+    for time, timepoint_data in data.items():
+        # Since time is the dictionary key, it has to be a string for
+        # JSON/BSON compatibility. But now that we're uploading it, we
+        # want it to be a float for fast searching.
+        reshaped_entry = {'time': float(time)}
+        for key, val in timepoint_data.items():
+            if key not in ('_id', 'time'):
+                reshaped_entry[key] = val
+        reshaped_data.append(reshaped_entry)
+    history_collection.insert_many(reshaped_data)
+
+    config_collection = client.configuration
+    config_collection.insert_one(environment_config)
+
+
 def get_atlas_database_emitter_config(
     username, password, cluster_subdomain, database
 ):

--- a/vivarium/core/process.py
+++ b/vivarium/core/process.py
@@ -9,6 +9,7 @@ from __future__ import absolute_import, division, print_function
 import copy
 import numpy as np
 
+from bson.objectid import ObjectId
 from multiprocessing import Pipe
 from multiprocessing import Process as Multiprocess
 
@@ -39,6 +40,8 @@ def serialize_value(value):
             serializer_registry.access('compartment').serialize(value))
     elif isinstance(value, (np.integer, np.floating)):
         return serializer_registry.access('numpy_scalar').serialize(value)
+    elif isinstance(value, ObjectId):
+        return str(value)
     else:
         return value
 


### PR DESCRIPTION
In `vivarium-scripts`, we want to be able to upload and download experiment data for archival. This adds support for these operations.