### PR TITLE
deriver ports

### DIFF
--- a/vivarium/core/process.py
+++ b/vivarium/core/process.py
@@ -126,7 +126,9 @@ def generate_derivers(processes, topology):
                     deriver_processes[deriver_key] = deriver
 
                     # generate deriver topology
-                    deriver_topology[deriver_key] = {}
+                    deriver_ports = deriver.ports()
+                    deriver_topology[deriver_key] = {
+                        port: (port,) for port in deriver_ports.keys()}
                     for target, source in config.get('port_mapping', {}).items():
                         path = subtopology[source]
                         deriver_topology[deriver_key][target] = path


### PR DESCRIPTION
This PR is makes fixes that help `vivarium-cell` replace the updater `port_mapping` requirements from some processes. 
`generate_derivers` now uses default port names for the stores, and then applies `port_mapping` (a different `port_mapping` from the one of the previous sentence) to override those names. So derivers can have ports not declared by the processes that require them.