### PR TITLE
Update Reference Docs

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.8]
     steps:
     - uses: actions/checkout@v2
     - name: Setup Python ${{ matrix.python-version }}

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@
 /build
 /dist
 /doc/_build
-/doc/reference/api
 /vivarium_core.egg-info
 
 *.out

--- a/.pylintrc
+++ b/.pylintrc
@@ -64,6 +64,7 @@ disable=print-statement,
         too-many-locals,
         too-many-branches,
         too-few-public-methods,
+        too-many-lines,
         no-self-use,
         fixme,
         unsupported-assignment-operation,  # Buggy with NewType objects

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -17,7 +17,6 @@ help:
 
 clean:
 	@rm -rf _build/*
-	@rm -rf $(APIDOCDIR)/*
 
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -10,6 +10,7 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
+from datetime import datetime
 import os
 import shutil
 import sys
@@ -20,15 +21,19 @@ from sphinx.addnodes import pending_xref
 from sphinx.ext import apidoc
 from sphinx.ext.intersphinx import missing_reference
 
+from setup import VERSION
+
 
 # -- Project information -----------------------------------------------------
 
 project = 'Vivarium Core'
-copyright = '2018-2020, The Vivarium Core Authors'
+copyright = '2018-{}, The Vivarium Core Authors'.format(
+    datetime.now().year)
 author = 'The Vivarium Core Authors'
 
 # The full version, including alpha/beta/rc tags
-release = 'v0.0.12'
+release = 'v{}'.format(VERSION)
+version = release
 
 
 # -- General configuration ---------------------------------------------------
@@ -64,6 +69,9 @@ nitpicky = True
 # a list of builtin themes.
 #
 html_theme = 'sphinx_rtd_theme'
+html_theme_options = {
+    'display_version': True,
+}
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
@@ -108,6 +116,10 @@ autodoc_mock_imports = [
 # Concatenate class and __init__ docstrings
 autoclass_content = 'both'
 
+def autodoc_skip_member_handler(app, what, name, obj, skip, options):
+    if name.startswith('test_'):
+        return True
+    return None
 
 # -- Custom Extensions -------------------------------------------------
 
@@ -144,16 +156,6 @@ def resolve_intersphinx_aliases(app, env, node, contnode):
     return None
 
 
-def run_apidoc(_):
-    cur_dir = os.path.abspath(os.path.dirname(__file__))
-    module = os.path.join(cur_dir, '..', 'vivarium')
-    apidoc_dir = os.path.join(cur_dir, 'reference', 'api')
-    if os.path.exists(apidoc_dir):
-        shutil.rmtree(apidoc_dir)
-    os.mkdir(apidoc_dir)
-    apidoc.main(['-f', '-e', '-o', apidoc_dir, module])
-
-
 # This function is adapted from a StackOverflow answer by Oleg Höfling
 # at https://stackoverflow.com/a/62301461. Per StackOverflow's licensing
 # terms, it is available under a CC-BY-SA 4.0 license
@@ -161,4 +163,4 @@ def run_apidoc(_):
 def setup(app):
     app.connect('doctree-read', resolve_internal_aliases)
     app.connect('missing-reference', resolve_intersphinx_aliases)
-    app.connect('builder-inited', run_apidoc)
+    app.connect('autodoc-skip-member', autodoc_skip_member_handler)

--- a/doc/guides/docs.rst
+++ b/doc/guides/docs.rst
@@ -163,7 +163,7 @@ reference. Sphinx includes docstrings in this reference as follows:
 * Tests (any members whose names start with ``test_``) are not included,
   even if they have docstrings.
 * Private members (members that start with ``_``) are not included, even
-  if they have dcostrings.
+  if they have docstrings.
 
 
 .. _building-docs:

--- a/doc/guides/docs.rst
+++ b/doc/guides/docs.rst
@@ -144,6 +144,27 @@ documentation:
   conventions. It also runs the ``proselint`` and ``write-good``
   linters, which check for generally good style.
 
+What APIs to Document
+=====================
+
+A standard convention in software development is that documented APIs
+(e.g. functions, methods, classes, and constants) are supported, so
+other users can count on them to work. Any changes to the
+inputs these APIs accept or their behavior constitutes an API change,
+and any changes that are not backward-compatible are breaking API
+changes that require a new major version release according to Semantic
+Versioning.
+
+For Vivarium, being "documented" means appearing in the compiled API
+reference. Sphinx includes docstrings in this reference as follows:
+
+* By default, everything appears in the reference, even if it doesn't
+  have a docstring.
+* Tests (any members whose names start with ``test_``) are not included,
+  even if they have docstrings.
+* Private members (members that start with ``_``) are not included, even
+  if they have dcostrings.
+
 
 .. _building-docs:
 

--- a/doc/guides/experiments.rst
+++ b/doc/guides/experiments.rst
@@ -20,7 +20,7 @@ To create an experiment, you need only instantiate the
 reproduce your experiment, create a file in the
 ``vivarium-core/experiments`` directory that defines a function that
 generates your experiment. For example, here is the function from
-:py:mod:`vivarium.experiments.glucose_phosphorylation` to create a toy
+``vivarium.experiments.glucose_phosphorylation`` to create a toy
 experiment that simulates the phosphorylation of injected glucose:
 
 .. code-block:: python

--- a/doc/guides/processes.rst
+++ b/doc/guides/processes.rst
@@ -256,7 +256,7 @@ how to use a process.
 If you are writing your own process, please include these examples!
 Also, executing the process class Python file should execute one of
 these examples and save the output as demonstrated in
-:py:mod:`vivarium.processes.glucose_phosphorylation`. Lastly, any
+``vivarium.processes.glucose_phosphorylation``. Lastly, any
 top-level functions you include that are prefixed with ``test_`` will be
 executed by ``pytest``. Please add these tests to help future developers
 make sure they haven't broken your process!

--- a/doc/reference/api/vivarium.core.composition.rst
+++ b/doc/reference/api/vivarium.core.composition.rst
@@ -1,0 +1,4 @@
+.. automodule:: vivarium.core.composition
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/doc/reference/api/vivarium.core.control.rst
+++ b/doc/reference/api/vivarium.core.control.rst
@@ -1,0 +1,4 @@
+.. automodule:: vivarium.core.control
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/doc/reference/api/vivarium.core.emitter.rst
+++ b/doc/reference/api/vivarium.core.emitter.rst
@@ -1,0 +1,4 @@
+.. automodule:: vivarium.core.emitter
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/doc/reference/api/vivarium.core.experiment.rst
+++ b/doc/reference/api/vivarium.core.experiment.rst
@@ -1,0 +1,4 @@
+.. automodule:: vivarium.core.experiment
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/doc/reference/api/vivarium.core.process.rst
+++ b/doc/reference/api/vivarium.core.process.rst
@@ -1,0 +1,4 @@
+.. automodule:: vivarium.core.process
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/doc/reference/api/vivarium.core.registry.rst
+++ b/doc/reference/api/vivarium.core.registry.rst
@@ -1,0 +1,4 @@
+.. automodule:: vivarium.core.registry
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/doc/reference/api/vivarium.core.rst
+++ b/doc/reference/api/vivarium.core.rst
@@ -1,0 +1,14 @@
+Core Vivarium Package
+=====================
+
+.. toctree::
+   :maxdepth: 4
+
+   vivarium.core.composition
+   vivarium.core.control
+   vivarium.core.emitter
+   vivarium.core.experiment
+   vivarium.core.process
+   vivarium.core.registry
+   vivarium.core.store
+   vivarium.core.types

--- a/doc/reference/api/vivarium.core.store.rst
+++ b/doc/reference/api/vivarium.core.store.rst
@@ -1,0 +1,4 @@
+.. automodule:: vivarium.core.store
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/doc/reference/api/vivarium.core.types.rst
+++ b/doc/reference/api/vivarium.core.types.rst
@@ -1,0 +1,4 @@
+.. automodule:: vivarium.core.types
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/doc/reference/api/vivarium.library.datum.rst
+++ b/doc/reference/api/vivarium.library.datum.rst
@@ -1,0 +1,4 @@
+.. automodule:: vivarium.library.datum
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/doc/reference/api/vivarium.library.pretty.rst
+++ b/doc/reference/api/vivarium.library.pretty.rst
@@ -1,0 +1,4 @@
+.. automodule:: vivarium.library.pretty
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/doc/reference/api/vivarium.library.rst
+++ b/doc/reference/api/vivarium.library.rst
@@ -1,0 +1,9 @@
+Library Package
+=================
+
+.. toctree::
+   :maxdepth: 4
+
+   vivarium.library.pretty
+   vivarium.library.topology
+   vivarium.library.datum

--- a/doc/reference/api/vivarium.library.topology.rst
+++ b/doc/reference/api/vivarium.library.topology.rst
@@ -1,0 +1,4 @@
+.. automodule:: vivarium.library.topology
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/doc/reference/api/vivarium.plots.rst
+++ b/doc/reference/api/vivarium.plots.rst
@@ -1,0 +1,7 @@
+Plotting Utilities Package
+==========================
+
+.. toctree::
+   :maxdepth: 4
+
+   vivarium.plots.simulation_output

--- a/doc/reference/api/vivarium.plots.simulation_output.rst
+++ b/doc/reference/api/vivarium.plots.simulation_output.rst
@@ -1,0 +1,4 @@
+.. automodule:: vivarium.plots.simulation_output
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/doc/reference/api/vivarium.processes.rst
+++ b/doc/reference/api/vivarium.processes.rst
@@ -1,0 +1,7 @@
+Processes Package
+=================
+
+.. toctree::
+   :maxdepth: 4
+
+   vivarium.processes.tree_mass

--- a/doc/reference/api/vivarium.processes.tree_mass.rst
+++ b/doc/reference/api/vivarium.processes.tree_mass.rst
@@ -1,0 +1,4 @@
+.. automodule:: vivarium.processes.tree_mass
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/doc/reference/api/vivarium.rst
+++ b/doc/reference/api/vivarium.rst
@@ -5,3 +5,6 @@ Vivarium
    :maxdepth: 4
 
    vivarium.core
+   vivarium.processes
+   vivarium.library
+   vivarium.plots

--- a/doc/reference/api/vivarium.rst
+++ b/doc/reference/api/vivarium.rst
@@ -1,0 +1,7 @@
+Vivarium
+========
+
+.. toctree::
+   :maxdepth: 4
+
+   vivarium.core

--- a/doc/reference/index.rst
+++ b/doc/reference/index.rst
@@ -8,7 +8,7 @@ comprehensively, try a :doc:`topic guide <../guides/index>` instead. If
 you are new to Vivarium, check out our :doc:`getting started guide
 <../getting_started>`.
 
-The :doc:`API Reference <api/modules>` is a representation of the
+The :doc:`API Reference <api/vivarium>` is a representation of the
 docstrings from Vivarium's code. This is a great place to look up
 details on how to use one of our classes or functions.
 
@@ -18,5 +18,5 @@ to Vivarium.
 .. toctree::
    :maxdepth: 2
 
-   API Reference <api/modules>
+   API Reference <api/vivarium>
    glossary

--- a/doc/vale/styles/vocab.txt
+++ b/doc/vale/styles/vocab.txt
@@ -11,6 +11,7 @@ multiscale
 discretize
 pseudocode
 docstrings
+docstring
 fg
 hexokinase
 adenosine

--- a/setup.py
+++ b/setup.py
@@ -4,71 +4,75 @@ from distutils.core import setup
 
 _ = setuptools  # don't warn about this unused import; it might have side effects
 
-with open("README.md", 'r') as readme:
-    description = readme.read()
-    # Patch the relative links to absolute URLs that will work on PyPI.
-    description2 = re.sub(
-        r']\(([\w/.-]+\.png)\)',
-        r'](https://github.com/vivarium-collective/vivarium-core/raw/master/\1)',
-        description)
-    long_description = re.sub(
-        r']\(([\w/.-]+)\)',
-        r'](https://github.com/vivarium-collective/vivarium-core/blob/master/\1)',
-        description2)
+
+VERSION = '0.2.13'
 
 
-setup(
-    name='vivarium-core',
-    version='0.2.13',
-    packages=[
-        'vivarium',
-        'vivarium.core',
-        'vivarium.processes',
-        'vivarium.composites',
-        'vivarium.experiments',
-        'vivarium.library',
-        'vivarium.plots'
-    ],
-    author='Eran Agmon, Ryan Spangler',
-    author_email='eagmon@stanford.edu, ryan.spangler@gmail.com',
-    url='https://github.com/vivarium-collective/vivarium-core',
-    project_urls={
-        'Source': 'https://github.com/vivarium-collective/vivarium-core',
-        'Documentation': 'https://vivarium-core.readthedocs.io/en/latest/',
-        'Changelog': 'https://github.com/vivarium-collective/vivarium-core/blob/master/CHANGELOG.md',
-    },
-    license='MIT',
-    entry_points={
-        'console_scripts': []},
-    description=(
-        'Engine for composing and simulating computational biology '
-        'models with the Vivarium interface.'
-    ),
-    long_description=long_description,
-    long_description_content_type='text/markdown',
-    package_data={},
-    include_package_data=True,
-    python_requires='>=3.6, <4',
-    install_requires=[
-        'matplotlib',
-        'networkx',
-        'numpy',
-        'Pint',
-        'pymongo',
-        'scipy',
-    ],
-    classifiers=[
-        'Development Status :: 4 - Beta',
-        'Intended Audience :: Developers',
-        'Intended Audience :: Education',
-        'Intended Audience :: Science/Research',
-        'License :: OSI Approved :: MIT License',
-        'Operating System :: OS Independent',
-        'Programming Language :: Python',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.8',
-        'Programming Language :: Python :: 3.9',
-        'Topic :: Scientific/Engineering',
-    ],
-    keywords='vivarium multi-scale computational-biology biology simulation framework',
-)
+if __name__ == '__main__':
+    with open("README.md", 'r') as readme:
+        description = readme.read()
+        # Patch the relative links to absolute URLs that will work on PyPI.
+        description2 = re.sub(
+            r']\(([\w/.-]+\.png)\)',
+            r'](https://github.com/vivarium-collective/vivarium-core/raw/master/\1)',
+            description)
+        long_description = re.sub(
+            r']\(([\w/.-]+)\)',
+            r'](https://github.com/vivarium-collective/vivarium-core/blob/master/\1)',
+            description2)
+
+    setup(
+        name='vivarium-core',
+        version=VERSION,
+        packages=[
+            'vivarium',
+            'vivarium.core',
+            'vivarium.processes',
+            'vivarium.composites',
+            'vivarium.experiments',
+            'vivarium.library',
+            'vivarium.plots'
+        ],
+        author='Eran Agmon, Ryan Spangler',
+        author_email='eagmon@stanford.edu, ryan.spangler@gmail.com',
+        url='https://github.com/vivarium-collective/vivarium-core',
+        project_urls={
+            'Source': 'https://github.com/vivarium-collective/vivarium-core',
+            'Documentation': 'https://vivarium-core.readthedocs.io/en/latest/',
+            'Changelog': 'https://github.com/vivarium-collective/vivarium-core/blob/master/CHANGELOG.md',
+        },
+        license='MIT',
+        entry_points={
+            'console_scripts': []},
+        description=(
+            'Engine for composing and simulating computational biology '
+            'models with the Vivarium interface.'
+        ),
+        long_description=long_description,
+        long_description_content_type='text/markdown',
+        package_data={},
+        include_package_data=True,
+        python_requires='>=3.6, <4',
+        install_requires=[
+            'matplotlib',
+            'networkx',
+            'numpy',
+            'Pint',
+            'pymongo',
+            'scipy',
+        ],
+        classifiers=[
+            'Development Status :: 4 - Beta',
+            'Intended Audience :: Developers',
+            'Intended Audience :: Education',
+            'Intended Audience :: Science/Research',
+            'License :: OSI Approved :: MIT License',
+            'Operating System :: OS Independent',
+            'Programming Language :: Python',
+            'Programming Language :: Python :: 3',
+            'Programming Language :: Python :: 3.8',
+            'Programming Language :: Python :: 3.9',
+            'Topic :: Scientific/Engineering',
+        ],
+        keywords='vivarium multi-scale computational-biology biology simulation framework',
+    )

--- a/vivarium/core/composition.py
+++ b/vivarium/core/composition.py
@@ -3,7 +3,7 @@
 Composition
 ===========
 
-Helper function for initializing and running experiments.
+Helper functions for initializing and running experiments.
 """
 
 import os
@@ -182,11 +182,11 @@ def add_timeline(
 ) -> None:
     """Add a timeline process to a composite
 
-        Args:
-            processes (dict): with {`process_name`: Process}
-            topology (dict): with {`process_name`: topology mapping}
-            timeline (dict): with `timeline` key. An optional `paths` key
-                overrides the topology mapping from (port: path).
+    Args:
+        processes: with ``{'process_name': Process}``
+        topology (dict): with ``{'process_name': topology mapping}``
+        timeline (dict): with ``timeline`` key. An optional ``paths``
+            key overrides the topology mapping from (port: path).
     """
     timeline_paths = timeline.get('paths', {})
     timeline_process = TimelineProcess(timeline)
@@ -207,11 +207,11 @@ def add_environment(
 ) -> None:
     """Add a NonSpatialEnvironment to a composite
 
-        Args:
-            processes (dict): with {`process_name`: Process}
-            topology (dict): with {`process_name`: topology mapping}
-            environment (dict): with `environment` key. An optional `paths` key
-                overrides the topology mapping from (port: path).
+    Args:
+        processes: with ``{'process_name': Process}``
+        topology: with ``{'process_name': topology mapping}``
+        environment: with ``environment`` key. An optional ``paths`` key
+            overrides the topology mapping from (port: path).
     """
 
     overide_topology = environment.get('paths', {})
@@ -234,17 +234,17 @@ def process_in_experiment(
         settings: Dict[str, Any] = None,
         initial_state: Dict[str, Any] = None,
 ) -> Experiment:
-    """put a Process in an Experiment
+    """Put a Process in an Experiment
 
     Args:
-        process (Process): the Process to put into the Experiment
-        settings (dict): a dictionary of optional configuration options,
+        process: the Process to put into the Experiment
+        settings: a dictionary of optional configuration options,
             keywords include timeline, environment, and topology that
             add to or modify the Process.
-        initial_state (dict): initial state to overrides the defaults.
+        initial_state: initial state to overrides the defaults.
 
     Returns:
-        an **Experiment**
+        an :term:`Experiment`.
     """
     settings = settings or {}
     initial_state = initial_state or {}
@@ -272,17 +272,17 @@ def composite_in_experiment(
         settings: Dict[str, Any] = None,
         initial_state: Dict[str, Any] = None,
 ) -> Experiment:
-    """put a Composite in an Experiment
+    """Put a Composite in an Experiment
 
     Args:
         composite: the :term:`Composite` object.
-        settings (dict): a dictionary of options, including composite_config
+        settings: a dictionary of options, including composite_config
             for configuring the composite. Additional  keywords include
             timeline, environment, and outer_path.
-        initial_state (dict): initial state to overrides the defaults.
+        initial_state: initial state to overrides the defaults.
 
     Returns:
-        an :term:`Experiment`
+        an :term:`Experiment`.
     """
     settings = settings or {}
     initial_state = initial_state or {}
@@ -318,14 +318,14 @@ def composer_in_experiment(
         config: Dict[str, Any] = None,
         outer_path: HierarchyPath = (),
 ) -> Experiment:
-    """generate a Composite in an Experiment
+    """Generate a Composite in an Experiment
 
     Args:
         composer: a :term:`Composer` object.
-        settings (dict): a dictionary of options, including composite_config
+        settings: a dictionary of options, including composite_config
             for configuring the composite. Additional  keywords include
             timeline, environment, and outer_path.
-        initial_state (dict): initial state to overrides the defaults.
+        initial_state: initial state to overrides the defaults.
         config: updates values in composer's config
         outer_path: path to the processes and topology
 
@@ -384,14 +384,14 @@ def simulate_experiment(
         experiment: Experiment,
         settings: Optional[Dict[str, Any]] = None
 ) -> Dict:
-    """Simulate an term:`Experiment`
+    """Simulate an :term:`Experiment`.
 
-        Args:
-        - a configured experiment
+    Args:
+        experiment: a configured experiment
 
-        Returns:
-            - a timeseries of variables from all ports.
-            - if 'return_raw_data' is True, it returns the raw data instead
+    Returns:
+        A timeseries of variables from all ports. If ``return_raw_data``
+        is True, return the raw data instead.
     """
     settings = settings or {}
     total_time = settings.get('total_time', 10)

--- a/vivarium/core/experiment.py
+++ b/vivarium/core/experiment.py
@@ -11,8 +11,6 @@ import os
 import logging as log
 import warnings
 import pprint
-import multiprocessing
-from multiprocessing import pool as multipool
 from typing import (
     Any, Dict, Optional, Union, Tuple, Callable)
 import math

--- a/vivarium/core/experiment.py
+++ b/vivarium/core/experiment.py
@@ -42,10 +42,12 @@ pretty = pprint.PrettyPrinter(indent=2)
 
 
 def pp(x: Any) -> None:
+    """Print ``x`` in a pretty format."""
     pretty.pprint(x)
 
 
 def pf(x: Any) -> str:
+    """Format ``x`` for display."""
     return pretty.pformat(x)
 
 
@@ -56,6 +58,15 @@ def starts_with(
         a_list: HierarchyPath,
         sub: HierarchyPath,
 ) -> bool:
+    """Check whether one path is a prefix of another.
+
+    Args:
+        a_list: Path to look for prefix in.
+        sub: Prefix.
+
+    Returns:
+        True if ``sub`` is a prefix of ``a_list``; False otherwise.
+    """
     return len(sub) <= len(a_list) and all(
         a_list[i] == el
         for i, el in enumerate(sub))
@@ -65,11 +76,36 @@ def invert_topology(
         update: Update,
         args: Tuple[HierarchyPath, Topology],
 ) -> State:
+    """Wrapper function around ``inverse_topology``.
+
+    Wraps :py:func:`vivarium.library.topology.inverse_topology`.
+
+    Updates are produced relative to the process that produced them. To
+    transform them such that they are relative to the root of the
+    simulation hierarchy, this function "inverts" a topology.
+
+    Args:
+        update: The update.
+        args: Tuple of the path to which the update is relative and the
+            topology.
+
+    Returns:
+        The update, relative to the root of ``path``.
+    """
     path, topology = args
     return inverse_topology(path[:-1], update, topology)
 
 
 def timestamp(dt: Optional[Any] = None) -> str:
+    """Get a timestamp of the form ``YYYYMMDD.HHMMSS``.
+
+    Args:
+        dt: Datetime object to generate timestamp from. If not
+            specified, the current time will be used.
+
+    Returns:
+        Timestamp.
+    """
     if not dt:
         dt = datetime.datetime.now()
     return "%04d%02d%02d.%02d%02d%02d" % (
@@ -82,6 +118,12 @@ def invoke_process(
         interval: float,
         states: State,
 ) -> Update:
+    """Compute a process's next update.
+
+    Call the process's
+    :py:meth:`vivarium.core.process.Process.next_update` function with
+    ``interval`` and ``states``.
+    """
     return process.next_update(interval, states)
 
 
@@ -92,11 +134,32 @@ class Defer:
             f: Callable,
             args: Tuple,
     ) -> None:
+        """Allows for delayed application of a function to an update.
+
+        The object simply holds the provided arguments until it's time
+        for the computation to be performed. Then, the function is
+        called.
+
+        Args:
+            defer: An object with a ``.get()`` method whose output will
+                be passed to the function. For example, the object could
+                be an :py:class:`InvokeProcess` object whose ``.get()``
+                method will return the process update.
+            function: The function. For example,
+                :py:func:`invert_topology` to transform the returned
+                update.
+            args: Passed as the second argument to the function.
+        """
         self.defer = defer
         self.f = f
         self.args = args
 
     def get(self) -> Update:
+        """Perform the deferred computation.
+
+        Returns:
+            The result of calling the function.
+        """
         return self.f(
             self.defer.get(),
             self.args)
@@ -109,6 +172,18 @@ class InvokeProcess:
             interval: float,
             states: State,
     ) -> None:
+        """A wrapper object that computes an update.
+
+        This class holds the update of a process that is not running in
+        parallel. When instantiated, it immediately computes the
+        process's next update.
+
+        Args:
+            process: The process that will calculate the update.
+            interval: The timestep for the update.
+            states: The simulation state to pass to the process's
+                ``next_update`` function.
+        """
         self.process = process
         self.interval = interval
         self.states = states
@@ -118,25 +193,14 @@ class InvokeProcess:
             self.states)
 
     def get(self) -> Update:
+        """Return the computed update.
+
+        This method is analogous to the ``.get()`` method in
+        :py:class:`vivarium.core.process.ParallelProcess` so that
+        parallel and non-parallel updates can be intermixed in the
+        simulation engine.
+        """
         return self.update
-
-
-class MultiInvoke:
-    def __init__(
-            self,
-            pool: multipool.Pool
-    ) -> None:
-        self.pool = pool
-
-    def invoke(
-            self,
-            process: Process,
-            interval: float,
-            states: State,
-    ) -> Any:
-        args = (process, interval, states)
-        result = self.pool.apply_async(invoke_process, args)
-        return result
 
 
 class Experiment:
@@ -203,7 +267,7 @@ class Experiment:
         # get a mapping of all paths to processes
         self.process_paths: Dict[HierarchyPath, Process] = {}
         self.deriver_paths: Dict[HierarchyPath, Process] = {}
-        self.find_process_paths(self.processes)
+        self._find_process_paths(self.processes)
 
         # initialize the state
         self.state = generate_state(
@@ -244,7 +308,7 @@ class Experiment:
         # log.info('\nCONFIG:')
         # log.info(pf(self.state.get_config(True)))
 
-    def add_process_path(
+    def _add_process_path(
             self,
             process: Process,
             path: HierarchyPath
@@ -254,15 +318,16 @@ class Experiment:
         else:
             self.process_paths[path] = process
 
-    def find_process_paths(
+    def _find_process_paths(
             self,
             processes: Processes
     ) -> None:
         tree = hierarchy_depth(processes)
         for path, process in tree.items():
-            self.add_process_path(process, path)
+            self._add_process_path(process, path)
 
     def emit_configuration(self) -> None:
+        """Emit configuration information to the emitter."""
         data: Dict[str, Any] = {
             'time_created': self.time_created,
             'experiment_id': self.experiment_id,
@@ -287,13 +352,32 @@ class Experiment:
                 emit_config['data']['processes'][process_id] = None
             self.emitter.emit(emit_config)
 
-    def invoke_process(
+    def _invoke_process(
             self,
             process: Process,
             path: HierarchyPath,
             interval: float,
             states: State,
     ) -> Any:
+        """Trigger computation of a process's update.
+
+        To allow processes to run in parallel, this function only
+        triggers update computation. When the function exits,
+        computation may not be complete.
+
+        Args:
+            process: The process.
+            path: The path at which the process resides. This is used to
+                track parallel processes in ``self.parallel``.
+            interval: The timestep for which to compute the update.
+            states: The simulation state to pass to
+                :py:meth:`vivarium.core.process.Process.next_update`.
+
+        Returns:
+            The deferred simulation update, for example a
+            :py:class:`vivarium.core.process.ParallelProcess` or an
+            :py:class:`InvokeProcess` object.
+        """
         if process.parallel:
             # add parallel process if it doesn't exist
             if path not in self.parallel:
@@ -305,7 +389,7 @@ class Experiment:
         # if not parallel, perform a normal invocation
         return self.invoke(process, interval, states)
 
-    def process_update(
+    def _process_update(
             self,
             path: HierarchyPath,
             process: Process,
@@ -313,8 +397,28 @@ class Experiment:
             states: State,
             interval: float,
     ) -> Tuple[Defer, Store]:
+        """Start generating a process's update.
 
-        update = self.invoke_process(
+        This function is similar to :py:meth:`_invoke_process` except in
+        addition to triggering the computation of the process's update
+        (by calling ``_invoke_process``), it also generates a
+        :py:class:`Defer` object to transform the update into absolute
+        terms.
+
+        Args:
+            path: Path to process.
+            process: The process.
+            store: The store at ``path``.
+            states: Simulation state to pass to process's
+                ``next_update`` method.
+            interval: Timestep for which to compute the update.
+
+        Returns:
+            Tuple of the deferred update (in absolute terms) and
+            ``store``.
+        """
+
+        update = self._invoke_process(
             process,
             path,
             interval,
@@ -332,6 +436,19 @@ class Experiment:
             path: HierarchyPath,
             process: Process,
     ) -> Tuple[Store, State]:
+        """Get the simulation state for a process's ``next_update``.
+
+        Before computing an update, we have to collect the simulation
+        variables the processes expects.
+
+        Args:
+            path: Path to the process.
+            process: The process.
+
+        Returns:
+            Tuple of the store at ``path`` and a collection of state
+            variables in the form the process expects.
+        """
         store = self.state.get_path(path)
 
         # translate the values from the tree structure into the form
@@ -346,8 +463,19 @@ class Experiment:
             process: Process,
             interval: float
     ) -> Tuple[Defer, Store]:
+        """Calculate a process's update.
+
+        Args:
+            path: Path to process.
+            process: The process.
+            interval: Timestep to compute update for.
+
+        Returns:
+            Tuple of the deferred update (relative to the root of
+            ``path``) and the store at ``path``.
+        """
         store, states = self.process_state(path, process)
-        return self.process_update(
+        return self._process_update(
             path, process, store, states, interval)
 
     def apply_update(
@@ -355,6 +483,14 @@ class Experiment:
             update: Update,
             state: Store
     ) -> None:
+        """Apply an update to the simulation state.
+
+        Args:
+            update: The update to apply. Must be relative to ``state``.
+            state: The store to which the update is relative (usually
+                root of simulation state. We need this so to preserve
+                the "perspective" from which the update was generated.
+        """
         topology_updates, process_updates, deletions = self.state.apply_update(
             update, state)
 
@@ -365,7 +501,7 @@ class Experiment:
         if process_updates:
             for path, process in process_updates:
                 assoc_path(self.processes, path, process)
-                self.add_process_path(process, path)
+                self._add_process_path(process, path)
 
         if deletions:
             for deletion in deletions:
@@ -375,6 +511,11 @@ class Experiment:
             self,
             deletion: HierarchyPath
     ) -> None:
+        """Delete a store from the state.
+
+        Args:
+            deletion: Path to store to delete.
+        """
         delete_in(self.processes, deletion)
         delete_in(self.topology, deletion)
 
@@ -387,6 +528,7 @@ class Experiment:
                 del self.deriver_paths[path]
 
     def run_derivers(self) -> None:
+        """Run all the derivers in the simulation."""
         paths = list(self.deriver_paths.keys())
         for path in paths:
             # deriver could have been deleted by another deriver
@@ -402,6 +544,10 @@ class Experiment:
                 self.apply_update(update.get(), store)
 
     def emit_data(self) -> None:
+        """Emit the current simulation state.
+
+        Only variables with ``_emit=True`` are emitted.
+        """
         data = self.state.emit_data()
         data.update({
             'time': self.experiment_time})
@@ -414,6 +560,13 @@ class Experiment:
             self,
             update_tuples: list
     ) -> None:
+        """Apply updates and run derivers.
+
+        Args:
+            update_tuples: List of tuples ``(update, state)`` where
+                ``state`` is the store from whose perspective the update
+                was generated.
+        """
         for update_tuple in update_tuples:
             update, state = update_tuple
             self.apply_update(update.get(), state)
@@ -424,7 +577,7 @@ class Experiment:
             self,
             interval: float
     ) -> None:
-        """ Run each process for the given interval and update the states.
+        """Run each process for the given interval and update the states.
         """
 
         time = 0.0
@@ -477,7 +630,7 @@ class Experiment:
                     #    Type Process doesn't have expected attribute 'schema'
                     # TODO(chris): Is there any reason to generate a process's
                     #  schema dynamically like this?
-                    update = self.process_update(
+                    update = self._process_update(
                         path, process, store, states, process_timestep)
 
                     # store the update to apply at its projected time
@@ -541,10 +694,16 @@ class Experiment:
             self.print_summary(clock_finish)
 
     def end(self) -> None:
+        """Terminate all processes running in parallel.
+
+        This MUST be called at the end of any simulation with parallel
+        processes.
+        """
         for parallel in self.parallel.values():
             parallel.end()
 
     def print_display(self) -> None:
+        """Print simulation metadata."""
         date, time = self.time_created.split('.')
         print('\nExperiment ID: {}'.format(self.experiment_id))
         print('Created: {} at {}'.format(
@@ -559,6 +718,7 @@ class Experiment:
             self,
             clock_finish: float
     ) -> None:
+        """Print summary of simulation runtime."""
         if clock_finish < 1:
             print('Completed in {:.6f} seconds'.format(clock_finish))
         else:
@@ -571,13 +731,13 @@ def print_progress_bar(
         decimals: float = 1,
         length: int = 50,
 ) -> None:
-    """ Call in a loop to create terminal progress bar
+    """Call in a loop to create terminal progress bar
 
-    Arguments:
-        iteration: (Required) current iteration
-        total:     (Required) total iterations
-        decimals:  (Optional) positive number of decimals in percent complete
-        length:    (Optional) character length of bar
+    Args:
+        iteration: Current iteration
+        total: Total iterations
+        decimals: Positive number of decimals in percent complete
+        length: Character length of bar
     """
     progress: str = ("{0:." + str(decimals) + "f}").format(total - iteration)
     filled_length: int = int(length * iteration // total)
@@ -590,7 +750,7 @@ def print_progress_bar(
         print()
 
 
-def make_proton(
+def _make_proton(
         parallel: bool = False
 ) -> Dict[str, Any]:
     processes = {
@@ -727,7 +887,7 @@ def test_recursive_store() -> None:
 
 
 def test_topology_ports() -> None:
-    proton = make_proton()
+    proton = _make_proton()
 
     experiment = Experiment(proton)
 
@@ -962,22 +1122,8 @@ def test_complex_topology() -> None:
     assert agent_state['ccc']['a3'] == initial_agent_state['ccc']['a3'] + 1
 
 
-def test_multi() -> None:
-    with multiprocessing.Pool(processes=4) as pool:
-        multi = MultiInvoke(pool)
-        proton = make_proton()
-        experiment = Experiment({**proton, 'invoke': multi.invoke})
-
-        log.debug(pf(experiment.state.get_config(True)))
-
-        experiment.update(10.0)
-
-        log.debug(pf(experiment.state.get_config(True)))
-        log.debug(pf(experiment.state.divide_value()))
-
-
 def test_parallel() -> None:
-    proton = make_proton(parallel=True)
+    proton = _make_proton(parallel=True)
     experiment = Experiment(proton)
 
     log.debug(pf(experiment.state.get_config(True)))

--- a/vivarium/core/process.py
+++ b/vivarium/core/process.py
@@ -490,7 +490,16 @@ class MetaComposer(Composer):
             self,
             composers: Iterable[Any] = tuple(),
             config: Optional[dict] = None,
-    ) -> None:
+            ) -> None:
+        """A collection of :py:class:`Composer` objects.
+
+        The MetaComposer can be used to create composites that combine
+        all the composers in the collection.
+
+        Args:
+            composers: Initial collection of composers.
+            config: Initial configuration.
+        """
         super().__init__(config)
         self.composers: List = list(composers)
 
@@ -498,6 +507,7 @@ class MetaComposer(Composer):
             self,
             config: Optional[dict] = None
     ) -> Dict[str, Any]:
+        """Do not override this method."""
         # TODO(Eran)-- override composite.config with config
         processes: Dict = {}
         for composer in self.composers:
@@ -513,6 +523,7 @@ class MetaComposer(Composer):
             self,
             config: Optional[dict] = None
     ) -> Topology:
+        """Do not override this method."""
         topology: Topology = {}
         for composer in self.composers:
             new_topology = composer.generate_topology(composer.config)
@@ -528,6 +539,13 @@ class MetaComposer(Composer):
             composer: Composer,
             config: Optional[Dict] = None,
     ) -> None:
+        """Add a composer to the collection of stored composers.
+
+        Args:
+            composer: The composer to add.
+            config: The composer's configuration, which will be merged
+                with the stored config.
+        """
         if config:
             self.config.update(config)
         self.composers.append(composer)
@@ -537,6 +555,13 @@ class MetaComposer(Composer):
             composers: List,
             config: Optional[Dict] = None,
     ) -> None:
+        """Add multiple composers to the collection of stored composers.
+
+        Args:
+            composers: The composers to add.
+            config: Configuration for the composers, which will be
+                merged with the stored config.
+        """
         if config:
             self.config.update(config)
         self.composers.extend(composers)
@@ -582,11 +607,13 @@ class Process(Composer, metaclass=abc.ABCMeta):
 
     def generate_processes(
             self, config: Optional[dict] = None) -> Dict[str, Any]:
+        """Do not override this method."""
         config = config or {}
         name = config.get('name', self.name)
         return {name: self}
 
     def generate_topology(self, config: Optional[dict] = None) -> Topology:
+        """Do not override this method."""
         config = config or {}
         name = config.get('name', self.name)
         override_topology = config.get('topology', {})
@@ -731,6 +758,11 @@ class Process(Composer, metaclass=abc.ABCMeta):
 class Deriver(Process, metaclass=abc.ABCMeta):
     """Base class for :term:`derivers`."""
     def initial_state(self, config: Optional[dict] = None) -> State:
+        """Subclasses should override this method.
+
+        Given a config, this method should return the Deriver's initial
+        state.
+        """
         return {}
 
     def is_deriver(self) -> bool:

--- a/vivarium/core/registry.py
+++ b/vivarium/core/registry.py
@@ -69,9 +69,16 @@ from vivarium.library.units import Quantity, units
 
 class Registry(object):
     def __init__(self):
+        """A Registry holds a collection of functions or objects."""
         self.registry = {}
 
     def register(self, key, item):
+        """Add an item to the registry.
+
+        Args:
+            key: Item key.
+            item: The item to add.
+        """
         if key in self.registry:
             if item != self.registry[key]:
                 raise Exception('registry already contains an entry for {}: {} --> {}'.format(
@@ -80,6 +87,7 @@ class Registry(object):
             self.registry[key] = item
 
     def access(self, key):
+        """Get an item by key from the registry."""
         return self.registry.get(key)
 
 
@@ -255,23 +263,53 @@ def assert_no_divide(state):
 
 # Serializers
 class Serializer(object):
+    """Base serializer class."""
     def serialize(self, data):
+        """Serialize some data.
+
+        Subclasses should override this function, which currently
+        returns the data unaltered.
+
+        Args:
+            data: Data to serialize.
+
+        Returns:
+            The serialized data.
+        """
         return data
 
     def deserialize(self, data):
+        """Deserialize some data.
+
+        Subclasses should override this function, which currently
+        returns the data unaltered.
+
+        Args:
+            data: Serialized data to deserialize.
+
+        Returns:
+            The deserialized data.
+        """
         return data
 
 
 class NumpySerializer(Serializer):
+    """Serializer for Numpy arrays."""
+
     def serialize(self, data):
+        """Returns ``data.tolist()``."""
         return data.tolist()
 
     def deserialize(self, data):
+        """Passes ``data`` to ``np.array``."""
         return np.array(data)
 
 
 class NumpyScalarSerializer(Serializer):
+    """Serializer for Numpy scalars."""
+
     def serialize(self, data):
+        """Convert scalar to :py:class:`int` or :py:class:`float`."""
         if isinstance(data, (int, np.integer)):
             return int(data)
         if isinstance(data, (float, np.floating)):
@@ -283,6 +321,7 @@ class NumpyScalarSerializer(Serializer):
         )
 
     def deserialize(self, data):
+        """Convert to ``np.int64`` or ``np.float64``."""
         if isinstance(data, int):
             return np.int64(data)
         if isinstance(data, float):
@@ -295,7 +334,22 @@ class NumpyScalarSerializer(Serializer):
 
 
 class UnitsSerializer(Serializer):
+    """Serializer for data with units."""
+
     def serialize(self, data, unit=None):
+        """Serialize data with units into a human-readable string.
+
+        Args:
+            data: The data to serialize. Should be a Pint object or a
+                list of such objects.
+            unit: The units to convert ``data`` to before serializing.
+                Optional. If omitted, no conversion occurs.
+
+        Returns:
+            The string representation of ``data`` if ``data`` is a
+            single Pint object. Otherwise, a list of string
+            representations.
+        """
         if isinstance(data, list):
             if unit is not None:
                 data = [d.to(unit) for d in data]
@@ -306,6 +360,17 @@ class UnitsSerializer(Serializer):
             return str(data)
 
     def deserialize(self, data, unit=None):
+        """Deserialize data with units from a human-readable string.
+
+        Args:
+            data: The data to deserialize.
+            unit: The units to convert ``data`` to after deserializing.
+                If omitted, no conversion occurs.
+
+        Returns:
+            A single deserialized object or, if ``data`` is a list, a
+            list of deserialized objects.
+        """
         if isinstance(data, list):
             unit_data = [units(d) for d in data]
             if unit is not None:
@@ -318,15 +383,35 @@ class UnitsSerializer(Serializer):
 
 
 class ProcessSerializer(Serializer):
+    """Serializer for processes.
+
+    Currently only supports serialization (for emtting simulation
+    configs).
+    """
     def serialize(self, data):
+        """Create a dictionary of process name and parameters."""
         return dict(data.parameters, _name=data.name)
 
 
 class ComposerSerializer(Serializer):
+    """Serializer for composers.
+
+    Currently only supports serialization (for emtting simulation
+    configs).
+    """
+
     def serialize(self, data):
+        """Create a dictionary of composer name and parameters."""
         return dict(data.config, _name=str(type(data)))
 
 
 class FunctionSerializer(Serializer):
+    """Serializer for functions.
+
+    Currently only supports serialization (for emtting simulation
+    configs).
+    """
+
     def serialize(self, data):
+        """Call ``data.__str__()``."""
         return str(data)

--- a/vivarium/core/store.py
+++ b/vivarium/core/store.py
@@ -27,6 +27,17 @@ def generate_state(
         topology: Topology,
         initial_state: State,
 ) -> 'Store':
+    """Initialize a simulation's state.
+
+    Args:
+        processes: Simulation processes.
+        topology: Topology linking process ports to stores.
+        initial_state: Initial simulation state. Omitted variables will
+            be assigned values based on schema defaults.
+
+    Returns:
+        Initialized state.
+    """
     store = Store({})
     store.generate_paths(processes, topology)
     store.apply_subschemas()
@@ -37,6 +48,17 @@ def generate_state(
 
 
 def key_for_value(d, looking):
+    """Get the key associated with a value in a dictionary.
+
+    Only top-level keys are searched.
+
+    Args:
+        d: The dictionary.
+        looking: The value to look for.
+
+    Returns:
+        The associated key, or None if no key found.
+    """
     found = None
     for key, value in d.items():
         if looking == value:
@@ -63,11 +85,11 @@ def hierarchy_depth(hierarchy, path=()):
     return base
 
 
-def always_true(_):
+def _always_true(_):
     return True
 
 
-def identity(y):
+def _identity(y):
     return y
 
 
@@ -125,6 +147,14 @@ class Store:
         self.apply_config(config, source)
 
     def check_default(self, new_default):
+        """Check a new default value.
+
+        Compare a new default value to the existing default. If they
+        conflict, decide which to rely on and log a warning.
+
+        Returns:
+            The new default value.
+        """
         defaults_equal = False
         if self.default is not None:
             self_default_comp = self.default
@@ -151,6 +181,18 @@ class Store:
         return new_default
 
     def check_value(self, new_value):
+        """Check a new schema value.
+
+        Args:
+            new_value: The new value.
+
+        Returns:
+            The new value.
+
+        Raises:
+            Exception: If the store already has a value and the new
+                value is different from the existing one.
+        """
         if self.value is not None and new_value != self.value:
             raise Exception(
                 '_value schema conflict: {} and {}'.format(
@@ -158,9 +200,11 @@ class Store:
         return new_value
 
     def merge_subtopology(self, subtopology):
+        """Merge a new subtopology with the store's existing one."""
         self.subtopology = deep_merge(self.subtopology, subtopology)
 
     def apply_subschema_config(self, subschema):
+        """Merge a new subschema config with the current subschema."""
         self.subschema = deep_merge(
             self.subschema,
             subschema)
@@ -297,6 +341,16 @@ class Store:
                     self.inner[key].apply_config(child, source=source)
 
     def get_updater(self, update):
+        """Get the updater to use for an update applied to this store.
+
+        Args:
+            update: The update.
+
+        Returns:
+            If available, the updater specified in the update. If no
+            such updater is specified, return this store's default
+            updater. If necessary, retrieves updater from the registry.
+        """
         updater = self.updater
         if isinstance(update, dict) and '_updater' in update:
             updater = update['_updater']
@@ -372,10 +426,10 @@ class Store:
 
         if self.inner:
             if condition is None:
-                condition = always_true
+                condition = _always_true
 
             if f is None:
-                f = identity
+                f = _identity
 
             return {
                 key: f(child.get_value(condition, f))
@@ -405,16 +459,35 @@ class Store:
         return self
 
     def get_paths(self, paths):
+        """Get the nodes at each of the specified paths.
+
+        Args:
+            paths: Map from keys to paths.
+
+        Returns:
+            A dictionary with the same keys as ``paths``. Each key is
+            mapped to the Store object at the associated path.
+        """
         return {
             key: self.get_path(path)
             for key, path in paths.items()}
 
     def get_values(self, paths):
+        """Get the values at each of the provided paths.
+
+        Args:
+            paths: Map from keys to paths.
+
+        Returns:
+            A dictionary with the same keys as ``paths``. Each key is
+            mapped to the value at the associated path.
+        """
         return {
             key: self.get_in(path)
             for key, path in paths.items()}
 
     def get_in(self, path):
+        """Get the value at ``path`` relative to this store."""
         return self.get_path(path).get_value()
 
     def get_template(self, template):
@@ -433,6 +506,14 @@ class Store:
         return state
 
     def emit_data(self):
+        """Emit the value at this Store.
+
+        Obeys the schema (namely emits only if ``_emit`` is true). Also
+        applies serializers and converts units as necessary.
+
+        Returns:
+            The value to emit, or None if nothing should be emitted.
+        """
         data = {}
         if self.inner:
             for key, child in self.inner.items():
@@ -901,6 +982,7 @@ class Store:
         return base
 
     def apply_subschema_path(self, path):
+        """Apply ``self.subschema`` at ``path``."""
         if path:
             inner = self.inner[path[0]]
             if self.subschema:
@@ -1076,6 +1158,15 @@ class Store:
                         source=source)
 
     def generate_paths(self, processes, topology):
+        """Set up state hierarchy with stores.
+
+        Recursively creates the entire state hierarchy rooted at
+        ``self``.
+
+        Args:
+            processes: Map from process names to process objects.
+            topology: The topology.
+        """
         for key, subprocess in processes.items():
             subtopology = topology[key]
             if isinstance(subprocess, Process):

--- a/vivarium/library/datum.py
+++ b/vivarium/library/datum.py
@@ -1,14 +1,10 @@
+'''
+=====
+Datum
+=====
+'''
+
 from typing import Any, Callable, Dict, List
-
-
-def first(a_list: List):
-    if a_list:
-        return a_list[0]
-
-
-def first_value(d: Dict):
-    if d:
-        return d[list(d.keys())[0]]  # TODO(jerry): iter(d.values()).__next__() would be faster
 
 
 class Datum(dict):
@@ -46,9 +42,11 @@ class Datum(dict):
                 self[schema] = value
 
     def to_dict(self):
+        '''Convert the datum to a dictionary.'''
         return self
 
     def fields(self):
+        '''Get the keys in the datum.'''
         return list(self.defaults.keys())
 
     def __repr__(self):

--- a/vivarium/library/pretty.py
+++ b/vivarium/library/pretty.py
@@ -1,3 +1,9 @@
+'''
+===============================
+Utilities for Formatting Output
+===============================
+'''
+
 import inspect
 import json
 import numpy as np

--- a/vivarium/library/topology.py
+++ b/vivarium/library/topology.py
@@ -20,7 +20,6 @@ def get_in(d, path, default=None):
     >>> get_in(d, ('a', 'b'))
     'c'
     >>> get_in(d, ('a', 'z'))
-    None
     >>> get_in(d, ('a', 'z'), 'y')
     'y'
     '''
@@ -134,11 +133,11 @@ def dict_to_paths(root, d):
     >>> d = {
     ...     'a': {
     ...         'b': 'c',
-    ...         'd': 'e',
     ...     },
+    ...     'd': 'e',
     ... }
     >>> dict_to_paths(root, d)
-    [('root', 'subroot', 'a', 'b'), ('root', 'subroot', 'a', d')]
+    [(('root', 'subroot', 'a', 'b'), 'c'), (('root', 'subroot', 'd'), 'e')]
     """
     if isinstance(d, dict):
         deeper = []

--- a/vivarium/library/topology.py
+++ b/vivarium/library/topology.py
@@ -26,7 +26,7 @@ def get_in(d, path, default=None):
     if path:
         head = path[0]
         if head in d:
-            return get_in(d[head], path[1:])
+            return get_in(d[head], path[1:], default)
         return default
     return d
 

--- a/vivarium/library/topology.py
+++ b/vivarium/library/topology.py
@@ -1,3 +1,9 @@
+'''
+==================
+Topology Utilities
+==================
+'''
+
 import copy
 import re
 
@@ -8,6 +14,16 @@ from vivarium.core.types import (
 
 
 def get_in(d, path, default=None):
+    '''Get the value from a dictionary by its path.
+
+    >>> d = {'a': {'b': 'c', 'd': 'e'}}
+    >>> get_in(d, ('a', 'b'))
+    'c'
+    >>> get_in(d, ('a', 'z'))
+    None
+    >>> get_in(d, ('a', 'z'), 'y')
+    'y'
+    '''
     if path:
         head = path[0]
         if head in d:
@@ -17,6 +33,13 @@ def get_in(d, path, default=None):
 
 
 def delete_in(d, path):
+    '''Delete an item from a dictionary by its path.
+
+    >>> d = {'a': {'b': 'c', 'd': 'e'}}
+    >>> delete_in(d, ('a', 'b'))
+    >>> d
+    {'a': {'d': 'e'}}
+    '''
     if len(path) > 0:
         head = path[0]
         if len(path) == 1:
@@ -29,6 +52,16 @@ def delete_in(d, path):
 
 
 def assoc_path(d, path, value):
+    '''Insert ``value`` into the dictionary ``d`` at ``path``.
+
+    >>> d = {'a': {'b': 'c'}}
+    >>> assoc_path(d, ('a', 'd'), 'e')
+    >>> d
+    {'a': {'b': 'c', 'd': 'e'}}
+
+    Create new dictionaries recursively as needed.
+    '''
+
     if path:
         head = path[0]
         if len(path) == 1:
@@ -42,6 +75,7 @@ def assoc_path(d, path, value):
 
 
 def without(d, removing):
+    '''Get a copy of ``d`` without the keys in ``removing``.'''
     return {
         key: value
         for key, value in d.items()
@@ -49,6 +83,21 @@ def without(d, removing):
 
 
 def update_in(d, path, f):
+    '''Update every value in a dictionary based on ``f``.
+
+    Args:
+        d: The dictionary ``path`` applies to. This object is not
+            modified.
+        path: Path to the sub-dictionary within ``d`` that should be
+            updated.
+        f: Function to call on every value in the dictionary to update.
+            The updated dictionary's values will be return values from
+            ``f``.
+
+    Returns:
+        A copy of ``d`` with all the values under ``path`` updated to
+        the value returned when ``f`` is called on the original value.
+    '''
     if path:
         head = path[0]
         d.setdefault(head, {})
@@ -59,6 +108,17 @@ def update_in(d, path, f):
 
 
 def paths_to_dict(path_list, f=lambda x: x):
+    '''Create a new dictionary that has the paths in ``path_list``.
+
+    Args:
+        path_list: A list of tuples ``(path, value)``.
+        f: A function to apply to each value before inserting it into
+            the dictionary.
+
+    Returns:
+        A new dictionary with the specified values (after being passed
+        through ``f``) at each associated path.
+    '''
     d = {}
     for path, node in path_list:
         assoc_path(d, path, f(node))
@@ -66,6 +126,20 @@ def paths_to_dict(path_list, f=lambda x: x):
 
 
 def dict_to_paths(root, d):
+    """Get all the paths in a dictionary.
+
+    For example:
+
+    >>> root = ('root', 'subroot')
+    >>> d = {
+    ...     'a': {
+    ...         'b': 'c',
+    ...         'd': 'e',
+    ...     },
+    ... }
+    >>> dict_to_paths(root, d)
+    [('root', 'subroot', 'a', 'b'), ('root', 'subroot', 'a', d')]
+    """
     if isinstance(d, dict):
         deeper = []
         for key, down in d.items():
@@ -74,7 +148,7 @@ def dict_to_paths(root, d):
         return deeper
     else:
         return [(root, d)]
-        
+
 
 def inverse_topology(outer, update, topology, inverse=None):
     '''
@@ -149,6 +223,7 @@ def inverse_topology(outer, update, topology, inverse=None):
 
 
 def normalize_path(path):
+    """Make a path absolute by resolving ``..`` elements."""
     progress = []
     for step in path:
         if step == '..' and len(progress) > 0:
@@ -161,14 +236,14 @@ def normalize_path(path):
 _PATH_ELEMENT = re.compile(r'[^>/]+')
 
 def convert_path_to_tuple(path: HierarchyPath) -> TuplePath:
-    """ convert paths to tuple format """
+    """Convert paths to tuple format."""
     if isinstance(path, str):
         path = tuple(_PATH_ELEMENT.findall(path.replace('<', '>..>')))
     return path
 
 
 def convert_topology_path(topology: Topology) -> Topology:
-    """ convert a topology's paths to tuple format """
+    """Convert a topology's paths to tuple format."""
     converted_topology: Topology = {}
     for name, path in topology.items():
         if isinstance(path, dict):

--- a/vivarium/plots/simulation_output.py
+++ b/vivarium/plots/simulation_output.py
@@ -1,3 +1,9 @@
+'''
+===========================
+Simulation Output Utilities
+===========================
+'''
+
 import os
 from typing import Any, Dict, Optional
 
@@ -6,6 +12,7 @@ import numpy as np
 import matplotlib.pyplot as plt
 
 from vivarium.core.emitter import path_timeseries_from_embedded_timeseries
+from vivarium.library.dict_utils import get_value_from_path
 
 
 def set_axes(
@@ -13,6 +20,17 @@ def set_axes(
         show_xaxis=False,
         sci_notation=False,
         y_offset=0.0):
+    '''Set up plot axes.
+
+    Args:
+        ax: The axes to set up.
+        show_xaxis: Whether to show the x axis.
+        sci_notation: Either ``False`` to not use scientific notation or
+            an integer :math:`x` such that scientific notation will be
+            used outside the range :math:`[10^{-x}, 10^x]`.
+        y_offset: Horizontal distance between axis offset text
+            (typically for scientific notation) and the y-axis.
+    '''
     if sci_notation:
         scilimits = 4
         if isinstance(sci_notation, int):
@@ -38,7 +56,7 @@ def set_axes(
         ax.tick_params(bottom=False, labelbottom=False)
 
 
-def save_fig_to_dir(
+def _save_fig_to_dir(
         fig,
         filename,
         out_dir='out/',
@@ -194,12 +212,20 @@ def plot_simulation_output(
 
     if out_dir:
         plt.subplots_adjust(wspace=column_width/3, hspace=column_width/3)
-        save_fig_to_dir(fig, filename, out_dir)
+        _save_fig_to_dir(fig, filename, out_dir)
     return fig
 
 
-# simple plotting function
 def get_variable_title(path):
+    '''Get figure title from a variable path.
+
+    Args:
+        path: Path to the variable.
+
+    Returns:
+        String representation of the variable suitable for a figure
+        title.
+    '''
     var = path[-1]
     separator = '>'
     connect_path = separator.join(path[:-1])
@@ -209,7 +235,6 @@ def get_variable_title(path):
         title = f'{connect_path}: {var}'
     return title
 
-from vivarium.library.dict_utils import get_value_from_path
 
 # simple plotting function
 def plot_variables(
@@ -224,6 +249,33 @@ def plot_variables(
         out_dir=None,
         filename='variables'
 ):
+    '''Create a simple figure with a timeseries for every variable.
+
+    Args:
+        output: Simulation output as a map from variable names or paths
+            to timeseries data. Should contain a ``time`` key whose
+            value is a list of time points.
+        variables: The variables to plot. May be a list of variable
+            names (if simulation output keys are just variable names) or
+            a dictionary with keys ``variable`` (for the variable path),
+            ``color`` (for the color to use for the plot), and
+            ``display`` (the variable name to display). If ``display``
+            is not provided, the result of calling
+            :py:func:`get_variable_title` on the variable path is used.
+        column_width: Figure width.
+        row_height: Height of each row. Each variable gets one row.
+        row_padding: Space between rows.
+        linewidth: Width of timeseries lines.
+        sci_notation: Either ``False`` for no scientific notation or an
+            integer :math:`x` such that scientific notation will be used
+            for values outside the range :math:`[10^{-x}, 10^x]`.
+        default_color: Default timeseries color.
+        out_dir: Output directory.
+        filename: Output filename.
+
+    Returns:
+        The figure.
+    '''
     n_rows = len(variables)
     fig = plt.figure(figsize=(column_width, n_rows * row_height))
     grid = plt.GridSpec(n_rows, 1)
@@ -257,7 +309,7 @@ def plot_variables(
 
     fig.subplots_adjust(hspace=row_padding)
     if out_dir:
-        save_fig_to_dir(fig, filename, out_dir)
+        _save_fig_to_dir(fig, filename, out_dir)
     return fig
 
 

--- a/vivarium/processes/tree_mass.py
+++ b/vivarium/processes/tree_mass.py
@@ -164,7 +164,7 @@ def test_tree_mass():
     return output
 
 
-def run_tree_mass():
+def _run_tree_mass():
     out_dir = os.path.join(PROCESS_OUT_DIR, NAME)
     os.makedirs(out_dir, exist_ok=True)
     output = test_tree_mass()
@@ -172,4 +172,4 @@ def run_tree_mass():
 
 
 if __name__ == '__main__':
-    run_tree_mass()
+    _run_tree_mass()


### PR DESCRIPTION
* Update docstrings and make some members private so that docstrings fully cover core files (except control).
* Clean up API stub files
* Stop using apidoc to auto-generate API stub files

To build the documentation, see the instructions [here](https://vivarium-core.readthedocs.io/en/latest/guides/docs.html#building-the-documentation).