### PR TITLE
Tree updates take keys, not paths

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open("README.md", 'r') as readme:
 
 setup(
     name='vivarium-core',
-    version='0.0.38',
+    version='0.1.0',
     packages=[
         'vivarium',
         'vivarium.core',

--- a/vivarium/core/experiment.py
+++ b/vivarium/core/experiment.py
@@ -662,7 +662,6 @@ class Store(object):
             if move_entries is not None:
                 # move nodes from source to target path
                 for move in move_entries:
-
                     # get the source node
                     source_key = move['source']
                     source_path = (source_key,)
@@ -687,9 +686,10 @@ class Store(object):
                     here = self.path_for()
                     source_absolute = tuple(here + source_path)
                     source_topology = get_in(experiment_topology, source_absolute)
-                    topology_updates.append((
-                        target_path,
-                        source_topology))
+                    if source_topology:
+                        topology_updates.append((
+                            target_path,
+                            source_topology))
 
                     self.delete_path(source_path)
                     deletions.append(source_absolute)
@@ -764,13 +764,7 @@ class Store(object):
                 self.delete_path(mother_path)
                 deletions.append(tuple(here + mother_path))
 
-            delete_paths = update.pop('_delete', None)
-            if delete_paths is not None:
-                # delete a list of paths
-                here = self.path_for()
-                for path in delete_paths:
-                    self.delete_path(path)
-                    deletions.append(tuple(here + path))
+            delete_keys = update.pop('_delete', None)
 
             for key, value in update.items():
                 if key in self.inner:
@@ -784,6 +778,14 @@ class Store(object):
                         process_updates.extend(inner_processes)
                     if inner_deletions:
                         deletions.extend(inner_deletions)
+
+            if delete_keys is not None:
+                # delete a list of paths
+                here = self.path_for()
+                for key in delete_keys:
+                    path = (key,)
+                    self.delete_path(path)
+                    deletions.append(tuple(here + path))
 
             return topology_updates, process_updates, deletions
 

--- a/vivarium/core/experiment.py
+++ b/vivarium/core/experiment.py
@@ -663,8 +663,6 @@ class Store(object):
                 # move nodes from source to target path
                 for move in move_entries:
 
-                    import ipdb; ipdb.set_trace()
-
                     # get the source node
                     source_key = move['source']
                     source_path = (source_key,)
@@ -1354,9 +1352,6 @@ class Experiment(object):
     def process_update(self, path, process, interval):
         state = self.state.get_path(path)
         process_topology = get_in(self.topology, path)
-
-        if state is None:
-            import ipdb; ipdb.set_trace()
 
         # translate the values from the tree structure into the form
         # that this process expects, based on its declared topology

--- a/vivarium/core/experiment.py
+++ b/vivarium/core/experiment.py
@@ -780,16 +780,8 @@ class Store(object):
 
                     if inner_topology:
                         topology_updates.extend(inner_topology)
-                        # topology_updates = deep_merge(
-                        #     topology_updates,
-                        #     {key: inner_topology})
-
                     if inner_processes:
                         process_updates.extend(inner_processes)
-                        # process_updates = deep_merge(
-                        #     process_updates,
-                        #     {key: inner_processes})
-
                     if inner_deletions:
                         deletions.extend(inner_deletions)
 

--- a/vivarium/core/experiment.py
+++ b/vivarium/core/experiment.py
@@ -663,6 +663,8 @@ class Store(object):
                 # move nodes from source to target path
                 for move in move_entries:
 
+                    import ipdb; ipdb.set_trace()
+
                     # get the source node
                     source_key = move['source']
                     source_path = (source_key,)
@@ -1026,6 +1028,7 @@ class Store(object):
             # this path already exists, update it
             self.apply_update({path[-1]: node.get_value()})
         else:
+            node.outer = target
             target.inner.update({path[-1]: node})
         return target
 
@@ -1351,6 +1354,9 @@ class Experiment(object):
     def process_update(self, path, process, interval):
         state = self.state.get_path(path)
         process_topology = get_in(self.topology, path)
+
+        if state is None:
+            import ipdb; ipdb.set_trace()
 
         # translate the values from the tree structure into the form
         # that this process expects, based on its declared topology

--- a/vivarium/core/experiment.py
+++ b/vivarium/core/experiment.py
@@ -642,7 +642,7 @@ class Store(object):
             if add_entries is not None:
                 # add a list of sub-states
                 for added in add_entries:
-                    path = added['path']
+                    path = (added['key'],)
                     added_state = added['state']
 
                     target = self.establish_path(path, {})
@@ -654,8 +654,8 @@ class Store(object):
             if move_entries is not None:
                 # move nodes from source to target path
                 for move in move_entries:
-                    source_path = move['source']
-                    target_path = move['target'] + (source_path[-1],)
+                    source_key = move['source']
+                    source_path = (source_key,)
                     here = self.path_for()
                     source_absolute = tuple(here + source_path)
 
@@ -668,7 +668,11 @@ class Store(object):
                     source_topology = get_in(experiment_topology, source_absolute)
 
                     # move source node to target path
-                    target = self.add_node(target_path, source_node)
+                    target_port = move['target']
+                    target_topology = get_in(state.topology, target_port)
+                    target_node = state.outer.get_path(target_topology)
+                    target = target_node.add_node(source_path, source_node)
+                    target_path = target.path_for()
 
                     assoc_path(
                         process_updates,
@@ -1098,6 +1102,7 @@ class Store(object):
                 process_state = Store({
                     '_value': subprocess,
                     '_updater': 'set',
+                    '_topology': subtopology,
                     '_serializer': 'process'}, outer=self)
                 self.inner[key] = process_state
 

--- a/vivarium/library/schema.py
+++ b/vivarium/library/schema.py
@@ -76,6 +76,6 @@ def listener_schema(elements):
 def add_elements(elements, id):
     return {
         '_add': [{
-            'path': (element[id],),
+            'key': element[id],
             'state': element}
             for element in elements]}

--- a/vivarium/library/topology.py
+++ b/vivarium/library/topology.py
@@ -54,12 +54,23 @@ def update_in(d, path, f):
     return f(d)
 
 
-def path_list_to_dict(path_list, f=lambda x: x):
+def paths_to_dict(path_list, f=lambda x: x):
     d = {}
     for path, node in path_list:
         assoc_path(d, path, f(node))
     return d
 
+
+def dict_to_paths(root, d):
+    if isinstance(d, dict):
+        deeper = []
+        for key, down in d.items():
+            paths = dict_to_paths(root + (key,), down)
+            deeper.extend(paths)
+        return deeper
+    else:
+        return [(root, d)]
+        
 
 def inverse_topology(outer, update, topology):
     '''

--- a/vivarium/processes/burst.py
+++ b/vivarium/processes/burst.py
@@ -52,12 +52,16 @@ class Burst(Deriver):
             },
             'outer': {
                 '*': {}
-            }
+            },
+            'compartment': {
+                '*': {}
+            },
         }
 
     def next_update(self, timestep, states):
         if states['trigger']:
             inner_states = states['inner']
+
             return {
                 'inner': {
                     '_move': [{
@@ -66,8 +70,10 @@ class Burst(Deriver):
                         # points to which port it will be moved
                         'target': 'outer',
                     } for state in inner_states],
+                },
+                'compartment': {
                     # remove self
-                    '_delete': [('..', '..', self.agent_id)]
+                    '_delete': [self.agent_id]
                 },
                 'trigger': {
                     '_updater': 'set',
@@ -84,7 +90,8 @@ class ToyAgent(Generator):
         'exchange': {
             'uptake_rate': 0.1},
         'inner_path': ('concentrations',),
-        'outer_path': ('..', '..', 'concentrations')
+        'outer_path': ('..', '..', 'concentrations'),
+        'compartment_path': ('..', '..', 'agents'),
     }
 
     def generate_processes(self, config):
@@ -102,6 +109,7 @@ class ToyAgent(Generator):
                 'trigger': ('trigger',),
                 'inner': config['inner_path'],
                 'outer': config['outer_path'],
+                'compartment': config['compartment_path'],
             }}
 
 

--- a/vivarium/processes/burst.py
+++ b/vivarium/processes/burst.py
@@ -190,9 +190,9 @@ def test_burst():
     output = experiment.emitter.get_data()
     experiment.end()  # end required for parallel processes
 
-    # # asserts total A is the same at the beginning and the end
-    # assert output[0.0]['concentrations']['A'] == initial_A
-    # assert output[5.0]['concentrations']['A'] + output[5.0]['agents'][agent_1_id]['concentrations']['A'] == initial_A
+    # asserts total A is the same at the beginning and the end
+    assert output[0.0]['concentrations']['A'] == initial_A
+    assert output[5.0]['concentrations']['A'] + output[5.0]['agents'][agent_1_id]['concentrations']['A'] == initial_A
 
     return output
 

--- a/vivarium/processes/engulf.py
+++ b/vivarium/processes/engulf.py
@@ -170,10 +170,7 @@ def test_engulf():
     output = experiment.emitter.get_data()
     experiment.end()  # end required for parallel processes
 
-    import ipdb; ipdb.set_trace()
-
-    # assert that initial agents store has agents 1 & 2,
-    # final has only agent 1, and agent 1 subcompartment has 2
+    # assert the engulfing/expelling saga
     assert [*output[0.0]['agents'].keys()] == agent_ids
     assert [*output[4.0]['agents'].keys()] == ['1', '3']
     assert [*output[6.0]['agents']['1']['agents'].keys()] == ['3']

--- a/vivarium/processes/meta_division.py
+++ b/vivarium/processes/meta_division.py
@@ -13,6 +13,9 @@ from vivarium.core.composition import (
     GENERATORS_KEY,
     PROCESS_OUT_DIR,
 )
+from vivarium.core.experiment import (
+    pp
+)
 
 # processes
 from vivarium.processes.exchange_a import ExchangeA
@@ -42,7 +45,6 @@ class MetaDivision(Deriver):
     name = NAME
     defaults = {
         'initial_state': {},
-        'daughter_path': ('agents',),
         'daughter_ids_function': daughter_phylogeny_id}
 
     def __init__(self, initial_parameters=None):
@@ -53,11 +55,9 @@ class MetaDivision(Deriver):
 
         # must provide a compartment to generate new daughters
         self.agent_id = initial_parameters['agent_id']
-        self.compartment = initial_parameters['compartment']
+        self.generator = initial_parameters['generator']
         self.daughter_ids_function = self.or_default(
             initial_parameters, 'daughter_ids_function')
-        self.daughter_path = self.or_default(
-            initial_parameters, 'daughter_path')
 
         super(MetaDivision, self).__init__(initial_parameters)
 
@@ -80,13 +80,12 @@ class MetaDivision(Deriver):
             daughter_updates = []
 
             for daughter_id in daughter_ids:
-                compartment = self.compartment.generate({
+                generator = self.generator.generate({
                     'agent_id': daughter_id})
                 daughter_updates.append({
-                    'daughter': daughter_id,
-                    'path': (daughter_id,) + self.daughter_path,
-                    'processes': compartment['processes'],
-                    'topology': compartment['topology'],
+                    'key': daughter_id,
+                    'processes': generator['processes'],
+                    'topology': generator['topology'],
                     'initial_state': {}})
 
             log.info(
@@ -107,17 +106,14 @@ class MetaDivision(Deriver):
 class ToyAgent(Generator):
     defaults = {
         'exchange': {'uptake_rate': 0.1},
-        'daughter_path': tuple(),
         'agents_path': ('..', '..', 'agents')}
 
     def generate_processes(self, config):
-        daughter_path = config['daughter_path']
         agent_id = config['agent_id']
         division_config = dict(
             {},
-            daughter_path=daughter_path,
             agent_id=agent_id,
-            compartment=self)
+            generator=self)
 
         return {
             'exchange': ExchangeA(config['exchange']),
@@ -209,7 +205,7 @@ def run_division():
     if not os.path.exists(out_dir):
         os.makedirs(out_dir)
     output = test_division()
-    # pp(output)
+    pp(output)
 
 
 if __name__ == '__main__':

--- a/vivarium/processes/remove.py
+++ b/vivarium/processes/remove.py
@@ -38,13 +38,13 @@ class Remove(Deriver):
             'trigger': {
                 '_default': False,
                 '_emit': True},
-            'agents': {}}
+            'agents': {'*': {}}}
 
     def next_update(self, timestep, states):
         if states['trigger']:
             return {
                 'agents': {
-                    '_delete': [(self.agent_id,)]}}
+                    '_delete': [self.agent_id]}}
         else:
             return {}
 

--- a/vivarium/processes/swap_processes.py
+++ b/vivarium/processes/swap_processes.py
@@ -61,7 +61,8 @@ class SwapProcesses(Deriver):
             'trigger': {
                 '_default': False,
                 '_emit': True},
-            'self': {}}
+            'self': {
+                '*': {}}}
 
     def next_update(self, timestep, states):
         if states['trigger']:
@@ -103,8 +104,8 @@ class ToyLivingCompartment(Generator):
         'exchange': {'uptake_rate': 0.1},
         'death': {
             'removed_processes': [
-                ('exchange',),
-                ('death',)],
+                'exchange',
+                'death'],
             'new_compartment': ToyDeadCompartment({})
         }}
 


### PR DESCRIPTION
In the process of implementing the Engulf and Burst processes, we had a realization that some confusion was arising from using paths, which are topology-relative, from inside processes, which are topology agnostic. This was leading to process configurations that modified or appended the paths, which is actually what the topology is supposed to be doing for us in the first place. 

This PR modifies all of the tree update operations to use `key` instead of `path` for their targets, which point to keys directly residing in the target ports, and updates everywhere in this repository that invokes these updates to align to the new approach. This means all path specifications will come from assigning topologies to process ports, instead of processes having to know anything about paths (which is the whole point of the topology). 

Still outstanding is updates to any other repository that references these tree related updates, which could be far reaching at this point. It is an API breaking change. 