### PR TITLE
Control improve

### DIFF
--- a/vivarium/core/control.py
+++ b/vivarium/core/control.py
@@ -92,38 +92,46 @@ class Control:
         )
         return parser.parse_args(args)
 
-    def run_experiment(self, experiment_config: Union[str, dict]) -> OutputDict:
+    def run_experiment(
+            self,
+            experiment_config: Union[str, dict]
+    ) -> OutputDict:
+
         if isinstance(experiment_config, dict):
             experiment_id = experiment_config.pop('experiment_id')
             experiment = self.experiments_library[experiment_id]
             return experiment(**experiment_config)
+
         elif isinstance(experiment_config, str):
             experiment = self.experiments_library[experiment_config]
             return experiment()
+
         else:
             raise Exception(f'invalid experiment config: {experiment_config}')
 
     def run_one_plot(
             self,
-            plot_id: str,
+            plot_config: Union[str, dict],
             data: OutputDict,
             out_dir: Optional[str] = None,
     ) -> None:
         data_copy = copy.deepcopy(data)
-        plot_spec = self.plots_library[plot_id]
-        if isinstance(plot_spec, dict):
-            # retrieve plot and config from dictionary
-            plot_function = plot_spec.pop('plot')
-            plot_function(
+
+        if isinstance(plot_config, dict):
+            plot_id = plot_config.pop('plot_id')
+            plot = self.plots_library[plot_id]
+            plot(
                 data=data_copy,
                 out_dir=out_dir,
-                **plot_spec)
+                **plot_config)
 
-        elif callable(plot_spec):
+        elif callable(plot_config):
             # call plot directly
-            plot_spec(
+            plot_config(
                 data=data_copy,
                 out_dir=out_dir)
+        else:
+            raise Exception(f'invalid plot config: {plot_config}')
 
     def run_plots(
             self,

--- a/vivarium/core/control.py
+++ b/vivarium/core/control.py
@@ -105,14 +105,13 @@ class Control:
                 experiment = experiment_config.pop('experiment')
             return experiment(**experiment_config)
 
-        elif isinstance(experiment_config, str):
+        if isinstance(experiment_config, str):
             experiment = self.experiments_library[experiment_config]
             if isinstance(experiment, dict):
                 experiment = experiment.pop('experiment')
             return experiment()
 
-        else:
-            raise Exception(f'invalid experiment config: {experiment_config}')
+        raise Exception(f'invalid experiment config: {experiment_config}')
 
     def run_one_plot(
             self,

--- a/vivarium/core/control.py
+++ b/vivarium/core/control.py
@@ -95,8 +95,8 @@ class Control:
     def run_experiment(self, experiment_id: str) -> OutputDict:
         experiment = self.experiments_library[experiment_id]
         if isinstance(experiment, dict):
-            kwargs = experiment.get('kwargs', {})
-            return experiment['experiment'](**kwargs)
+            experiment_function = experiment.pop('experiment')
+            return experiment_function(**experiment)
         return experiment()
 
     def run_one_plot(
@@ -109,12 +109,11 @@ class Control:
         plot_spec = self.plots_library[plot_id]
         if isinstance(plot_spec, dict):
             # retrieve plot and config from dictionary
-            config = plot_spec.get('config', {})
-            plot = plot_spec['plot']
-            plot(
+            plot_function = plot_spec.pop('plot')
+            plot_function(
                 data=data_copy,
-                config=config,
-                out_dir=out_dir)
+                out_dir=out_dir,
+                **plot_spec)
 
         elif callable(plot_spec):
             # call plot directly

--- a/vivarium/core/control.py
+++ b/vivarium/core/control.py
@@ -92,12 +92,16 @@ class Control:
         )
         return parser.parse_args(args)
 
-    def run_experiment(self, experiment_id: str) -> OutputDict:
-        experiment = self.experiments_library[experiment_id]
-        if isinstance(experiment, dict):
-            experiment_function = experiment.pop('experiment')
-            return experiment_function(**experiment)
-        return experiment()
+    def run_experiment(self, experiment_config: Union[str, dict]) -> OutputDict:
+        if isinstance(experiment_config, dict):
+            experiment_id = experiment_config.pop('experiment_id')
+            experiment = self.experiments_library[experiment_id]
+            return experiment(**experiment_config)
+        elif isinstance(experiment_config, str):
+            experiment = self.experiments_library[experiment_config]
+            return experiment()
+        else:
+            raise Exception(f'invalid experiment config: {experiment_config}')
 
     def run_one_plot(
             self,

--- a/vivarium/core/control.py
+++ b/vivarium/core/control.py
@@ -98,9 +98,9 @@ class Control:
     ) -> OutputDict:
 
         if isinstance(experiment_config, dict):
-            if 'name' in experiment_config:
-                name = experiment_config.pop('name')
-                experiment = self.experiments_library[name]
+            if 'experiment_id' in experiment_config:
+                experiment_id = experiment_config.pop('experiment_id')
+                experiment = self.experiments_library[experiment_id]
             else:
                 experiment = experiment_config.pop('experiment')
             return experiment(**experiment_config)
@@ -125,9 +125,9 @@ class Control:
             plot_config = self.plots_library[plot_config]
 
         if isinstance(plot_config, dict):
-            if 'name' in plot_config:
-                name = plot_config.pop('name')
-                plot = self.plots_library[name]
+            if 'plot_id' in plot_config:
+                plot_id = plot_config.pop('plot_id')
+                plot = self.plots_library[plot_id]
             else:
                 plot = plot_config.pop('plot')
             plot(

--- a/vivarium/core/control.py
+++ b/vivarium/core/control.py
@@ -98,12 +98,17 @@ class Control:
     ) -> OutputDict:
 
         if isinstance(experiment_config, dict):
-            experiment_id = experiment_config.pop('experiment_id')
-            experiment = self.experiments_library[experiment_id]
+            if 'name' in experiment_config:
+                name = experiment_config.pop('name')
+                experiment = self.experiments_library[name]
+            else:
+                experiment = experiment_config.pop('experiment')
             return experiment(**experiment_config)
 
         elif isinstance(experiment_config, str):
             experiment = self.experiments_library[experiment_config]
+            if isinstance(experiment, dict):
+                experiment = experiment.pop('experiment')
             return experiment()
 
         else:
@@ -117,9 +122,15 @@ class Control:
     ) -> None:
         data_copy = copy.deepcopy(data)
 
+        if isinstance(plot_config, str):
+            plot_config = self.plots_library[plot_config]
+
         if isinstance(plot_config, dict):
-            plot_id = plot_config.pop('plot_id')
-            plot = self.plots_library[plot_id]
+            if 'name' in plot_config:
+                name = plot_config.pop('name')
+                plot = self.plots_library[name]
+            else:
+                plot = plot_config.pop('plot')
             plot(
                 data=data_copy,
                 out_dir=out_dir,


### PR DESCRIPTION
This adds more options to declaring control experiments, plots, and workflows. If strings, they are looked up in the `self.experiment_library` or `self.plot_library`.  If dicts, they can have either `'name'` keys for looking up in libraries, or `'plot'`/`'experiment'` keys for getting the functions directly.  Pytests pass unchanged, so all previous `Control` instances should be compatible.