### PR TITLE
growth_rate

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -69,6 +69,10 @@ disallow_incomplete_defs = False
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
+[mypy-vivarium.processes.growth_rate.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
 [mypy-vivarium.processes.template_process.*]
 disallow_untyped_defs = False
 disallow_incomplete_defs = False

--- a/vivarium/core/process.py
+++ b/vivarium/core/process.py
@@ -341,6 +341,9 @@ class Process(Composite, metaclass=abc.ABCMeta):
         if self.config.get('_register'):
             self.register()
 
+        if 'time_step' not in self.parameters:
+             self.parameters['time_step'] = DEFAULT_TIME_STEP
+
     def initial_state(self, config=None):
         """Get initial state in embedded path dictionary
 
@@ -384,12 +387,19 @@ class Process(Composite, metaclass=abc.ABCMeta):
             port: list(states.keys())
             for port, states in ports_schema.items()}
 
+    def set_timestep(self, timestep) -> None:
+         '''Update the process's timestep
+
+         This will override the default timestep
+         '''
+         self.parameters['time_step'] = timestep
+
     def local_timestep(self):
         '''
         Returns the favored timestep for this process.
         Meant to be overridden in subclasses, unless 1.0 is a happy value.
         '''
-        return self.parameters.get('time_step', DEFAULT_TIME_STEP)
+        return self.parameters['time_step']
 
     def default_state(self):
         schema = self.ports_schema()

--- a/vivarium/processes/growth_rate.py
+++ b/vivarium/processes/growth_rate.py
@@ -1,0 +1,85 @@
+import os
+import numpy as np
+from typing import Any, Dict, Optional
+
+# import the vivarium process class
+from vivarium.core.process import Process
+
+from vivarium.core.composition import (
+    PROCESS_OUT_DIR,
+    process_in_experiment,
+)
+from vivarium.plots.simulation_output import plot_simulation_output
+
+NAME = 'growth_rate'
+
+
+class GrowthRate(Process):
+    ''' A Vivarium process that models exponential growth of biomass '''
+
+    name = NAME
+    defaults = {
+        'default_growth_rate': 0.0005,
+        'default_growth_noise': 0.0,
+        'variables': ['mass']
+    }
+
+    def ports_schema(self):
+        return {
+            'variables': {
+                variable: {
+                    '_default': 1000.0,
+                    '_emit': True,
+                } for variable in self.parameters['variables']
+            },
+            'rates': {
+                'growth_rate': {
+                    variable: {
+                        '_default': self.parameters['default_growth_rate'],
+                    } for variable in self.parameters['variables']
+                },
+                'growth_noise': {
+                    variable: {
+                        '_default': self.parameters['default_growth_noise'],
+                    } for variable in self.parameters['variables']
+                },
+            }
+        }
+
+    def next_update(self, timestep, states):
+        variables = states['variables']
+        growth_rate = states['rates']['growth_rate']
+        growth_noise = states['rates']['growth_noise']
+
+        variable_update = {
+            variable: value * (np.exp(growth_rate[variable] +
+                       np.random.normal(0, growth_noise[variable])
+                       ) * timestep) - value
+            for variable, value in variables.items()}
+
+        return {'variables': variable_update}
+
+
+def test_growth_rate(total_time=1350):
+    growth_rate = GrowthRate({'variables': ['mass']})
+    initial_state = {'variables': {'mass': 100}}
+    experiment = process_in_experiment(growth_rate, initial_state=initial_state)
+    experiment.update(total_time)
+    output = experiment.emitter.get_timeseries()
+    assert output['variables']['mass'][-1] > output['variables']['mass'][0]
+    return output
+
+
+def main(out_dir):
+    data = test_growth_rate()
+    plot_settings = {}
+    plot_simulation_output(data, plot_settings, out_dir)
+
+
+
+if __name__ == '__main__':
+    out_dir = os.path.join(PROCESS_OUT_DIR, NAME)
+    if not os.path.exists(out_dir):
+        os.makedirs(out_dir)
+
+    main(out_dir)


### PR DESCRIPTION
This PR introduces a generic `growth_rate` process that applies exponential growth to a list of variables. It also includes optional growth rate noise. Each variable can have its own dynamic `growth_rate` and`growth_rate_noise` under the `rates` port -- these are set to `default_growth_rate` and `default_growth_rate_noise` parameters by default.