### PR TITLE
mass adaptors

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -65,6 +65,10 @@ disallow_incomplete_defs = False
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
+[mypy-vivarium.processes.mass_adaptor.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
 [mypy-vivarium.processes.toy_gillespie.*]
 disallow_untyped_defs = False
 disallow_incomplete_defs = False

--- a/vivarium/__init__.py
+++ b/vivarium/__init__.py
@@ -26,6 +26,7 @@ from vivarium.processes.nonspatial_environment import (
 from vivarium.processes.swap_processes import SwapProcesses
 from vivarium.processes.remove import Remove
 from vivarium.processes.divide_condition import DivideCondition
+from vivarium.processes.mass_adaptor import MassToConcentration, MassToCount
 
 # import updaters, dividers, serializers
 from vivarium.core.registry import (
@@ -52,6 +53,8 @@ process_registry.register(
 process_registry.register(SwapProcesses.name, SwapProcesses)
 process_registry.register(Remove.name, Remove)
 process_registry.register(Clock.name, Clock)
+process_registry.register(MassToConcentration.name, MassToConcentration)
+process_registry.register(MassToCount.name, MassToCount)
 
 # register updaters
 updater_registry.register('accumulate', update_accumulate)

--- a/vivarium/processes/mass_adaptor.py
+++ b/vivarium/processes/mass_adaptor.py
@@ -4,7 +4,7 @@ from vivarium.library.units import units
 
 class MassToConcentration(Deriver):
     """ Adapts mass variable to mass concentration """
-
+    name = 'mass_to_concentration'
     defaults = {
         'input_mass_units': 1.0 * units.fg,
         'input_volume_units': 1.0 * units.fL,
@@ -53,7 +53,7 @@ class MassToConcentration(Deriver):
 
 class MassToCount(Deriver):
     """ Adapts mass variable to mass concentration """
-
+    name = 'mass_to_count'
     defaults = {
         'input_mass_units': 1.0 * units.fg,
         'mass_species_molecular_weight': 1.0 * units.fg / units.molec

--- a/vivarium/processes/mass_adaptor.py
+++ b/vivarium/processes/mass_adaptor.py
@@ -10,7 +10,7 @@ class MassToConcentration(Deriver):
         'input_volume_units': 1.0 * units.fL,
         'output_concentration_units': 1.0 * units.mmolar,
         'characteristic_output_volume': 1.0 * units.fL,
-        'mass_species_molecular_weight': 1.0 * units.fg / units.molec
+        'mass_species_mw': 1.0 * units.fg / units.molec
     }
 
     def initial_state(self, config=None):
@@ -38,14 +38,15 @@ class MassToConcentration(Deriver):
 
         # do conversion
         # Concentration = mass/molecular_weight/characteristic volume
-        # Note: Biomass is also used to set Volume, so here we just set the scale
-        mass_species_conc = mass / self.config['mass_species_molecular_weight'] / (
+        # Note: here we just set the scale, not the volume
+        mass_species_conc = mass / self.config['mass_species_mw'] / (
             self.config['characteristic_output_volume'])
 
         update = {
             'output': {
                 # Return the correct units, with units stripped away
-                'biomass': mass_species_conc.to(self.config['output_concentration_units']).magnitude
+                'biomass': mass_species_conc.to(
+                    self.config['output_concentration_units']).magnitude
             }
         }
         return update
@@ -56,7 +57,7 @@ class MassToCount(Deriver):
     name = 'mass_to_count'
     defaults = {
         'input_mass_units': 1.0 * units.fg,
-        'mass_species_molecular_weight': 1.0 * units.fg / units.molec
+        'mass_species_mw': 1.0 * units.fg / units.molec
     }
 
     def initial_state(self, config=None):
@@ -82,8 +83,8 @@ class MassToCount(Deriver):
 
         # do conversion
         # count = mass/molecular_weight
-        # Note: Biomass is also used to set Volume, so here we just set the scale
-        mass_species_count = mass / self.config['mass_species_molecular_weight']
+        # Note: here we just set the scale, not the volume
+        mass_species_count = mass / self.config['mass_species_mw']
 
         update = {
             'output': {

--- a/vivarium/processes/mass_adaptor.py
+++ b/vivarium/processes/mass_adaptor.py
@@ -1,0 +1,94 @@
+from vivarium.core.process import Deriver
+from vivarium.library.units import units
+
+
+class MassToConcentration(Deriver):
+    """ Adapts mass variable to mass concentration """
+
+    defaults = {
+        'input_mass_units': 1.0 * units.fg,
+        'input_volume_units': 1.0 * units.fL,
+        'output_concentration_units': 1.0 * units.mmolar,
+        'characteristic_output_volume': 1.0 * units.fL,
+        'mass_species_molecular_weight': 1.0 * units.fg / units.molec
+    }
+
+    def initial_state(self, config=None):
+        return {}
+
+    def ports_schema(self):
+        return {
+            'input': {
+                'mass': {
+                    '_default': 1.0 * self.parameters['input_mass_units'],
+                },
+                'volume': {
+                    '_default': 1.0 * self.parameters['input_volume_units']}
+            },
+            'output': {
+                'biomass': {
+                    '_default': 1.0,
+                    '_update': 'set',
+                }
+            }
+        }
+
+    def next_update(self, timestep, states):
+        mass = states['input']['mass']
+
+        # do conversion
+        # Concentration = mass/molecular_weight/characteristic volume
+        # Note: Biomass is also used to set Volume, so here we just set the scale
+        mass_species_conc = mass / self.config['mass_species_molecular_weight'] / (
+            self.config['characteristic_output_volume'])
+
+        update = {
+            'output': {
+                # Return the correct units, with units stripped away
+                'biomass': mass_species_conc.to(self.config['output_concentration_units']).magnitude
+            }
+        }
+        return update
+
+
+class MassToCount(Deriver):
+    """ Adapts mass variable to mass concentration """
+
+    defaults = {
+        'input_mass_units': 1.0 * units.fg,
+        'mass_species_molecular_weight': 1.0 * units.fg / units.molec
+    }
+
+    def initial_state(self, config=None):
+        return {}
+
+    def ports_schema(self):
+        return {
+            'input': {
+                'mass': {
+                    '_default': 1.0 * units.fg,
+                },
+            },
+            'output': {
+                'biomass': {
+                    '_default': 1.0,
+                    '_update': 'set',
+                }
+            }
+        }
+
+    def next_update(self, timestep, states):
+        mass = states['input']['mass']
+
+        # do conversion
+        # count = mass/molecular_weight
+        # Note: Biomass is also used to set Volume, so here we just set the scale
+        mass_species_count = mass / self.config['mass_species_molecular_weight']
+
+        update = {
+            'output': {
+                # Return the correct units, with units stripped away
+                'biomass': mass_species_count.magnitude
+            }
+        }
+        return update


### PR DESCRIPTION
This PR brings in the mass adaptors @WilliamIX developed for the BioscrapeCOBRA composite. These are general adaptor derivers, which can be reused for many different projects. `MassToConcentration` converts mass (e.g. *fg*) to concentration (e.g. *mmolar*), and `MassToCount` converts mass to counts using a molecular weight. The characteristic units can be set upon initialization with parameters such as `output_concentration_units`.