### PR TITLE
Improve the topology grapher

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -51,6 +51,13 @@ exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store', 'venv']
 # will help avoid broken links.
 nitpicky = True
 
+# Ignore warnings like:
+# "docstring of ... reference target not found: matplotlib.pyplot.Figure".
+# Is there a way to make those references work?
+nitpick_ignore = [
+    ('py:class', 'networkx.Graph'),
+    ('py:class', 'matplotlib.pyplot.Figure')]
+
 
 # -- Options for HTML output -------------------------------------------------
 

--- a/vivarium/plots/topology.py
+++ b/vivarium/plots/topology.py
@@ -99,7 +99,7 @@ def graph_figure(
         node_distance: float = 2.5,
         buffer: float = 1.0,
         border_width: float = 3,
-        label_pos: float = 0.75,
+        label_pos: float = 0.65,
 ) -> plt.Figure:
     """ Make a figure from a networkx graph.
 


### PR DESCRIPTION
This tool is great for productivity! It draws the Process + Store topology network.

This PR tunes the rendering, mainly to show Stores using the standard flowchart symbol for data stores. The trick is to construct a matplotlib `Path` and let `draw_networkx_nodes(node_shape=s)` pass it to `ax.scatter(marker=s)`.

Labels are bigger and `..` draws as ⬆︎.

![image](https://user-images.githubusercontent.com/1043120/104515564-db2d2380-55a7-11eb-80ca-23a807990564.png)
