### PR TITLE
Break up emits into smaller chunks

### DIFF
--- a/vivarium/core/emitter.py
+++ b/vivarium/core/emitter.py
@@ -64,7 +64,7 @@ def breakdown_data(limit, data, path=(), size=None):
             remaining = total
             index = 0
             large_keys = []
-            while remaining > limit or index >= len(order):
+            while remaining > limit and index < len(order):
                 key, subsize = order[index]
                 large_keys.append(key)
                 remaining -= subsize

--- a/vivarium/core/emitter.py
+++ b/vivarium/core/emitter.py
@@ -257,8 +257,9 @@ class RAMEmitter(Emitter):
         """
         if data['table'] == 'history':
             emit_data = data['data']
-            time = emit_data.pop('time')  # TODO: OK to modify caller's dict?
-            self.saved_data[time] = emit_data
+            time = emit_data['time']
+            self.saved_data[time] = {
+                key: value for key, value in emit_data.items() if key is not 'time'}
 
     def get_data(self) -> dict:
         """ Return the accumulated timeseries history of "emitted" data. """

--- a/vivarium/core/emitter.py
+++ b/vivarium/core/emitter.py
@@ -259,7 +259,8 @@ class RAMEmitter(Emitter):
             emit_data = data['data']
             time = emit_data['time']
             self.saved_data[time] = {
-                key: value for key, value in emit_data.items() if key is not 'time'}
+                key: value for key, value in emit_data.items()
+                if key not in ['time']}
 
     def get_data(self) -> dict:
         """ Return the accumulated timeseries history of "emitted" data. """

--- a/vivarium/core/emitter.py
+++ b/vivarium/core/emitter.py
@@ -246,6 +246,14 @@ class DatabaseEmitter(Emitter):
         table = getattr(self.db, data['table'])
         table.insert_one(emit_data)
 
+    def write_emit(self):
+        # TODO pass chunks
+        pass
+
+    def read_emit(self):
+        # re-assemble
+        pass
+
     def get_data(self) -> dict:
         return get_history_data_db(self.history, self.experiment_id)
 

--- a/vivarium/core/emitter.py
+++ b/vivarium/core/emitter.py
@@ -29,16 +29,12 @@ HISTORY_INDEXES = [
     'type',
     'simulation_id',
     'experiment_id',
-    '_child_id',
-    '_data_id',
 ]
 
 CONFIGURATION_INDEXES = [
     'type',
     'simulation_id',
     'experiment_id',
-    '_child_id',
-    '_data_id',
 ]
 
 SECRETS_PATH = 'secrets.json'

--- a/vivarium/core/emitter.py
+++ b/vivarium/core/emitter.py
@@ -108,7 +108,7 @@ def get_emitter(config: Optional[Dict[str, str]]) -> 'Emitter':
     * ``database``: :py:class:`DatabaseEmitter`
     * ``null``: :py:class:`NullEmitter`
     * ``print``: :py:class:`Emitter`, prints to stdout
-    * ``timeseries``: :py:class:`TimeSeriesEmitter`
+    * ``timeseries``: :py:class:`RAMEmitter`
 
     Arguments:
         config: Must comtain the ``type`` key, which specifies the emitter
@@ -127,7 +127,7 @@ def get_emitter(config: Optional[Dict[str, str]]) -> 'Emitter':
     elif emitter_type == 'null':
         emitter = NullEmitter(config)
     elif emitter_type == 'timeseries':
-        emitter = TimeSeriesEmitter(config)
+        emitter = RAMEmitter(config)
     else:
         emitter = Emitter(config)
 
@@ -239,7 +239,7 @@ class NullEmitter(Emitter):
         pass
 
 
-class TimeSeriesEmitter(Emitter):
+class RAMEmitter(Emitter):
     """
     Accumulate the timeseries history portion of the "emitted" data to a table
     in RAM.

--- a/vivarium/core/emitter.py
+++ b/vivarium/core/emitter.py
@@ -256,19 +256,17 @@ class DatabaseEmitter(Emitter):
         """
         data_bytes = sys.getsizeof(str(emit_data))
         if data_bytes > self.emit_limit:
-
-            # TODO -- save key with parent so they know how to find child.
             mother_data = {}
 
             # break up by keys, and emit each individually
             for key, child_data in emit_data.items():
                 child_key = str(uuid.uuid1())
-                mother_data[key] = child_key
-                child_data['_child_key'] = child_key
+                mother_data[key] = {'_child_emit': child_key}
+                child_emit = {child_key: child_data}
 
                 import ipdb; ipdb.set_trace()
 
-                self.write_emit(table, child_data)
+                self.write_emit(table, child_emit)
             self.write_emit(table, mother_data)
         else:
             table.insert_one(emit_data)

--- a/vivarium/core/emitter.py
+++ b/vivarium/core/emitter.py
@@ -309,10 +309,13 @@ class DatabaseEmitter(Emitter):
         self.create_indexes(self.phylogeny, CONFIGURATION_INDEXES)
 
     def emit(self, data: Dict[str, Any]) -> None:
-        data['experiment_id'] = self.experiment_id
-        table_id = data.pop('table')
+        table_id = data['table']
         table = getattr(self.db, table_id)
-        self.write_emit(table, data)
+        emit_data = {
+            key: value for key, value in data.items()
+            if key not in ['table']}
+        emit_data['experiment_id'] = self.experiment_id
+        self.write_emit(table, emit_data)
 
     def write_emit(self, table: Any, emit_data: Dict[str, Any]) -> None:
         """Check that data size is less than emit limit.

--- a/vivarium/core/engine.py
+++ b/vivarium/core/engine.py
@@ -8,7 +8,6 @@ Engine runs the simulation.
 
 import os
 import logging as log
-import warnings
 import pprint
 from typing import (
     Any, Dict, Optional, Union, Tuple, Callable)

--- a/vivarium/core/experiment.py
+++ b/vivarium/core/experiment.py
@@ -325,7 +325,7 @@ class Experiment:
             self._add_process_path(process, path)
 
     def emit_configuration(self) -> None:
-        """Emit configuration information to the emitter."""
+        """Send experiment configuration to the emitter."""
         data: Dict[str, Any] = {
             'time_created': self.time_created,
             'experiment_id': self.experiment_id,
@@ -335,20 +335,30 @@ class Experiment:
             'processes': serialize_value(self.processes),
             'state': serialize_value(self.state.get_config())
         }
-        emit_config: Dict[str, Any] = {
-            'table': 'configuration',
-            'data': data}
+        self.emit_send(data, table='configuration')
 
-        # get size of data for emit
-        data_bytes = sys.getsizeof(str(emit_config))
-        if data_bytes < 26000000:  # pymongo document size limit
+    def emit_data(self) -> None:
+        """Emit the current simulation state.
+
+        Only variables with ``_emit=True`` are emitted.
+        """
+        data = self.state.emit_data()
+        data.update({
+            'time': self.experiment_time})
+        self.emit_send(serialize_value(data), table='history')
+
+    def emit_send(self, data, table):
+        """Break the emit into small chunks and send them to the emitter"""
+        emit_limit = 26000000
+        data_bytes = sys.getsizeof(str(data))
+        if data_bytes < emit_limit:
+            emit_config: Dict[str, Any] = {
+                'table': table,
+                'data': data}
             self.emitter.emit(emit_config)
         else:
-            warnings.warn('configuration size is too big for the emitter, '
-                          'discarding process parameters')
-            for process_id in emit_config['data']['processes'].keys():
-                emit_config['data']['processes'][process_id] = None
-            self.emitter.emit(emit_config)
+            # TODO -- break data up into smaller chunks
+            warnings.warn('data is too big for the emitter')
 
     def invoke_process(
             self,
@@ -541,18 +551,6 @@ class Experiment:
                     path, deriver, 0)
                 self.apply_update(update.get(), store)
 
-    def emit_data(self) -> None:
-        """Emit the current simulation state.
-
-        Only variables with ``_emit=True`` are emitted.
-        """
-        data = self.state.emit_data()
-        data.update({
-            'time': self.experiment_time})
-        emit_config = {
-            'table': 'history',
-            'data': serialize_value(data)}
-        self.emitter.emit(emit_config)
 
     def send_updates(
             self,

--- a/vivarium/core/experiment.py
+++ b/vivarium/core/experiment.py
@@ -349,6 +349,8 @@ class Experiment:
 
     def emit_send(self, data, table):
         """Break the emit into small chunks and send them to the emitter"""
+
+        # TODO -- this is mongo specific. This should be done in in mongo emitter
         emit_limit = 26000000
         data_bytes = sys.getsizeof(str(data))
         if data_bytes < emit_limit:

--- a/vivarium/experiments/large_database_experiment.py
+++ b/vivarium/experiments/large_database_experiment.py
@@ -1,3 +1,7 @@
+"""
+Experiment to test maximum BSON document size with MongoDB emitter
+"""
+
 import random
 from vivarium.core.experiment import Experiment
 from vivarium.core.process import Process, Composer

--- a/vivarium/experiments/large_database_experiment.py
+++ b/vivarium/experiments/large_database_experiment.py
@@ -84,7 +84,8 @@ def run_large_initial_emit():
 
     # retrieve the data from emitter
     data = experiment.emitter.get_data()
-    assert list(data.keys()) == [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0]
+    assert list(data.keys()) == [
+        0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0]
 
     # retrieve the data directly from database
     db = get_experiment_database()

--- a/vivarium/experiments/large_database_experiment.py
+++ b/vivarium/experiments/large_database_experiment.py
@@ -26,7 +26,7 @@ class ManyParametersProcess(Process):
         super().__init__(random_parameters)
 
     def ports_schema(self):
-        return {'port': {'variable': {'_default': 0}}}
+        return {'port': {'variable': {'_default': 0, '_emit': True}}}
     def next_update(self, timestep, states):
         return {}
 
@@ -83,6 +83,14 @@ def run_large_initial_emit():
 
     assert 'processes' in experiment_config
     assert 0.0 in data
+
+    # run the experiment
+    experiment.update(10)
+
+    # retrieve the data
+    data = experiment.emitter.get_data()
+
+    import ipdb; ipdb.set_trace()
 
     # delete the experiment
     delete_experiment_from_database(experiment_id)

--- a/vivarium/experiments/large_database_experiment.py
+++ b/vivarium/experiments/large_database_experiment.py
@@ -57,6 +57,10 @@ class ManyParametersComposite(Composer):
             for process_id in self.process_ids}
 
 def run_large_initial_emit():
+    """
+    This experiment runs a large experiment to test the database emitter.
+    This requires MongoDB to be configured and running.
+    """
 
     config = {
         'number_of_processes': 1000,

--- a/vivarium/experiments/large_database_experiment.py
+++ b/vivarium/experiments/large_database_experiment.py
@@ -28,7 +28,7 @@ class ManyParametersProcess(Process):
     def ports_schema(self):
         return {'port': {'variable': {'_default': 0, '_emit': True}}}
     def next_update(self, timestep, states):
-        return {}
+        return {'port': {'variable': 1}}
 
 
 class ManyParametersComposite(Composer):
@@ -43,7 +43,6 @@ class ManyParametersComposite(Composer):
             for key in range(self.config['number_of_processes'])]
 
     def generate_processes(self, config):
-
         # make a bunch of processes
         return {
             process_id: ManyParametersProcess({

--- a/vivarium/experiments/large_database_experiment.py
+++ b/vivarium/experiments/large_database_experiment.py
@@ -66,6 +66,7 @@ def run_large_initial_emit():
     composite = composer.generate()
 
     settings = {
+        'experiment_name': 'large database experiment',
         'emitter': 'database'
     }
 
@@ -78,6 +79,7 @@ def run_large_initial_emit():
     experiment_id = experiment.experiment_id
     db = get_experiment_database()
     data, experiment_config = data_from_database(experiment_id, db)
+    # TODO -- data_from_database needs to know about assemble method!
 
     assert 'processes' in experiment_config
     assert 0.0 in data

--- a/vivarium/experiments/large_database_experiment.py
+++ b/vivarium/experiments/large_database_experiment.py
@@ -1,8 +1,9 @@
 """
 Experiment to test maximum BSON document size with MongoDB emitter
 """
-
+import uuid
 import random
+
 from vivarium.core.engine import Engine
 from vivarium.core.process import Process
 from vivarium.core.composer import Composer
@@ -66,8 +67,8 @@ def run_large_initial_emit():
 
     settings = {
         'experiment_name': 'large database experiment',
-
-        'emitter': 'database'
+        'experiment_id': f'large_{str(uuid.uuid4())}',
+        'emitter': 'database',
     }
 
     experiment = Engine({
@@ -83,19 +84,13 @@ def run_large_initial_emit():
 
     # retrieve the data from emitter
     data = experiment.emitter.get_data()
-
     assert list(data.keys()) == [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0]
-
 
     # retrieve the data directly from database
     db = get_experiment_database()
     data, experiment_config = data_from_database(experiment_id, db)
-
-    import ipdb;
-    ipdb.set_trace()
-    #
-    # assert 'processes' in experiment_config
-    # assert 0.0 in data
+    assert 'processes' in experiment_config
+    assert 0.0 in data
 
     # delete the experiment
     delete_experiment_from_database(experiment_id)

--- a/vivarium/experiments/large_database_experiment.py
+++ b/vivarium/experiments/large_database_experiment.py
@@ -52,7 +52,7 @@ class ManyParametersComposite(Composer):
 
     def generate_topology(self, config):
         return {
-            process_id: {'port': ('store',)}
+            process_id: {'port': ('store', process_id,)}
             for process_id in self.process_ids}
 
 def run_large_initial_emit():
@@ -66,6 +66,7 @@ def run_large_initial_emit():
 
     settings = {
         'experiment_name': 'large database experiment',
+
         'emitter': 'database'
     }
 
@@ -74,22 +75,27 @@ def run_large_initial_emit():
         'topology': composite['topology'],
         **settings})
 
-    # retrieve the data
-    experiment_id = experiment.experiment_id
-    db = get_experiment_database()
-    data, experiment_config = data_from_database(experiment_id, db)
-    # TODO -- data_from_database needs to know about assemble method!
-
-    assert 'processes' in experiment_config
-    assert 0.0 in data
-
     # run the experiment
     experiment.update(10)
 
-    # retrieve the data
+    # retrieve the data with data_from_database
+    experiment_id = experiment.experiment_id
+
+    # retrieve the data from emitter
     data = experiment.emitter.get_data()
 
-    import ipdb; ipdb.set_trace()
+    assert list(data.keys()) == [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0]
+
+
+    # retrieve the data directly from database
+    db = get_experiment_database()
+    data, experiment_config = data_from_database(experiment_id, db)
+
+    import ipdb;
+    ipdb.set_trace()
+    #
+    # assert 'processes' in experiment_config
+    # assert 0.0 in data
 
     # delete the experiment
     delete_experiment_from_database(experiment_id)


### PR DESCRIPTION
Some emits -- either of data or configurations -- can exceed mongoDB's 16MB document size limit. This PR aims to break those emits into smaller chunks and send them individually.