### PR TITLE
improved custom divider

### DIFF
--- a/vivarium/__init__.py
+++ b/vivarium/__init__.py
@@ -37,6 +37,7 @@ from vivarium.core.registry import (
     update_accumulate, update_set, update_merge, update_null,
     update_nonnegative_accumulate, divide_set, divide_split,
     divide_split_dict, divide_zero, assert_no_divide, divide_binomial,
+    divide_set_value,
     NumpySerializer, NumpyScalarSerializer, UnitsSerializer,
     ProcessSerializer, ComposerSerializer, FunctionSerializer,
 )
@@ -76,6 +77,7 @@ divider_registry.register('split', divide_split)
 divider_registry.register('split_dict', divide_split_dict)
 divider_registry.register('zero', divide_zero)
 divider_registry.register('no_divide', assert_no_divide)
+divider_registry.register('set_value', divide_set_value)
 
 # register serializers
 serializer_registry.register('numpy', NumpySerializer())

--- a/vivarium/core/experiment.py
+++ b/vivarium/core/experiment.py
@@ -20,7 +20,7 @@ import datetime
 import time as clock
 import uuid
 
-from vivarium.composites.toys import Proton, Electron, Sine, PoQo
+from vivarium.composites.toys import Proton, Electron, Sine, PoQo, ToyDivider
 from vivarium.core.store import hierarchy_depth, Store, generate_state
 from vivarium.core.emitter import get_emitter
 from vivarium.core.process import (
@@ -1093,6 +1093,23 @@ def test_units() -> None:
     pp(data_unitless)
 
 
+def test_custom_divider():
+    composer = ToyDivider({'divider': {'agent_id': '1'}})
+    composite = composer.generate()
+
+    experiment = Experiment({
+        'processes': composite.processes,
+        'topology': composite.topology,
+    })
+
+    experiment.update(10)
+
+    data = experiment.emitter.get_data()
+
+    print(pp(data))
+    # import ipdb; ipdb.set_trace()
+
+
 if __name__ == '__main__':
     # test_recursive_store()
     # test_timescales()
@@ -1100,7 +1117,9 @@ if __name__ == '__main__':
     # test_multi()
     # test_sine()
     # test_parallel()
-    test_complex_topology()
+    # test_complex_topology()
     # test_multi_port_merge()
     # test_2_store_1_port()
     # test_units()
+    test_custom_divider()
+

--- a/vivarium/core/experiment.py
+++ b/vivarium/core/experiment.py
@@ -1094,20 +1094,24 @@ def test_units() -> None:
 
 
 def test_custom_divider():
-    composer = ToyDivider({'divider': {'agent_id': '1'}})
-    composite = composer.generate()
+    agent_id = '1'
+    composer = ToyDivider({
+        'agent_id': agent_id,
+        'divider': {
+            'x_default': 3,
+            'x_division_threshold': 25,
+        }
+    })
+    composite = composer.generate(path=('agents', agent_id))
 
     experiment = Experiment({
         'processes': composite.processes,
         'topology': composite.topology,
     })
 
-    experiment.update(10)
-
+    experiment.update(80)
     data = experiment.emitter.get_data()
-
     print(pp(data))
-    # import ipdb; ipdb.set_trace()
 
 
 if __name__ == '__main__':

--- a/vivarium/core/registry.py
+++ b/vivarium/core/registry.py
@@ -174,6 +174,16 @@ def divide_set(state):
     return [state, state]
 
 
+def divide_set_value(state, value):
+    """Set Value Divider
+    Args:
+        'state': value
+    Returns:
+        A list ``[value, value]``. No copying is performed.
+    """
+    return [value, value]
+
+
 def divide_split(state):
     """Split Divider
 

--- a/vivarium/core/store.py
+++ b/vivarium/core/store.py
@@ -481,8 +481,13 @@ class Store:
             # divider is either a function or a dict with topology
             if isinstance(self.divider, dict):
                 divider = self.divider['divider']
-                topology = self.divider['topology']
-                state = self.outer.get_values(topology)
+                if 'topology' in self.divider:
+                    topology = self.divider['topology']
+                    state = self.outer.get_values(topology)
+                elif 'state' in self.divider:
+                    state = self.divider['state']
+                else:
+                    state = None
                 return divider(self.get_value(), state)
             return self.divider(self.get_value())
         if self.inner:
@@ -695,10 +700,13 @@ class Store:
                 # use dividers to find initial states for daughters
                 mother = divide['mother']
                 daughters = divide['daughters']
-                initial_state = self.inner[mother].get_value(
-                    condition=lambda child: not
-                    (isinstance(child.value, Process)),
-                    f=lambda child: copy.deepcopy(child))
+                try:
+                    initial_state = self.inner[mother].get_value(
+                        condition=lambda child: not
+                        (isinstance(child.value, Process)),
+                        f=lambda child: copy.deepcopy(child))
+                except:
+                    import ipdb; ipdb.set_trace()
                 daughter_states = self.inner[mother].divide_value()
 
                 here = self.path_for()


### PR DESCRIPTION
This PR extends the divider functionality to accept a `config` argument in addition to `topology`. This allows the divider to be configured, for example with a specific value to reset to.