### PR TITLE
print process evaluation time

### DIFF
--- a/vivarium/core/process.py
+++ b/vivarium/core/process.py
@@ -4,9 +4,8 @@ Process and Compartment Classes
 ==========================================
 """
 
-from __future__ import absolute_import, division, print_function
-
 import copy
+import time as clock
 import numpy as np
 
 from bson.objectid import ObjectId
@@ -366,11 +365,16 @@ class ParallelProcess(object):
             args=(self.child, self.process))
         self.multiprocess.start()
 
+        self.time_before = None
+
     def update(self, interval, states):
+        self.time_before = clock.time()
         self.parent.send((interval, states))
 
     def get(self):
-        return self.parent.recv()
+        update = self.parent.recv()
+        eval_time = clock.time() - self.time_before
+        return update
 
     def end(self):
         self.parent.send((-1, None))


### PR DESCRIPTION
This adds a print-out of each process' evaluation time at the end of each experiment.

<pre>
Progress:|████████████████████████████████████████████████████████████| 0.0/1.0 simulated seconds remaining 
Completed in 0.000318 seconds
Process evaluation time:
 ('po',): 0.000083 seconds
 ('qo',): 0.000057 seconds
</pre>

TODO: 
- [ ]  add derivers!
- [ ]  make this work with invoke/defer and parallel processes
