### PR TITLE
division process

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -133,6 +133,10 @@ disallow_incomplete_defs = False
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
+[mypy-vivarium.processes.division.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
 [mypy-vivarium.processes.engulf.*]
 disallow_untyped_defs = False
 disallow_incomplete_defs = False

--- a/vivarium/processes/division.py
+++ b/vivarium/processes/division.py
@@ -1,4 +1,3 @@
-import uuid
 from typing import Any, Dict
 import logging as log
 
@@ -59,8 +58,8 @@ class Division(Deriver):
                     'initial_state': {}})
 
             log.info(
-                'DIVIDE! \n--> MOTHER: {} \n--> DAUGHTERS: {}'.format(
-                    self.agent_id, daughter_ids))
+                'DIVIDE! \n--> MOTHER: %s \n--> DAUGHTERS: %s',
+                    str(self.agent_id), str(daughter_ids))
 
             # initial state will be provided by division in the tree
             return {
@@ -68,5 +67,4 @@ class Division(Deriver):
                     '_divide': {
                         'mother': self.agent_id,
                         'daughters': daughter_updates}}}
-        else:
-            return {}
+        return {}

--- a/vivarium/processes/division.py
+++ b/vivarium/processes/division.py
@@ -9,6 +9,7 @@ def daughter_phylogeny_id(mother_id):
         str(mother_id) + '0',
         str(mother_id) + '1']
 
+
 def pass_threshold(value, config):
     threshold = config['threshold']
     if value >= threshold:
@@ -31,7 +32,7 @@ class Division(Deriver):
         self.condition_function = self.parameters['condition_function']
         self.condition_config = self.parameters['condition_config']
 
-        # must provide a compartment to generate new daughters
+        # must provide a composer to generate new daughters
         self.agent_id = self.parameters['agent_id']
         self.composer = self.parameters['composer']
         self.daughter_ids_function = self.parameters['daughter_ids_function']
@@ -59,7 +60,7 @@ class Division(Deriver):
 
             log.info(
                 'DIVIDE! \n--> MOTHER: %s \n--> DAUGHTERS: %s',
-                    str(self.agent_id), str(daughter_ids))
+                str(self.agent_id), str(daughter_ids))
 
             # initial state will be provided by division in the tree
             return {

--- a/vivarium/processes/division.py
+++ b/vivarium/processes/division.py
@@ -1,0 +1,72 @@
+import uuid
+from typing import Any, Dict
+import logging as log
+
+from vivarium.core.process import Deriver
+
+
+def daughter_phylogeny_id(mother_id):
+    return [
+        str(mother_id) + '0',
+        str(mother_id) + '1']
+
+def pass_threshold(value, config):
+    threshold = config['threshold']
+    if value >= threshold:
+        return True
+    return False
+
+
+class Division(Deriver):
+    """ Division Process """
+    defaults: Dict[str, Any] = {
+        'daughter_ids_function': daughter_phylogeny_id,
+        'condition_function': pass_threshold,
+        'condition_config': {
+            'threshold': None
+        }
+    }
+
+    def __init__(self, parameters=None):
+        super().__init__(parameters)
+        self.condition_function = self.parameters['condition_function']
+        self.condition_config = self.parameters['condition_config']
+
+        # must provide a compartment to generate new daughters
+        self.agent_id = self.parameters['agent_id']
+        self.composer = self.parameters['composer']
+        self.daughter_ids_function = self.parameters['daughter_ids_function']
+
+    def ports_schema(self):
+        return {
+            'variable': {},
+            'agents': {
+                '*': {}}}
+
+    def next_update(self, timestep, states):
+        variable = states['variable']
+        if self.condition_function(variable, self.condition_config):
+            daughter_ids = self.daughter_ids_function(self.agent_id)
+            daughter_updates = []
+
+            for daughter_id in daughter_ids:
+                composer = self.composer.generate({
+                    'agent_id': daughter_id})
+                daughter_updates.append({
+                    'key': daughter_id,
+                    'processes': composer['processes'],
+                    'topology': composer['topology'],
+                    'initial_state': {}})
+
+            log.info(
+                'DIVIDE! \n--> MOTHER: {} \n--> DAUGHTERS: {}'.format(
+                    self.agent_id, daughter_ids))
+
+            # initial state will be provided by division in the tree
+            return {
+                'agents': {
+                    '_divide': {
+                        'mother': self.agent_id,
+                        'daughters': daughter_updates}}}
+        else:
+            return {}


### PR DESCRIPTION
`divide_condition` and `meta_division` are always used together, so here we introduce a single `division` process that does the job of both the previous processes. Additionally, this has a configurable `condition_function` that can be used to define any function to trigger division. It defaults to the same threshold function that was used in `divide_condition`.