### PR TITLE
Experiment emitter config test

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -53,6 +53,10 @@ disallow_incomplete_defs = False
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
+[mypy-vivarium.experiments.test_experiments.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
 [mypy-vivarium.processes.timeline.*]
 disallow_untyped_defs = False
 disallow_incomplete_defs = False

--- a/mypy.ini
+++ b/mypy.ini
@@ -53,7 +53,7 @@ disallow_incomplete_defs = False
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-vivarium.experiments.test_experiments.*]
+[mypy-vivarium.experiments.large_database_experiment.*]
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 

--- a/vivarium/core/emitter.py
+++ b/vivarium/core/emitter.py
@@ -220,6 +220,29 @@ class DatabaseEmitter(Emitter):
         return get_history_data_db(self.history, self.experiment_id)
 
 
+def get_experiment_database(
+        port: Any = 27017,
+        database_name: str = 'simulations'
+):
+    config = {
+        'host': '{}:{}'.format('localhost', port),
+        'database': database_name}
+    emitter = DatabaseEmitter(config)
+    db = emitter.db
+    return db
+
+
+def delete_experiment_from_database(
+        experiment_id: str,
+        port: Any = 27017,
+        database_name: str = 'simulations'
+) -> None:
+    db = get_experiment_database(port, database_name)
+    query = {'experiment_id': experiment_id}
+    db.history.delete_many(query)
+    db.configuration.delete_many(query)
+
+
 def get_history_data_db(
         history_collection: Any, experiment_id: Any) -> Dict[float, dict]:
     """Query MongoDB for history data."""

--- a/vivarium/core/emitter.py
+++ b/vivarium/core/emitter.py
@@ -212,7 +212,6 @@ class DatabaseEmitter(Emitter):
     def emit(self, data: Dict[str, Any]) -> None:
         emit_data: dict = data['data']
         emit_data['experiment_id'] = self.experiment_id
-        # TODO(jerry): Should this pop('table') from emit_data?
         table = getattr(self.db, data['table'])
         table.insert_one(emit_data)
 

--- a/vivarium/core/emitter.py
+++ b/vivarium/core/emitter.py
@@ -222,7 +222,7 @@ class DatabaseEmitter(Emitter):
 def get_experiment_database(
         port: Any = 27017,
         database_name: str = 'simulations'
-):
+) -> Any:
     config = {
         'host': '{}:{}'.format('localhost', port),
         'database': database_name}

--- a/vivarium/core/experiment.py
+++ b/vivarium/core/experiment.py
@@ -20,8 +20,6 @@ import datetime
 import time as clock
 import uuid
 
-from pymongo.errors import PyMongoError
-
 from vivarium.composites.toys import Proton, Electron, Sine, PoQo
 from vivarium.core.store import hierarchy_depth, Store, generate_state
 from vivarium.core.emitter import get_emitter
@@ -285,7 +283,7 @@ class Experiment:
         else:
             warnings.warn('configuration size is too big for the emitter, '
                           'discarding process parameters')
-            for process_id, parameters in emit_config['data']['processes'].items():
+            for process_id in emit_config['data']['processes'].keys():
                 emit_config['data']['processes'][process_id] = None
             self.emitter.emit(emit_config)
 

--- a/vivarium/core/experiment.py
+++ b/vivarium/core/experiment.py
@@ -6,8 +6,10 @@ Experiment
 Experiment runs the simulation.
 """
 
+import sys
 import os
 import logging as log
+import warnings
 import pprint
 import multiprocessing
 from multiprocessing import pool as multipool
@@ -275,13 +277,16 @@ class Experiment:
         emit_config: Dict[str, Any] = {
             'table': 'configuration',
             'data': data}
-        try:
+
+        # get size of data for emit
+        data_bytes = sys.getsizeof(str(emit_config))
+        if data_bytes < 26000000:  # pymongo document size limit
             self.emitter.emit(emit_config)
-        except PyMongoError:
-            log.exception("emitter.emit", exc_info=True, stack_info=True)
-            # TODO -- handle large parameter sets to meet mongoDB limit
-            del emit_config['data']['processes']
-            del emit_config['data']['state']
+        else:
+            warnings.warn('configuration size is too big for the emitter, '
+                          'discarding process parameters')
+            for process_id, parameters in emit_config['data']['processes'].items():
+                emit_config['data']['processes'][process_id] = None
             self.emitter.emit(emit_config)
 
     def invoke_process(

--- a/vivarium/experiments/large_database_experiment.py
+++ b/vivarium/experiments/large_database_experiment.py
@@ -51,7 +51,7 @@ class ManyParametersComposite(Composer):
             process_id: {'port': ('store',)}
             for process_id in self.process_ids}
 
-def test_large_initial_emit():
+def run_large_initial_emit():
 
     config = {
         'number_of_processes': 1000,
@@ -82,4 +82,4 @@ def test_large_initial_emit():
 
 
 if __name__ == '__main__':
-    test_large_initial_emit()
+    run_large_initial_emit()

--- a/vivarium/experiments/test_experiments.py
+++ b/vivarium/experiments/test_experiments.py
@@ -54,8 +54,8 @@ class ManyParametersComposite(Composer):
 def test_large_initial_emit():
 
     config = {
-        'number_of_processes': 100,
-        'number_of_parameters': 100}
+        'number_of_processes': 1000,
+        'number_of_parameters': 1000}
 
     composer = ManyParametersComposite(config)
     composite = composer.generate()

--- a/vivarium/experiments/test_experiments.py
+++ b/vivarium/experiments/test_experiments.py
@@ -1,0 +1,82 @@
+import random
+from vivarium.core.experiment import Experiment
+from vivarium.core.process import Process, Composer
+from vivarium.core.emitter import (
+    get_experiment_database,
+    data_from_database,
+    delete_experiment_from_database)
+
+
+class ManyParametersProcess(Process):
+    defaults = {
+        'number_of_parameters': 100}
+
+    def __init__(self, parameters=None):
+        super().__init__(parameters)
+
+        # make a bunch of parameters
+        random_parameters = {
+            key: random.random()
+            for key in range(self.parameters['number_of_parameters'])}
+        super().__init__(random_parameters)
+
+    def ports_schema(self):
+        return {'port': {'variable': {'_default': 0}}}
+    def next_update(self, timestep, states):
+        return {}
+
+
+class ManyParametersComposite(Composer):
+    defaults = {
+        'number_of_processes': 10,
+        'number_of_parameters': 100}
+
+    def __init__(self, config=None):
+        super().__init__(config)
+        self.process_ids = [
+            f'process_{key}'
+            for key in range(self.config['number_of_processes'])]
+
+    def generate_processes(self, config):
+
+        # make a bunch of processes
+        return {
+            process_id: ManyParametersProcess({
+                'name': process_id,
+                'number_of_parameters': self.config['number_of_parameters']})
+            for process_id in self.process_ids}
+
+    def generate_topology(self, config):
+        return {
+            process_id: {'port': ('store',)}
+            for process_id in self.process_ids}
+
+def test_large_initial_emit():
+
+    config = {
+        'number_of_processes': 100,
+        'number_of_parameters': 100}
+
+    composer = ManyParametersComposite(config)
+    composite = composer.generate()
+
+    settings = {
+        'emitter': 'database'
+    }
+
+    experiment = Experiment({
+        'processes': composite['processes'],
+        'topology': composite['topology'],
+        **settings})
+
+    # retrieve the data
+    experiment_id = experiment.experiment_id
+    db = get_experiment_database()
+    data, experiment_config = data_from_database(experiment_id, db)
+
+    # delete the experiment
+    delete_experiment_from_database(experiment_id)
+
+
+if __name__ == '__main__':
+    test_large_initial_emit()

--- a/vivarium/experiments/test_experiments.py
+++ b/vivarium/experiments/test_experiments.py
@@ -74,6 +74,9 @@ def test_large_initial_emit():
     db = get_experiment_database()
     data, experiment_config = data_from_database(experiment_id, db)
 
+    assert 'processes' in experiment_config
+    assert 0.0 in data
+
     # delete the experiment
     delete_experiment_from_database(experiment_id)
 


### PR DESCRIPTION
This PR fixes `Experiment's` `emit_configuration` method to better check the size of the emitted configuration, and remove all process parameters if it is too large for pymongo. I also added a new `large_database_experiment` file that makes an experiment with bunch of processes with random parameters, and emits them to the simulation database.