### PR TITLE
Composite debug

### DIFF
--- a/vivarium/core/process.py
+++ b/vivarium/core/process.py
@@ -269,8 +269,9 @@ class Composite(Datum):
 
     def __init__(
             self,
-            config: Dict[str, Any]
+            config: Optional[Dict[str, Any]] = None
     ) -> None:
+        config = config or {}
         super().__init__(config)
         _override_schemas(self._schema, self.processes)
 

--- a/vivarium/core/process.py
+++ b/vivarium/core/process.py
@@ -259,6 +259,9 @@ class Composite(Datum):
 
     Contains keys for processes and topology
     """
+    processes: Dict[str, Any] = {}
+    topology: Dict[str, Any] = {}
+    _schema: Dict[str, Any] = {}
     defaults: Dict[str, Any] = {
         'processes': dict,
         'topology': dict,

--- a/vivarium/core/process.py
+++ b/vivarium/core/process.py
@@ -259,13 +259,10 @@ class Composite(Datum):
 
     Contains keys for processes and topology
     """
-    processes: Dict[str, Any] = {}
-    topology: Dict[str, Any] = {}
-    _schema: Dict[str, Any] = {}
     defaults: Dict[str, Any] = {
-        'processes': processes,
-        'topology': topology,
-        '_schema': _schema}
+        'processes': dict,
+        'topology': dict,
+        '_schema': dict}
 
     def __init__(
             self,

--- a/vivarium/experiments/composite_merge.py
+++ b/vivarium/experiments/composite_merge.py
@@ -1,0 +1,41 @@
+from vivarium.composites.toys import ExchangeA
+from vivarium.core.process import Composite
+
+
+
+def test_multi_composite():
+
+    composite1 = Composite()
+
+    processes = {
+        'A': ExchangeA()
+    }
+    topology = {
+        'A': {
+            'internal': ('in',),
+            'external': ('out',)}}
+    composite2 = Composite({
+            'processes': processes,
+            'topology': topology,
+        })
+
+
+    composite1.merge(composite=composite2, path=('agents', '1',))
+
+
+
+
+    composite3 = Composite()
+
+    print(f"Composite processes: {Composite.processes}")
+    print(f"Composite topology: {Composite.topology}")
+    print(f"composite3 processes: {composite3['processes']}")
+    print(f"composite3 topology: {composite3['topology']}")
+
+    import ipdb;
+    ipdb.set_trace()
+
+
+
+if __name__ == '__main__':
+    test_multi_composite()

--- a/vivarium/experiments/composite_merge.py
+++ b/vivarium/experiments/composite_merge.py
@@ -19,21 +19,17 @@ def test_multi_composite():
             'topology': topology,
         })
 
-
-    composite1.merge(composite=composite2, path=('agents', '1',))
-
-
-
-
     composite3 = Composite()
-
-    print(f"Composite processes: {Composite.processes}")
-    print(f"Composite topology: {Composite.topology}")
     print(f"composite3 processes: {composite3['processes']}")
     print(f"composite3 topology: {composite3['topology']}")
 
-    import ipdb;
-    ipdb.set_trace()
+    composite1.merge(composite=composite2, path=('agents', '1',))
+
+    composite4 = Composite()
+    print(f"composite4 processes: {composite4['processes']}")
+    print(f"composite4 topology: {composite4['topology']}")
+
+
 
 
 

--- a/vivarium/experiments/composite_merge.py
+++ b/vivarium/experiments/composite_merge.py
@@ -3,7 +3,7 @@ from vivarium.core.process import Composite
 
 
 
-def test_multi_composite():
+def test_multi_composite() -> None:
 
     composite1 = Composite()
 
@@ -20,12 +20,16 @@ def test_multi_composite():
         })
 
     composite3 = Composite()
+    assert not composite3['processes']
+    assert not composite3['topology']
     print(f"composite3 processes: {composite3['processes']}")
     print(f"composite3 topology: {composite3['topology']}")
 
     composite1.merge(composite=composite2, path=('agents', '1',))
 
     composite4 = Composite()
+    assert not composite4['processes']
+    assert not composite4['topology']
     print(f"composite4 processes: {composite4['processes']}")
     print(f"composite4 topology: {composite4['topology']}")
 

--- a/vivarium/library/datum.py
+++ b/vivarium/library/datum.py
@@ -30,9 +30,13 @@ class Datum(dict):
     defaults: Dict[str, Any] = {}
 
     def __init__(self, config):
-        super().__init__(self.defaults)
+        defaults = {
+            key: value() if callable(value) else value
+            for key, value in self.defaults.items()}
+
+        super().__init__(defaults)
         self.update(config)
-        self.__dict__ = self  # TODO(jerry): Instead define `def __getattr__(self, item): return self[item]`?
+        self.__dict__ = self
 
         for schema, realize in self.schema.items():
             if schema in self:


### PR DESCRIPTION
`Composite` had an interesting bug in which after a composite was initialized and merged into the class `Composite` was holding onto the `self.processes` and `self.topology` of the prior composite. So when a new composite was created, it had those processes. The PR fixes that by making a new `defaults` dict within `Datum`'s `__init__`. Also, `Composite` has new immutable defaults that get generated in `Datum`.