### PR TITLE
fix complex topology bug

### DIFF
--- a/vivarium/core/experiment.py
+++ b/vivarium/core/experiment.py
@@ -794,7 +794,7 @@ class Store(object):
                     if inner_deletions:
                         deletions.extend(inner_deletions)
 
-                if key == '..':
+                elif key == '..':
                     self.outer.apply_update(value, state)
 
             if delete_keys is not None:

--- a/vivarium/core/experiment.py
+++ b/vivarium/core/experiment.py
@@ -2091,7 +2091,8 @@ def test_complex_topology():
                 'po': {
                     'A': {
                         '_path': ('aaa',),
-                        'b': ('o',)},
+                        'b': ('o',),
+                        'c': ('..', '..', 'UP')},
                     'B': ('bbb',)},
                 'qo': {
                     'D': {
@@ -2102,6 +2103,9 @@ def test_complex_topology():
                         'u': ('aaa', 'u'),
                         'v': ('bbb', 'e')}}}
 
+
+
+    outer_path = ('universe', 'agent')
     initial_state = {
         'aaa': {
             'a': 2,
@@ -2114,14 +2118,22 @@ def test_complex_topology():
         'ddd': {
             'z': 333}}
 
-    pq = PoQo({})
-    pq_config = pq.generate()
-    pq_config['initial_state'] = initial_state
+    initial_state = {
+        'universe': {
+            'agent': initial_state}}
 
-    experiment = Experiment(pq_config)
+    pq = PoQo({})
+    pq_composite = pq.generate(path=outer_path)
+    pq_composite['initial_state'] = initial_state
+
+    experiment = Experiment(pq_composite)
 
     pp(experiment.state.get_value())
     experiment.update(1)
+
+    import ipdb;
+    ipdb.set_trace()
+
 
     state = experiment.state.get_value()
     assert state['aaa']['a'] == initial_state['aaa']['a'] + initial_state['aaa']['o'] - 1
@@ -2263,8 +2275,7 @@ if __name__ == '__main__':
     # test_multi()
     # test_sine()
     # test_parallel()
-    # test_complex_topology()
+    test_complex_topology()
     # test_multi_port_merge()
     # test_2_store_1_port()
-
-    test_units()
+    # test_units()

--- a/vivarium/core/experiment.py
+++ b/vivarium/core/experiment.py
@@ -794,6 +794,9 @@ class Store(object):
                     if inner_deletions:
                         deletions.extend(inner_deletions)
 
+                if key == '..':
+                    self.outer.apply_update(value, state)
+
             if delete_keys is not None:
                 # delete a list of paths
                 here = self.path_for()
@@ -1356,7 +1359,7 @@ class Experiment(object):
 
     def process_update(self, path, process, interval):
         state = self.state.get_path(path)
-        process_topology = get_in(self.topology, path)
+        process_topology = state.topology
 
         # translate the values from the tree structure into the form
         # that this process expects, based on its declared topology
@@ -2128,10 +2131,6 @@ def test_complex_topology():
     # pull out the agent state
     initial_agent_state = initial_state['universe']['agent']
     agent_state = next_state['universe']['agent']
-
-    # import ipdb;
-    # ipdb.set_trace()
-    # TODO -- is ['ccc']['a3'] updating appropriately?
 
     assert agent_state['aaa']['a1'] == initial_agent_state['aaa']['a1'] + 1
     assert agent_state['aaa']['x'] == initial_agent_state['aaa']['x'] - 9


### PR DESCRIPTION
This PR fixes #54. The bug was that when using inverting the topology to apply an update, with a topology that included a '..', the `store.apply_update()` was not reading '..' correctly and skipped the update. The addition of this line to `apply_update` fixed it:
```
                if key == '..':
                    self.outer.apply_update(value, state)
```

This PR also extends the `test_complex_topology` pytest to include this configuration and assert that the update is applied.