### PR TITLE
Disintegrate process

### DIFF
--- a/doc/reference/api/vivarium.processes.rst
+++ b/doc/reference/api/vivarium.processes.rst
@@ -9,10 +9,13 @@ Submodules
 
    vivarium.processes.derive_concentrations
    vivarium.processes.derive_counts
+   vivarium.processes.disintegrate
+   vivarium.processes.exchange_a
    vivarium.processes.glucose_phosphorylation
    vivarium.processes.injector
    vivarium.processes.meta_division
    vivarium.processes.nonspatial_environment
+   vivarium.processes.swap_processes
    vivarium.processes.template_process
    vivarium.processes.timeline
    vivarium.processes.tree_mass

--- a/doc/reference/api/vivarium.rst
+++ b/doc/reference/api/vivarium.rst
@@ -7,9 +7,11 @@ Subpackages
 .. toctree::
    :maxdepth: 4
 
+   vivarium.composites
    vivarium.core
    vivarium.experiments
    vivarium.library
+   vivarium.plots
    vivarium.processes
 
 Module contents

--- a/vivarium/__init__.py
+++ b/vivarium/__init__.py
@@ -17,7 +17,8 @@ from vivarium.processes.derive_concentrations import DeriveConcentrations
 from vivarium.processes.derive_counts import DeriveCounts
 from vivarium.processes.timeline import TimelineProcess
 from vivarium.processes.nonspatial_environment import NonSpatialEnvironment
-from vivarium.processes.swap_compartment import SwapCompartment
+from vivarium.processes.swap_processes import SwapProcesses
+from vivarium.processes.disintegrate import Disintegrate
 
 # import updaters, dividers, serializers
 from vivarium.core.registry import (
@@ -35,7 +36,8 @@ process_registry.register(DeriveConcentrations.name, DeriveConcentrations)
 process_registry.register(DeriveCounts.name, DeriveCounts)
 process_registry.register(TimelineProcess.name, TimelineProcess)
 process_registry.register(NonSpatialEnvironment.name, NonSpatialEnvironment)
-process_registry.register(SwapCompartment.name, SwapCompartment)
+process_registry.register(SwapProcesses.name, SwapProcesses)
+process_registry.register(Disintegrate.name, Disintegrate)
 
 # register updaters
 updater_registry.register('accumulate', update_accumulate)

--- a/vivarium/core/composition.py
+++ b/vivarium/core/composition.py
@@ -170,16 +170,16 @@ def compartment_hierarchy_experiment(
     """Make an experiment with arbitrarily embedded compartments.
 
      Arguments:
-        hierarchy: an embedded dictionary matching the desired topology, with processes
-            at a given level declared with a "processes" key mapping to a list of
-            process configurations, and generators under a "generators" key mapping
-            to a list of generator configurations.
-        settings: settings include **emitter**
-        initial_state: is the initial_state.
-        invoke: is the invoke object for calling updates.
+        * hierarchy: an embedded dictionary mapping the desired topology,
+        with processes at a given level declared with a 'processes' key
+        that maps to a list of process configurations, and generators
+        under a 'generators' key mapping to a list of generator configurations.
+        * settings: settings include **emitter**.
+        * initial_state: is the initial_state.
+        * invoke: is the invoke object for calling updates.
 
     Returns:
-        The experiment.
+        * The experiment.
     """
     if settings is None:
         settings = {}

--- a/vivarium/core/composition.py
+++ b/vivarium/core/composition.py
@@ -165,7 +165,22 @@ def compartment_hierarchy_experiment(
         hierarchy=None,
         settings=None,
         initial_state=None,
+        invoke=None,
 ):
+    """Make an experiment with arbitrarily embedded compartments.
+
+     Arguments:
+        hierarchy: an embedded dictionary matching the desired topology, with processes
+            at a given level declared with a "processes" key mapping to a list of
+            process configurations, and generators under a "generators" key mapping
+            to a list of generator configurations.
+        settings: settings include **emitter**
+        initial_state: is the initial_state.
+        invoke: is the invoke object for calling updates.
+
+    Returns:
+        The experiment.
+    """
     if settings is None:
         settings = {}
     if initial_state is None:
@@ -184,6 +199,15 @@ def compartment_hierarchy_experiment(
         'topology': topology,
         'emitter': emitter,
         'initial_state': initial_state}
+
+    if settings.get('experiment_name'):
+        experiment_config['experiment_name'] = settings.get('experiment_name')
+    if settings.get('description'):
+        experiment_config['description'] = settings.get('description')
+    if invoke:
+        experiment_config['invoke'] = invoke
+    if 'emit_step' in settings:
+        experiment_config['emit_step'] = settings['emit_step']
     return Experiment(experiment_config)
 
 

--- a/vivarium/core/composition.py
+++ b/vivarium/core/composition.py
@@ -179,7 +179,8 @@ def compartment_hierarchy_experiment(
         * invoke: is the invoke object for calling updates.
 
     Returns:
-        * The experiment.
+        The experiment.
+
     """
     if settings is None:
         settings = {}

--- a/vivarium/core/composition.py
+++ b/vivarium/core/composition.py
@@ -169,7 +169,7 @@ def compartment_hierarchy_experiment(
 ):
     """Make an experiment with arbitrarily embedded compartments.
 
-     Arguments:
+    Arguments:
         * hierarchy: an embedded dictionary mapping the desired topology,
         with processes at a given level declared with a 'processes' key
         that maps to a list of process configurations, and generators

--- a/vivarium/core/composition.py
+++ b/vivarium/core/composition.py
@@ -4,6 +4,7 @@ import copy
 import csv
 import os
 import io
+import uuid
 
 import numpy as np
 
@@ -25,7 +26,6 @@ from vivarium.library.units import units
 
 from vivarium.processes.timeline import TimelineProcess
 from vivarium.processes.nonspatial_environment import NonSpatialEnvironment
-
 
 REFERENCE_DATA_DIR = os.path.join('vivarium', 'reference_data')
 TEST_OUT_DIR = os.path.join('out', 'tests')
@@ -91,6 +91,100 @@ def make_agent_ids(agents_config):
     for index in sorted(remove, reverse=True):
         del agents_config[index]
     return agent_ids
+
+
+def add_process_to_tree(process_def, processes, topology):
+    process_type = process_def['type']
+    process_config = process_def['config']
+    process_topology = process_def['topology']
+
+    # make the process
+    process = process_type(process_config)
+
+    # extend processes and topology list
+    name = process_def.get('name', process.name)
+    deep_merge(processes, {name: process})
+    deep_merge(topology, {name: process_topology})
+
+
+def add_generator_to_tree(generator_def, processes, topology):
+    generator_type = generator_def['type']
+    generator_config = generator_def['config']
+
+    # generate
+    composite = generator_type(generator_config)
+    network = composite.generate()
+    new_processes = network['processes']
+    new_topology = network['topology']
+
+    # replace process names that already exist
+    replace_name = []
+    for name, p in new_processes.items():
+        if name in processes:
+            replace_name.append(name)
+    for name in replace_name:
+        new_name = name + '_' + str(uuid.uuid1())
+        new_processes[new_name] = new_processes[name]
+        new_topology[new_name] = new_topology[name]
+        del new_processes[name]
+        del new_topology[name]
+
+    # extend processes and topology list
+    composite_name = generator_def.get('name', composite.name)
+    deep_merge_check(processes, {composite_name: new_processes})
+    deep_merge(topology, {composite_name: new_topology})
+
+
+def initialize_hierarchy(hierarchy):
+    processes = {}
+    topology = {}
+    for key, level in hierarchy.items():
+        if key == 'processes':
+            if isinstance(level, list):
+                for process_def in level:
+                    add_process_to_tree(process_def, processes, topology)
+            elif isinstance(level, dict):
+                add_process_to_tree(level, processes, topology)
+        elif key == 'generators':
+            if isinstance(level, list):
+                for generator_def in level:
+                    add_generator_to_tree(generator_def, processes, topology)
+            elif isinstance(level, dict):
+                add_generator_to_tree(level, processes, topology)
+        else:
+            network = initialize_hierarchy(level)
+            deep_merge_check(processes, {key: network['processes']})
+            deep_merge(topology, {key: network['topology']})
+
+    return {
+        'processes': processes,
+        'topology': topology}
+
+
+def compartment_hierarchy_experiment(
+        hierarchy=None,
+        settings=None,
+        initial_state=None,
+):
+    if settings is None:
+        settings = {}
+    if initial_state is None:
+        initial_state = {}
+
+    # experiment settings
+    emitter = settings.get('emitter', {'type': 'timeseries'})
+
+    # make the hierarchy
+    network = initialize_hierarchy(hierarchy)
+    processes = network['processes']
+    topology = network['topology']
+
+    experiment_config = {
+        'processes': processes,
+        'topology': topology,
+        'emitter': emitter,
+        'initial_state': initial_state}
+    return Experiment(experiment_config)
 
 
 def agent_environment_experiment(
@@ -411,7 +505,7 @@ def simulate_experiment(experiment, settings={}):
     # run simulation
     experiment.update(total_time)
     experiment.end()
-    
+
     # return data from emitter
     if return_raw_data:
         return experiment.emitter.get_data()

--- a/vivarium/core/composition.py
+++ b/vivarium/core/composition.py
@@ -170,17 +170,16 @@ def compartment_hierarchy_experiment(
     """Make an experiment with arbitrarily embedded compartments.
 
     Arguments:
-        * hierarchy: an embedded dictionary mapping the desired topology,
-        with processes at a given level declared with a 'processes' key
-        that maps to a list of process configurations, and generators
-        under a 'generators' key mapping to a list of generator configurations.
-        * settings: settings include **emitter**.
-        * initial_state: is the initial_state.
-        * invoke: is the invoke object for calling updates.
+        hierarchy: an embedded dictionary mapping the desired topology,
+          with processes at a given level declared with a processes key
+          that maps to a list of process configurations, and generators
+          under a generators key mapping to a list of generator configurations.
+        settings: settings include **emitter**.
+        initial_state: is the initial_state.
+        invoke: is the invoke object for calling updates.
 
     Returns:
         The experiment.
-
     """
     if settings is None:
         settings = {}

--- a/vivarium/core/experiment.py
+++ b/vivarium/core/experiment.py
@@ -621,7 +621,7 @@ class Store(object):
         There are five special update keys:
 
         * `_updater` - Override the default updater with any updater you want.
-        * `_delete` - The value here is a list of paths to delete from
+        * `_delete` - The value here is a list of paths (tuples) to delete from
           the tree.
         * `_add` - Adds a state into the subtree:
 

--- a/vivarium/processes/derive_concentrations.py
+++ b/vivarium/processes/derive_concentrations.py
@@ -56,11 +56,15 @@ class DeriveConcentrations(Deriver):
 
         # concentration update
         concentrations = {}
-        for molecule, count in counts.items():
-            concentrations[molecule] = count / mmol_to_counts
+        if mmol_to_counts != 0:
+            for molecule, count in counts.items():
+                concentrations[molecule] = count / mmol_to_counts
 
-        for molecule, concentration in concentrations.items():
-            assert concentration >= 0, 'derived {} concentration < 0'.format(molecule)
+            for molecule, concentration in concentrations.items():
+                assert concentration >= 0, 'derived {} concentration < 0'.format(molecule)
 
-        return {
-            'concentrations': concentrations}
+            return {
+                'concentrations': concentrations}
+        else:
+            print('mmol_to_counts is 0!')
+            return {}

--- a/vivarium/processes/disintegrate.py
+++ b/vivarium/processes/disintegrate.py
@@ -8,6 +8,7 @@ import os
 import uuid
 import logging as log
 
+from vivarium.core.experiment import pp
 from vivarium.core.process import (
     Deriver,
     Process,
@@ -47,7 +48,7 @@ class Disintegrate(Deriver):
         if states['trigger']:
             return {
                 'agents': {
-                    '_delete': self.agent_id}}
+                    '_delete': [(self.agent_id,)]}}
         else:
             return {}
 
@@ -110,6 +111,9 @@ def test_disintegrate():
         compartment,
         settings)
 
+    assert len(output['agents']['1']['dead']) == time_dead + 1
+    assert len(output['time']) == time_total + 1
+
     return output
 
 def run_disintegrate():
@@ -117,7 +121,7 @@ def run_disintegrate():
     if not os.path.exists(out_dir):
         os.makedirs(out_dir)
     output = test_disintegrate()
-    plot_simulation_output(output, {}, out_dir)
+    pp(output)
 
 
 if __name__ == '__main__':

--- a/vivarium/processes/disintegrate.py
+++ b/vivarium/processes/disintegrate.py
@@ -11,7 +11,6 @@ import logging as log
 from vivarium.core.experiment import pp
 from vivarium.core.process import (
     Deriver,
-    Process,
     Generator,
 )
 from vivarium.core.composition import (

--- a/vivarium/processes/disintegrate.py
+++ b/vivarium/processes/disintegrate.py
@@ -1,0 +1,124 @@
+"""
+====================
+Disintegrate Process
+====================
+"""
+
+import os
+import uuid
+import logging as log
+
+from vivarium.core.process import (
+    Deriver,
+    Process,
+    Generator,
+)
+from vivarium.core.composition import (
+    simulate_compartment_in_experiment,
+    PROCESS_OUT_DIR,
+)
+from vivarium.plots.simulation_output import plot_simulation_output
+from vivarium.processes.exchange_a import ExchangeA
+
+
+NAME = 'disintegrate'
+
+
+class Disintegrate(Deriver):
+    """ Disintegrate Process
+
+    remove a compartment when the state under the 'trigger' port is set to True.
+    """
+    name = NAME
+    defaults = {}
+
+    def __init__(self, parameters=None):
+        super(Disintegrate, self).__init__(parameters)
+        self.agent_id = self.parameters['agent_id']
+
+    def ports_schema(self):
+        return {
+            'trigger': {
+                '_default': False,
+                '_emit': True},
+            'agents': {}}
+
+    def next_update(self, timestep, states):
+        if states['trigger']:
+            return {
+                'agents': {
+                    '_delete': self.agent_id}}
+        else:
+            return {}
+
+
+# test
+class ToyLivingCompartment(Generator):
+    defaults = {
+        'exchange': {'uptake_rate': 0.1},
+        'death': {}
+    }
+
+    def generate_processes(self, config):
+        death_config = config['death']
+        death_config['agent_id'] = config['agent_id']
+        return {
+            'exchange': ExchangeA(config['exchange']),
+            'death': Disintegrate(death_config)}
+
+    def generate_topology(self, config):
+        agents_path = ('..', '..', 'agents')
+        return {
+            'exchange': {
+                'internal': ('internal',),
+                'external': ('external',)},
+            'death': {
+                # set the trigger to be the 'dead' state
+                'trigger': ('dead',),
+                'agents': agents_path}}
+
+
+def test_disintegrate():
+    agent_id = '1'
+
+    # make the compartment
+    compartment = ToyLivingCompartment({
+        'agent_id': agent_id})
+
+    # initial state
+    initial_state = {
+        'agents': {
+            agent_id: {
+                'external': {'A': 1},
+                'trigger': False}}}
+
+    # timeline turns death on
+    time_dead = 5
+    time_total = 10
+    timeline = [
+        (0, {('agents', agent_id, 'dead'): False}),
+        (time_dead, {('agents', agent_id, 'dead'): True}),
+        (time_total, {})]
+
+    # simulate
+    settings = {
+        'outer_path': ('agents', agent_id),
+        'timeline': {
+            'timeline': timeline},
+        'initial_state': initial_state}
+    output = simulate_compartment_in_experiment(
+        compartment,
+        settings)
+
+    return output
+
+def run_disintegrate():
+    out_dir = os.path.join(PROCESS_OUT_DIR, NAME)
+    if not os.path.exists(out_dir):
+        os.makedirs(out_dir)
+    output = test_disintegrate()
+    plot_simulation_output(output, {}, out_dir)
+
+
+if __name__ == '__main__':
+    run_disintegrate()

--- a/vivarium/processes/exchange_a.py
+++ b/vivarium/processes/exchange_a.py
@@ -1,0 +1,37 @@
+from vivarium.core.process import Process
+
+
+class ExchangeA(Process):
+    """ Exchange A
+
+    A minimal exchange process that moves molecules 'A' between internal
+    and external ports
+    """
+    name = 'exchange_a'
+    defaults = {
+        'uptake_rate': 0.0,
+        'secrete_rate': 0.0}
+
+    def __init__(self, parameters=None):
+        super(ExchangeA, self).__init__(parameters)
+        self.uptake_rate = self.parameters['uptake_rate']
+        self.secrete_rate = self.parameters['secrete_rate']
+
+    def ports_schema(self):
+        return {
+            'internal': {
+                'A': {
+                    '_default': 0.0,
+                    '_emit': True}},
+            'external': {
+                'A': {
+                    '_default': 0.0,
+                    '_emit': True}}}
+
+    def next_update(self, timestep, states):
+        A_in = states['internal']['A']
+        A_out = states['external']['A']
+        delta_A_in = A_out * self.uptake_rate - A_in * self.secrete_rate
+        return {
+            'internal': {'A': delta_A_in},
+            'external': {'A': -delta_A_in}}

--- a/vivarium/processes/meta_division.py
+++ b/vivarium/processes/meta_division.py
@@ -1,9 +1,24 @@
 from __future__ import absolute_import, division, print_function
 
+import os
 import uuid
 import logging as log
 
-from vivarium.core.process import Deriver
+from vivarium.core.process import (
+    Deriver,
+    Generator
+)
+from vivarium.core.composition import (
+    compartment_hierarchy_experiment,
+    PROCESS_OUT_DIR,
+)
+from vivarium.core.experiment import pp
+
+# processes
+from vivarium.processes.exchange_a import ExchangeA
+from vivarium.processes.timeline import TimelineProcess
+
+NAME = 'meta_division'
 
 
 # functions for generating daughter ids
@@ -11,6 +26,7 @@ def daughter_uuid(mother_id):
     return [
         str(uuid.uuid1()),
         str(uuid.uuid1())]
+
 
 def daughter_phylogeny_id(mother_id):
     return [
@@ -23,8 +39,7 @@ def divider_set_false(state):
 
 
 class MetaDivision(Deriver):
-
-    name = 'meta_division'
+    name = NAME
     defaults = {
         'initial_state': {},
         'daughter_path': ('agents',),
@@ -63,7 +78,7 @@ class MetaDivision(Deriver):
         if divide:
             daughter_ids = self.daughter_ids_function(self.agent_id)
             daughter_updates = []
-            
+
             for daughter_id in daughter_ids:
                 compartment = self.compartment.generate({
                     'agent_id': daughter_id})
@@ -85,4 +100,117 @@ class MetaDivision(Deriver):
                         'mother': self.agent_id,
                         'daughters': daughter_updates}}}
         else:
-             return {}   
+            return {}
+
+        # test
+
+
+class ToyAgent(Generator):
+    defaults = {
+        'exchange': {'uptake_rate': 0.1},
+        'daughter_path': tuple(),
+        'agents_path': ('..', '..', 'agents')}
+
+    def generate_processes(self, config):
+        daughter_path = config['daughter_path']
+        agent_id = config['agent_id']
+        division_config = dict(
+            {},
+            daughter_path=daughter_path,
+            agent_id=agent_id,
+            compartment=self)
+
+        return {
+            'exchange': ExchangeA(config['exchange']),
+            'division': MetaDivision(division_config)}
+
+    def generate_topology(self, config):
+        agents_path = config['agents_path']
+        return {
+            'exchange': {
+                'internal': ('internal',),
+                'external': ('external',)},
+            'division': {
+                'global': ('global',),
+                'agents': agents_path,
+            }
+        }
+
+
+def test_division():
+    agent_id = '1'
+
+    # initial state
+    initial_state = {
+        'agents': {
+            agent_id: {
+                'internal': {'A': 0},
+                'external': {'A': 1},
+                'global': {
+                    'divide': False
+                }
+            },
+        }
+    }
+
+    # timeline triggers division
+    time_divide = 5
+    time_total = 10
+    timeline = [
+        (0, {('agents', agent_id, 'global', 'divide'): False}),
+        (time_divide, {('agents', agent_id, 'global', 'divide'): True}),
+        (time_total, {})]
+
+    # declare the hierarchy
+    hierarchy = {
+        'processes': [
+            {
+                'type': TimelineProcess,
+                'config': {'timeline': timeline},
+                'topology': {
+                    'global': ('global',),
+                    'agents': ('agents',)
+                }
+            }
+        ],
+        'agents': {
+            'generators': [
+                {
+                    'name': agent_id,
+                    'type': ToyAgent,
+                    'config': {'agent_id': agent_id}
+                },
+            ]
+        }
+    }
+
+    # configure experiment
+    experiment = compartment_hierarchy_experiment(
+        hierarchy=hierarchy,
+        initial_state=initial_state)
+
+    # run simulation
+    experiment.update(time_total)
+    output = experiment.emitter.get_data()
+    experiment.end()
+
+    # external starts at 1, goes down until death, and then back up
+    # internal does the inverse
+    assert list(output[time_divide]['agents'].keys()) == [agent_id]
+    assert agent_id not in list(output[time_divide + 1]['agents'].keys())
+    assert len(output[time_divide]['agents']) == 1
+    assert len(output[time_divide + 1]['agents']) == 2
+
+    return output
+
+
+def run_division():
+    out_dir = os.path.join(PROCESS_OUT_DIR, NAME)
+    if not os.path.exists(out_dir):
+        os.makedirs(out_dir)
+    output = test_division()
+    pp(output)
+
+
+if __name__ == '__main__':
+    run_division()

--- a/vivarium/processes/swap_compartment.py
+++ b/vivarium/processes/swap_compartment.py
@@ -18,6 +18,8 @@ from vivarium.core.composition import (
     PROCESS_OUT_DIR,
 )
 from vivarium.plots.simulation_output import plot_simulation_output
+from vivarium.processes.exchange_a import ExchangeA
+
 
 NAME = 'swap_compartment'
 
@@ -83,37 +85,6 @@ class SwapCompartment(Deriver):
 
 
 # test
-class ExchangeA(Process):
-    name = 'exchange_a'
-    defaults = {
-        'uptake_rate': 0.0,
-        'secrete_rate': 0.0}
-
-    def __init__(self, parameters=None):
-        super(ExchangeA, self).__init__(parameters)
-        self.uptake_rate = self.parameters['uptake_rate']
-        self.secrete_rate = self.parameters['secrete_rate']
-
-    def ports_schema(self):
-        return {
-            'internal': {
-                'A': {
-                    '_default': 0.0,
-                    '_emit': True}},
-            'external': {
-                'A': {
-                    '_default': 0.0,
-                    '_emit': True}}}
-
-    def next_update(self, timestep, states):
-        A_in = states['internal']['A']
-        A_out = states['external']['A']
-        delta_A_in = A_out * self.uptake_rate - A_in * self.secrete_rate
-        return {
-            'internal': {'A': delta_A_in},
-            'external': {'A': -delta_A_in}}
-
-
 class ToyDeadCompartment(Generator):
     defaults = {
         'secrete': {

--- a/vivarium/processes/swap_processes.py
+++ b/vivarium/processes/swap_processes.py
@@ -1,7 +1,7 @@
 """
-========================
-Swap Compartment Process
-========================
+=======================
+Swap Processes Process
+=======================
 """
 
 import os
@@ -24,8 +24,8 @@ from vivarium.processes.exchange_a import ExchangeA
 NAME = 'swap_compartment'
 
 
-class SwapCompartment(Deriver):
-    """ SwapCompartment Process
+class SwapProcesses(Deriver):
+    """ SwapProcesses Process
 
     Replaces the contents of a compartment when the state under the
     'trigger' port is set to True.
@@ -54,7 +54,7 @@ class SwapCompartment(Deriver):
     }
 
     def __init__(self, parameters=None):
-        super(SwapCompartment, self).__init__(parameters)
+        super(SwapProcesses, self).__init__(parameters)
         self.removed_processes = self.parameters['removed_processes']
         self.new_compartment = self.parameters['new_compartment']
         self.initial_state = self.parameters['initial_state']
@@ -114,7 +114,7 @@ class ToyLivingCompartment(Generator):
     def generate_processes(self, config):
         return {
             'exchange': ExchangeA(config['exchange']),
-            'death': SwapCompartment(config['death'])}
+            'death': SwapProcesses(config['death'])}
 
     def generate_topology(self, config):
         self_path = ('..', config['agent_id'])


### PR DESCRIPTION
This process can be used to remove a compartment when the state under its ```'trigger'``` port is set to ```True```. It can probably be extended to release its state into its outer for a more comprehensive disintegration.

Also added in this PR: ```compartment_hierarchy_experiment``` is a new function in ```composition.py``` that lets you specify experiments with arbitrarily embedded compartments, and under any keys.  This is used for a new test in ```meta_division```.