### PR TITLE
Topology update in list of (path, value) pairs

### DIFF
--- a/vivarium/core/experiment.py
+++ b/vivarium/core/experiment.py
@@ -664,7 +664,7 @@ class Store(object):
         elif self.inner or self.subschema:
             # Branch update: this node has an inner
 
-            process_updates, topology_updates, deletions = {}, {}, []
+            process_updates, topology_updates, deletions = [], [], []
             update = dict(update)  # avoid mutating the caller's dict
 
             delete_paths = update.pop('_delete', None)
@@ -699,15 +699,16 @@ class Store(object):
                         generate['topology'],
                         generate['initial_state'])
 
-                    assoc_path(
-                        process_updates,
-                        path,
-                        generate['processes'])
-
-                    assoc_path(
-                        topology_updates,
-                        path,
-                        generate['topology'])
+                    # TODO -- add processes and topologies as (path, node) lists
+                    # assoc_path(
+                    #     process_updates,
+                    #     path,
+                    #     generate['processes'])
+                    #
+                    # assoc_path(
+                    #     topology_updates,
+                    #     path,
+                    #     generate['topology'])
 
                     self.apply_subschema_path(path)
                     self.get_path(path).apply_defaults()
@@ -738,15 +739,16 @@ class Store(object):
                         daughter['topology'],
                         daughter['initial_state'])
 
-                    assoc_path(
-                        process_updates,
-                        path,
-                        daughter['processes'])
-
-                    assoc_path(
-                        topology_updates,
-                        path,
-                        daughter['topology'])
+                    # TODO -- add processes and topologies as (path, node) lists
+                    # assoc_path(
+                    #     process_updates,
+                    #     path,
+                    #     daughter['processes'])
+                    #
+                    # assoc_path(
+                    #     topology_updates,
+                    #     path,
+                    #     daughter['topology'])
 
                     self.apply_subschema_path(path)
                     target = self.get_path(path)
@@ -765,14 +767,16 @@ class Store(object):
                         value, process_topology, state)
 
                     if inner_topology:
-                        topology_updates = deep_merge(
-                            topology_updates,
-                            {key: inner_topology})
+                        # TODO -- add inner_topology needs to be appended, not merged
+                        # topology_updates = deep_merge(
+                        #     topology_updates,
+                        #     {key: inner_topology})
 
                     if inner_processes:
-                        process_updates = deep_merge(
-                            process_updates,
-                            {key: inner_processes})
+                        # TODO -- add inner_processes needs to be appended, not merged
+                        # process_updates = deep_merge(
+                        #     process_updates,
+                        #     {key: inner_processes})
 
                     if inner_deletions:
                         deletions += inner_deletions
@@ -1429,11 +1433,13 @@ class Experiment(object):
         topology_updates, process_updates, deletions = self.state.apply_update(
             update, process_topology, state)
 
+        # TODO -- convert topology_updates to dict, then merge
         if topology_updates:
-            self.topology = deep_merge(self.topology, topology_updates)
+            # self.topology = deep_merge(self.topology, topology_updates)
 
+        # TODO -- convert process_updates to dict, then merge
         if process_updates:
-            self.processes = deep_merge(self.processes, process_updates)
+            # self.processes = deep_merge(self.processes, process_updates)
             self.find_process_paths(process_updates)
 
         if deletions:

--- a/vivarium/core/experiment.py
+++ b/vivarium/core/experiment.py
@@ -80,6 +80,7 @@ def get_in(d, path, default=None):
 
 
 def assoc_path(d, path, value):
+    path = normalize_path(path)
     if path:
         head = path[0]
         if len(path) == 1:
@@ -2330,6 +2331,13 @@ def test_sine():
         'amplitude': 0.1,
         'phase': 1.5}))
 
+def test_assoc_path():
+    x = {'a': {'b': 1, 'c': 2}, 'e': {'f': 3}}
+    assoc_path(x, ('a', 'b'), 5)
+    assert x == {'a': {'b': 5, 'c': 2}, 'e': {'f': 3}}
+    assoc_path(x, ('a', 'b', '..'), 5)
+    assert x =={'a': 5, 'e': {'f': 3}}
+
 
 if __name__ == '__main__':
     # test_recursive_store()
@@ -2340,5 +2348,6 @@ if __name__ == '__main__':
     # test_sine()
     # test_parallel()
     # test_complex_topology()
+    # test_multi_port_merge()
 
-    test_multi_port_merge()
+    test_assoc_path()


### PR DESCRIPTION
In #33, the attempt to build an `Engulf` process which requires a `_move` topology update, I discovered that since `topology_update` is a dictionary it can not reach outside of the given topology to a node's outer.  This would be required for `_move` updates such as excrete and engulf. The solution is to represent the `topology_update` and `process_update` as lists of paths, which could include a `..` hence going up a level in a way dictionaries cannot. This PR changes these updates to address this requirement.