### PR TITLE
Provide information about update failure

### DIFF
--- a/vivarium/core/store.py
+++ b/vivarium/core/store.py
@@ -8,6 +8,7 @@ The file system for storing and updating state variables during an experiment.
 
 import copy
 import logging as log
+from pprint import pformat
 
 import numpy as np
 from pint import Quantity
@@ -780,6 +781,12 @@ class Store:
                 self.schema_keys and set(update.keys()):
             if '_updater' in update:
                 update = update.get('_value', self.default)
+
+        if updater is None:
+            raise Exception(
+                f"updater is absent at path {self.path_for()} "
+                f"with value {self.value} for {pformat(update)}"
+            )
 
         self.value = updater(self.value, update)
 


### PR DESCRIPTION
Currently if the updater for an update ever ends up being `None`, it fails with a cryptic message about not being able to apply None as a function. This PR detects the failure and provides useful information about what went wrong: 

* the path to this node
* its current value
* what the update is that was trying to be applied, but whose updater is `None` for whatever reason. 

Beyond this case I think this is a general usability principle, that we should be on the lookout for cryptic failures that take awhile to figure out (especially things deep inside store) and figure out a way to provide more information to the user about what might be going wrong (!)