### PR TITLE
Topology plot

### DIFF
--- a/vivarium/plots/topology.py
+++ b/vivarium/plots/topology.py
@@ -175,7 +175,7 @@ def graph_figure(
         for (store_1, store_2) in place_edges:
             outers.add(store_1)
             inners.add(store_2)
-            graph.add_edge(store_1, store_2, outer=store_1, inner=store_2)
+            graph.add_edge(store_1, store_2, place_edge=True)
 
         # add non-embedded nodes to outers
         all_stores = outers.union(inners)
@@ -265,13 +265,16 @@ def graph_figure(
                            node_shape=cast(str, STORAGE_PATH))
 
     # edges
-    # TODO -- 'hierarchy' edges
     edge_args = {}
-    if graph_format != 'hierarchy' and color_edges:
+    edge_args['width'] = [1.5 for _ in edges.keys()]
+    if color_edges:
         edge_args['edge_color'] = list(range(1, len(edges) + 1))
+        if graph_format == 'hierarchy':
+            edge_args['edge_color'].extend([0 for _ in place_edges])
+            edge_args['width'].extend([3.0 for _ in place_edges])
 
     nx.draw_networkx_edges(graph, pos,
-                           width=1.5,
+                           # width=1.5,
                            **edge_args)
 
     # labels
@@ -453,11 +456,11 @@ def main():
         fig_name = 'topology_3'
         settings = {
             'graph_format': 'hierarchy',
-            'store_color': 'k'
+            'store_color': 'navy'
         }
     else:
         pass
-        # more complxe topology, with ..?
+        # more complex topology, with ..?
 
     test_graph(
         fig_name=fig_name,

--- a/vivarium/plots/topology.py
+++ b/vivarium/plots/topology.py
@@ -110,8 +110,7 @@ def graph_figure(
         graph: nx.Graph,
         *,
         graph_format: str = 'horizontal',
-        place_edges: list = None,
-        compartment_nodes: list = None,
+        place_edges: Optional[list] = None,
         show_ports: bool = True,
         store_color: Any = 'tab:blue',
         process_color: Any = 'tab:orange',
@@ -171,7 +170,8 @@ def graph_figure(
     # get positions
     pos = {}
     if graph_format == 'hierarchy':
-
+        place_edges = place_edges or []
+        
         # add new place edges by iterating over all place_edges
         outers = set()
         inners = set()
@@ -318,7 +318,6 @@ def plot_topology(
     # make networkx graph
     g, place_edges, compartment_nodes = get_networkx_graph(composite)
     settings['place_edges'] = place_edges
-    settings['compartment_nodes'] = compartment_nodes
 
     # make graph figure
     fig = graph_figure(g, **settings)

--- a/vivarium/plots/topology.py
+++ b/vivarium/plots/topology.py
@@ -114,7 +114,7 @@ def graph_figure(
         store_colors: Optional[Dict] = None,
         process_colors: Optional[Dict] = None,
         color_edges: bool = True,
-        edge_width: float = 1.5,
+        edge_width: float = 2.0,
         fill_color: Any = 'w',
         node_size: float = 8000,
         font_size: int = 14,

--- a/vivarium/plots/topology.py
+++ b/vivarium/plots/topology.py
@@ -229,9 +229,9 @@ def save_network(out_dir='out', filename='network'):
 
 def plot_topology(
         composite,
-        settings: Optional[Dict[str, Any]] = None,
-        out_dir=None,
-        filename=None,
+        settings: Optional[Dict] = None,
+        out_dir: Optional[str] = None,
+        filename: Optional[str] = None,
 ):
     """ Plot a composite's topology """
 
@@ -313,8 +313,8 @@ class MergePort(Composer):
 
 def test_graph(
         fig_name=None,
-        topology: Optional[Dict[str, Any]] = None,
-        settings: Optional[Dict[str, Any]] = None,
+        topology=None,
+        settings=None,
 ):
 
     if topology is None:

--- a/vivarium/plots/topology.py
+++ b/vivarium/plots/topology.py
@@ -145,6 +145,7 @@ def graph_figure(
     """
     process_colors = process_colors or {}
     store_colors = store_colors or {}
+    place_edges = place_edges or []
 
     node_attributes = dict(graph.nodes.data())
     process_nodes = [
@@ -168,8 +169,6 @@ def graph_figure(
     # get positions
     pos = {}
     if graph_format == 'hierarchy':
-        place_edges = place_edges or []
-
         # add new place edges by iterating over all place_edges
         outers = set()
         inners = set()
@@ -268,14 +267,14 @@ def graph_figure(
     # edges
     edge_args = {}
 
-    # colors
+    # edge colors
     if color_edges:
         edge_args['edge_cmap'] = plt.get_cmap('nipy_spectral')
         edge_args['edge_color'] = list(range(1, len(edges) + 1))
         if graph_format == 'hierarchy':
             edge_args['edge_color'].extend([0 for _ in place_edges])
 
-    # width
+    # edge width
     edge_args['width'] = [edge_width for _ in edges.keys()]
     if graph_format == 'hierarchy':
         # thicker edges for hierarchy connections
@@ -285,7 +284,7 @@ def graph_figure(
                            # width=1.5,
                            **edge_args)
 
-    # labels
+    # edge labels
     nx.draw_networkx_labels(graph, pos,
                             font_size=font_size)
     if show_ports:
@@ -294,7 +293,7 @@ def graph_figure(
                                      font_size=font_size,
                                      label_pos=label_pos)
 
-    # add buffer
+    # add white buffer around final figure
     xmin, xmax, ymin, ymax = plt.axis()
     plt.xlim(xmin - buffer, xmax + buffer)
     plt.ylim(ymin - buffer, ymax + buffer)

--- a/vivarium/plots/topology.py
+++ b/vivarium/plots/topology.py
@@ -43,7 +43,7 @@ STORAGE_PATH = construct_storage_path()
 
 
 def get_bipartite_graph(topology):
-    ''' Get a graph with Processes, Stores, and edges from a Vivarium topology '''
+    """ Get a graph with Processes, Stores, and edges from a Vivarium topology """
     if 'topology' in topology:
         topology = topology['topology']
 
@@ -53,11 +53,9 @@ def get_bipartite_graph(topology):
     compartment_nodes = []
     place_edges = []
     for process_id, connections in topology.items():
-        # process_id = process_id.replace("_", "_\n")  # line breaks at underscores
         process_nodes.append(process_id)
 
         for port, path in connections.items():
-
             # store_id = '\n'.join(path)  # TODO: a fancier graph for a dict
             # store_id = store_id.replace('..\n', '⬆︎')
             store_id = path[-1]
@@ -65,7 +63,6 @@ def get_bipartite_graph(topology):
                 store_nodes.append(store_id)
 
             if len(path) > 1:
-
                 # hierarchy place edges between inner/outer stores
                 for store_1, store_2 in zip(path, path[1:]):
 
@@ -85,12 +82,12 @@ def get_bipartite_graph(topology):
     if overlap:
         print('{} shared by processes and stores'.format(overlap))
 
-    return process_nodes, store_nodes, edges, place_edges, compartment_nodes
+    return process_nodes, store_nodes, edges, place_edges
 
 
 def get_networkx_graph(topology):
-    ''' Make a networkX graph from a Vivarium topology '''
-    process_nodes, store_nodes, edges, place_edges, compartment_nodes = get_bipartite_graph(topology)
+    """ Make a networkX graph from a Vivarium topology """
+    process_nodes, store_nodes, edges, place_edges = get_bipartite_graph(topology)
 
     # make networkX graph
     g = nx.Graph()
@@ -103,7 +100,7 @@ def get_networkx_graph(topology):
     for (process_id, store_id), port in edges.items():
         g.add_edge(process_id, store_id, port=port)
 
-    return g, place_edges, compartment_nodes
+    return g, place_edges
 
 
 def graph_figure(
@@ -128,7 +125,7 @@ def graph_figure(
     """ Make a figure from a networkx graph.
 
     :param graph: the networkx.Graph to plot
-    :param graph_format: 'horizontal' or 'vertical'
+    :param graph_format: 'horizontal', 'vertical', or 'hierarchy'
     :param show_ports: whether to show the Port labels
     :param store_color: default color for the Store nodes; any matplotlib color value
     :param process_color: default color for the Process nodes; any matplotlib color value
@@ -171,7 +168,7 @@ def graph_figure(
     pos = {}
     if graph_format == 'hierarchy':
         place_edges = place_edges or []
-        
+
         # add new place edges by iterating over all place_edges
         outers = set()
         inners = set()
@@ -316,7 +313,7 @@ def plot_topology(
         composite = composite.generate()
 
     # make networkx graph
-    g, place_edges, compartment_nodes = get_networkx_graph(composite)
+    g, place_edges = get_networkx_graph(composite)
     settings['place_edges'] = place_edges
 
     # make graph figure

--- a/vivarium/plots/topology.py
+++ b/vivarium/plots/topology.py
@@ -270,6 +270,7 @@ def graph_figure(
 
     # colors
     if color_edges:
+        edge_args['edge_cmap'] = plt.get_cmap('nipy_spectral')
         edge_args['edge_color'] = list(range(1, len(edges) + 1))
         if graph_format == 'hierarchy':
             edge_args['edge_color'].extend([0 for _ in place_edges])

--- a/vivarium/plots/topology.py
+++ b/vivarium/plots/topology.py
@@ -206,14 +206,19 @@ def graph_figure(
             accounted.update(next_level)
             unaccounted = unaccounted.difference(accounted)
 
+        # buffer makes things centered
+        n_max = max([len(level) for level in levels])
+        buffer_processes = (n_max - n_processes) / 2
+
         # place the nodes according to levels
         for idx, node_id in enumerate(process_nodes, 1):
-            pos[node_id] = np.array([idx, 1])
+            pos[node_id] = np.array([buffer_processes + idx, 1])
         for level_idx, level in enumerate(levels, 1):
+            level_buffer = (n_max - len(level)) / 2
             for idx, node_id in enumerate(level, 1):
-                pos[node_id] = np.array([idx, -1*level_idx])
+                pos[node_id] = np.array([level_buffer + idx, -1*level_idx])
 
-        fig = plt.figure(1, figsize=(n_max * node_distance, 12))
+        fig = plt.figure(1, figsize=(n_max * node_distance, 6 + 3 * len(levels)))
 
     elif graph_format == 'vertical':
         # processes in a column, and stores in a column

--- a/vivarium/plots/topology.py
+++ b/vivarium/plots/topology.py
@@ -114,6 +114,7 @@ def graph_figure(
         store_colors: Optional[Dict] = None,
         process_colors: Optional[Dict] = None,
         color_edges: bool = True,
+        edge_width: float = 1.5,
         fill_color: Any = 'w',
         node_size: float = 8000,
         font_size: int = 14,
@@ -266,12 +267,18 @@ def graph_figure(
 
     # edges
     edge_args = {}
-    edge_args['width'] = [1.5 for _ in edges.keys()]
+
+    # colors
     if color_edges:
         edge_args['edge_color'] = list(range(1, len(edges) + 1))
         if graph_format == 'hierarchy':
             edge_args['edge_color'].extend([0 for _ in place_edges])
-            edge_args['width'].extend([3.0 for _ in place_edges])
+
+    # width
+    edge_args['width'] = [edge_width for _ in edges.keys()]
+    if graph_format == 'hierarchy':
+        # thicker edges for hierarchy connections
+        edge_args['width'].extend([edge_width * 2 for _ in place_edges])
 
     nx.draw_networkx_edges(graph, pos,
                            # width=1.5,


### PR DESCRIPTION
@WilliamIX -- check this out! Feedback is welcome on the PR.

This PR updates the topology plot with additional options.

This include a "horizontal" `graph_format` setting that places processes above stores in two rows. This is now the default output.
![topology_2](https://user-images.githubusercontent.com/6809431/109395113-8c311880-78df-11eb-9afd-f4e23779f146.png)

There is also a new `process_colors` and `store_colors` option to set specific colors for each node: 
![topology_1](https://user-images.githubusercontent.com/6809431/109395118-918e6300-78df-11eb-9067-cce313e72823.png)

And a "hierarchy" `graph_format` option for separating levels of the store hierarchy:
![topology_3](https://user-images.githubusercontent.com/6809431/109395120-9521ea00-78df-11eb-93c2-fa9620d045f7.png)




