### PR TITLE
Revert string paths

### DIFF
--- a/vivarium/composites/toys.py
+++ b/vivarium/composites/toys.py
@@ -144,17 +144,17 @@ class ToyCompartment(Composer):
     def generate_topology(self, config):
         return{
             'metabolism': {
-                'pool': 'cytoplasm'},
+                'pool': ('cytoplasm',)},
             'transport': {
-                'external': 'periplasm',
-                'internal': 'cytoplasm'},
+                'external': ('periplasm',),
+                'internal': ('cytoplasm',)},
             'death': {
-                'global': '',
-                'compartment': 'cytoplasm'},
+                'global': tuple(),
+                'compartment': ('cytoplasm',)},
             'external_volume': {
-                'compartment': 'periplasm'},
+                'compartment': ('periplasm',)},
             'internal_volume': {
-                'compartment': 'cytoplasm'}}
+                'compartment': ('cytoplasm',)}}
 
 
 class ToyMetabolism(Process):
@@ -450,21 +450,21 @@ class PoQo(Composer):
         return {
             'po': {
                 'A': {
-                    '_path': 'aaa',
-                    'a2': 'x',
-                    'a3': '<ccc>a3'},
-                'B': 'bbb',
+                    '_path': ('aaa',),
+                    'a2': ('x',),
+                    'a3': ('..', 'ccc', 'a3')},
+                'B': ('bbb',),
             },
             'qo': {
                 'D': {
-                    '_path': '',
-                    'd1': 'aaa>d1',
-                    'd2': 'aaa>d2',
-                    'd3': 'ccc>d3'},
+                    '_path': (),
+                    'd1': ('aaa', 'd1'),
+                    'd2': ('aaa', 'd2'),
+                    'd3': ('ccc', 'd3')},
                 'E': {
-                    '_path': '',
-                    'e1': 'aaa>x',
-                    'e2': 'bbb>e2'}
+                    '_path': (),
+                    'e1': ('aaa', 'x'),
+                    'e2': ('bbb', 'e2')}
             },
         }
 

--- a/vivarium/core/process.py
+++ b/vivarium/core/process.py
@@ -17,8 +17,7 @@ import numpy as np
 from pint.errors import UndefinedUnitError
 
 from vivarium.library.datum import Datum
-from vivarium.library.topology import (
-    inverse_topology, convert_topology_path)
+from vivarium.library.topology import inverse_topology
 from vivarium.library.units import Quantity, Unit
 from vivarium.core.registry import serializer_registry
 from vivarium.library.dict_utils import deep_merge
@@ -446,7 +445,6 @@ class Composer(metaclass=abc.ABCMeta):
 
         processes = self.generate_processes(config)
         topology = self.generate_topology(config)
-        topology = convert_topology_path(topology)
         _override_schemas(self.schema_override, processes)
 
         return Composite({

--- a/vivarium/core/process.py
+++ b/vivarium/core/process.py
@@ -18,13 +18,12 @@ from pint.errors import UndefinedUnitError
 
 from vivarium.library.datum import Datum
 from vivarium.library.topology import (
-    inverse_topology, convert_path_to_tuple, convert_topology_path)
+    inverse_topology, convert_path_style, convert_topology_path)
 from vivarium.library.units import Quantity, Unit
 from vivarium.core.registry import serializer_registry
 from vivarium.library.dict_utils import deep_merge
 from vivarium.core.types import (
-    HierarchyPath, TuplePath, Topology,
-    Schema, State, Update, Processes)
+    HierarchyPath, Topology, Schema, State, Update)
 
 DEFAULT_TIME_STEP = 1.0
 
@@ -218,7 +217,7 @@ def _get_composite_state(
         processes: Dict[str, 'Process'],
         topology: Any,
         state_type: Optional[str] = 'initial',
-        path: Optional[TuplePath] = None,
+        path: Optional[HierarchyPath] = None,
         initial_state: Optional[State] = None,
         config: Optional[dict] = None,
 ) -> Optional[State]:
@@ -319,7 +318,7 @@ class Composite(Datum):
         processes = processes or {}
         topology = topology or {}
         path = path or tuple()
-        path = convert_path_to_tuple(path)
+        path = convert_path_style(path)
         schema_override = schema_override or {}
 
         # get the processes and topology to merge
@@ -424,7 +423,7 @@ class Composer(metaclass=abc.ABCMeta):
     def generate(
             self,
             config: Optional[dict] = None,
-            path: HierarchyPath = '') -> Composite:
+            path: HierarchyPath = None) -> Composite:
         """Generate processes and topology dictionaries.
 
         Args:
@@ -440,12 +439,13 @@ class Composer(metaclass=abc.ABCMeta):
             constructor for
             :py:class:`vivarium.core.experiment.Experiment`.
         """
+        path = path or tuple()
+        path = convert_path_style(path)
         if config is None:
             config = self.config
         else:
             default = copy.deepcopy(self.config)
             config = deep_merge(default, config)
-        path = convert_path_to_tuple(path)
 
         processes = self.generate_processes(config)
         topology = self.generate_topology(config)

--- a/vivarium/core/process.py
+++ b/vivarium/core/process.py
@@ -18,7 +18,7 @@ from pint.errors import UndefinedUnitError
 
 from vivarium.library.datum import Datum
 from vivarium.library.topology import (
-    inverse_topology, convert_path_style, convert_topology_path)
+    inverse_topology, convert_topology_path)
 from vivarium.library.units import Quantity, Unit
 from vivarium.core.registry import serializer_registry
 from vivarium.library.dict_utils import deep_merge
@@ -318,7 +318,6 @@ class Composite(Datum):
         processes = processes or {}
         topology = topology or {}
         path = path or tuple()
-        path = convert_path_style(path)
         schema_override = schema_override or {}
 
         # get the processes and topology to merge
@@ -423,7 +422,7 @@ class Composer(metaclass=abc.ABCMeta):
     def generate(
             self,
             config: Optional[dict] = None,
-            path: HierarchyPath = None) -> Composite:
+            path: HierarchyPath = ()) -> Composite:
         """Generate processes and topology dictionaries.
 
         Args:
@@ -439,8 +438,6 @@ class Composer(metaclass=abc.ABCMeta):
             constructor for
             :py:class:`vivarium.core.experiment.Experiment`.
         """
-        path = path or tuple()
-        path = convert_path_style(path)
         if config is None:
             config = self.config
         else:

--- a/vivarium/core/process.py
+++ b/vivarium/core/process.py
@@ -22,7 +22,7 @@ from vivarium.library.units import Quantity, Unit
 from vivarium.core.registry import serializer_registry
 from vivarium.library.dict_utils import deep_merge
 from vivarium.core.types import (
-    HierarchyPath, Topology, Schema, State, Update)
+    HierarchyPath, Topology, Schema, State, Update, Processes)
 
 DEFAULT_TIME_STEP = 1.0
 

--- a/vivarium/core/types.py
+++ b/vivarium/core/types.py
@@ -9,8 +9,7 @@ from typing import Tuple, Dict, Any, Union
 
 #: Relative path between nodes in the :term:`hierarchy`. Like Unix file
 #: paths, ".." refers to the parent directory.
-TuplePath = Tuple[str, ...]
-HierarchyPath = Union[str, TuplePath]
+HierarchyPath = Tuple[str, ...]
 
 #: Mapping from :term:`ports` to paths that specify which node in the
 #: :term:`hierarchy` should be wired to each port.

--- a/vivarium/library/topology.py
+++ b/vivarium/library/topology.py
@@ -237,17 +237,6 @@ def convert_path_style(path):
     return path
 
 
-def convert_topology_path(topology):
-    converted_topology = {}
-    for name, path in topology.items():
-        converted_topology[name] = {}
-        if isinstance(path, dict):
-            converted_topology[name] = convert_topology_path(path)
-        else:
-            converted_topology[name] = convert_path_style(path)
-    return converted_topology
-
-
 class TestUpdateIn:
     d = {
         'foo': {
@@ -430,30 +419,6 @@ def test_path_declare():
     new_path_up = convert_path_style(path_up)
     assert new_path_up == ('..', '..', 'store')
 
-def test_topology_paths():
-    topology = {
-        'a': {
-            '1': 'path>to>A',
-            '2': 'path>to>B',
-            '3': '<<C'
-        },
-        'b': {
-            '1': 'path>to>B',
-            '2': ('path', 'to', 'A')
-        },
-    }
-
-    new_topology = convert_topology_path(topology)
-    assert new_topology == {
-        'a': {
-            '1': ('path', 'to', 'A'),
-            '2': ('path', 'to', 'B'),
-            '3': ('..', '..', 'C')},
-        'b': {
-            '1': ('path', 'to', 'B'),
-            '2': ('path', 'to', 'A')}}
-
 
 if __name__ == '__main__':
     test_path_declare()
-    test_topology_paths()

--- a/vivarium/library/topology.py
+++ b/vivarium/library/topology.py
@@ -235,15 +235,13 @@ def normalize_path(path):
 _PATH_ELEMENT = re.compile(r'[^>]+')
 
 def convert_path_to_tuple(path: HierarchyPath) -> TuplePath:
-    """Convert paths to tuple format."""
     if isinstance(path, str):
         path = tuple(_PATH_ELEMENT.findall(path.replace('<', '>..>')))
     return path
 
 
-def convert_topology_path(topology: Topology) -> Topology:
-    """Convert a topology's paths to tuple format."""
-    converted_topology: Topology = {}
+def convert_topology_path(topology):
+    converted_topology = {}
     for name, path in topology.items():
         if isinstance(path, dict):
             converted_topology[name] = convert_topology_path(path)
@@ -435,19 +433,18 @@ def test_path_declare():
     assert new_path_up == ('..', '..', 'store')
 
 def test_topology_paths():
-
-    # complex topology test
     topology = {
         'a': {
             '1': 'path>to>A',
             '2': 'path>to>B',
-            '3': '<<C'},
+            '3': '<<C'
+        },
         'b': {
             '1': 'path>to>B',
-            '2': 'path>to>A'},
-        'c': {
-            'cc': {
-                '1': '<<path>to>B'}}}
+            '2': ('path', 'to', 'A')
+        },
+    }
+
     new_topology = convert_topology_path(topology)
     assert new_topology == {
         'a': {
@@ -456,20 +453,7 @@ def test_topology_paths():
             '3': ('..', '..', 'C')},
         'b': {
             '1': ('path', 'to', 'B'),
-            '2': ('path', 'to', 'A')},
-        'c': {
-            'cc': {
-                '1': ('..', '..', 'path', 'to', 'B')}}}
-
-    # tuple test
-    topology = {'a': {'1': ('path', 'to', 'A')}}
-    new_topology = convert_topology_path(topology)
-    assert new_topology == {'a': {'1': ('path', 'to', 'A')}}
-
-    # boundary case test
-    topology = {'a': {'1': ''}}
-    new_topology = convert_topology_path(topology)
-    assert new_topology == {'a': {'1': ()}}
+            '2': ('path', 'to', 'A')}}
 
 
 if __name__ == '__main__':

--- a/vivarium/library/topology.py
+++ b/vivarium/library/topology.py
@@ -232,7 +232,7 @@ def normalize_path(path):
     return tuple(progress)
 
 
-_PATH_ELEMENT = re.compile(r'[^>/]+')
+_PATH_ELEMENT = re.compile(r'[^>]+')
 
 def convert_path_to_tuple(path: HierarchyPath) -> TuplePath:
     """Convert paths to tuple format."""
@@ -460,11 +460,6 @@ def test_topology_paths():
         'c': {
             'cc': {
                 '1': ('..', '..', 'path', 'to', 'B')}}}
-
-    # slash test
-    topology = {'a': {'1': '../../path/to/A'}}
-    new_topology = convert_topology_path(topology)
-    assert new_topology == {'a': {'1': ('..', '..', 'path', 'to', 'A')}}
 
     # tuple test
     topology = {'a': {'1': ('path', 'to', 'A')}}

--- a/vivarium/library/topology.py
+++ b/vivarium/library/topology.py
@@ -7,9 +7,7 @@ Topology Utilities
 import copy
 import re
 
-from vivarium.library.dict_utils import (
-    deep_merge, deep_merge_multi_update)
-from vivarium.core.types import HierarchyPath
+from vivarium.library.dict_utils import deep_merge, deep_merge_multi_update
 
 
 def get_in(d, path, default=None):
@@ -231,7 +229,7 @@ def normalize_path(path):
     return tuple(progress)
 
 
-def convert_path_style(path) -> HierarchyPath:
+def convert_path_style(path):
     if isinstance(path, str):
         path = re.sub(r'<', '..<', path)
         path = tuple(re.split('<|>', path))


### PR DESCRIPTION
This reverts #48. We have another branch being worked on that improves Vivarium's API, in a way similar to what was done in #48. The string-based paths for composers added in #48 just add unnecessary complexity.