### PR TITLE
Exception messages

### DIFF
--- a/vivarium/core/store.py
+++ b/vivarium/core/store.py
@@ -788,7 +788,10 @@ class Store:
                 f"with value {self.value} for {pformat(update)}"
             )
 
-        self.value = updater(self.value, update)
+        try:
+            self.value = updater(self.value, update)
+        except ValueError:
+            print(f'failed update at path {self.path_for}, for received update {update}')
 
         return EMPTY_UPDATES
 

--- a/vivarium/core/store.py
+++ b/vivarium/core/store.py
@@ -782,16 +782,18 @@ class Store:
             if '_updater' in update:
                 update = update.get('_value', self.default)
 
-        if updater is None:
-            raise Exception(
-                f"updater is absent at path {self.path_for()} "
-                f"with value {self.value} for {pformat(update)}"
-            )
-
         try:
             self.value = updater(self.value, update)
-        except ValueError:
-            print(f'failed update at path {self.path_for}, for received update {update}')
+        except:
+            # provide error messages
+            if updater is None:
+                raise Exception(
+                    f"updater is absent at path {self.path_for()} "
+                    f"with value {self.value} for update {pformat(update)}")
+            else:
+                raise Exception(
+                    f"failed update at path {self.path_for} "
+                    f"with value {self.value} for update {pformat(update)}")
 
         return EMPTY_UPDATES
 


### PR DESCRIPTION
Vivarium-core needs to provide more warning and exception messages when expectations are not met. Users should not have to use a debugger within this library, and ideally all of their errors will get appropriate messages to help them fix the problem.

To start, I added a ValueError when `Store's` `apply_update` fails to run the line `self.value = updater(self.value, update)`. The message provides the path at which this happens, and the update received.