### PR TITLE
improve node_labels in topology plot

### DIFF
--- a/vivarium/core/emitter.py
+++ b/vivarium/core/emitter.py
@@ -213,7 +213,7 @@ class DatabaseEmitter(Emitter):
         emit_data: dict = data['data']
         emit_data['experiment_id'] = self.experiment_id
         # TODO(jerry): Should this pop('table') from emit_data?
-        table = getattr(self.db, emit_data['table'])
+        table = getattr(self.db, data['table'])
         table.insert_one(emit_data)
 
     def get_data(self) -> dict:

--- a/vivarium/core/experiment.py
+++ b/vivarium/core/experiment.py
@@ -234,7 +234,7 @@ class Experiment:
             'description': self.description,
             'topology': self.topology,
             'processes': serialize_value(self.processes),
-            'state': self.state.get_config()
+            'state': serialize_value(self.state.get_config())
         }
         emit_config = {
             'table': 'configuration',

--- a/vivarium/core/process.py
+++ b/vivarium/core/process.py
@@ -232,7 +232,8 @@ def _get_composite_state(
                 topology=subtopology,
                 state_type=state_type,
                 path=subpath,
-                initial_state=initial_state
+                initial_state=initial_state,
+                config=config.get(key),
             )
         elif isinstance(node, Process):
             if state_type == 'initial':

--- a/vivarium/core/process.py
+++ b/vivarium/core/process.py
@@ -18,7 +18,7 @@ from pint.errors import UndefinedUnitError
 
 from vivarium.library.datum import Datum
 from vivarium.library.topology import inverse_topology
-from vivarium.library.units import Quantity
+from vivarium.library.units import Quantity, Unit
 from vivarium.core.registry import serializer_registry
 from vivarium.library.dict_utils import deep_merge
 from vivarium.core.types import (
@@ -79,6 +79,9 @@ def serialize_value(value: Any) -> Any:
         return serializer_registry.access('numpy').serialize(value)
     if isinstance(value, Quantity):
         value = cast(Quantity, value)
+        return serializer_registry.access('units').serialize(value)
+    if isinstance(value, Unit):
+        value = cast(Unit, value)
         return serializer_registry.access('units').serialize(value)
     if callable(value):
         value = cast(Callable, value)

--- a/vivarium/library/units.py
+++ b/vivarium/library/units.py
@@ -25,7 +25,7 @@ from typing import Any
 import pint
 # noinspection PyProtectedMember
 from pint.quantity import _Quantity as Quantity
-
+from pint.unit import Unit
 
 #: Units registry that stores the units used throughout Vivarium
 units = pint.UnitRegistry()

--- a/vivarium/plots/topology.py
+++ b/vivarium/plots/topology.py
@@ -236,6 +236,7 @@ def graph_figure(
     :param label_pos: position of the Port labels along their connection lines,
         (0=head, 0.5=center, 1=tail)
     """
+    node_labels = node_labels or {}
     process_colors = process_colors or {}
     store_colors = store_colors or {}
     place_edges = place_edges or []


### PR DESCRIPTION
This change simplifies the code, and allows multiple nodes to be given the same label. The labeling only happens at the very end, upon plotting. So node ids assume the original node name for all other functions.