### PR TITLE
API improvements and simple divide

### DIFF
--- a/vivarium/core/composer.py
+++ b/vivarium/core/composer.py
@@ -183,6 +183,10 @@ class Composer(metaclass=abc.ABCMeta):
         self.config = deep_merge(self.config, config)
         self.schema_override = self.config.pop('_schema', {})
 
+    def generate_store(self, config: Optional[dict] = None) -> Store:
+        composite = self.generate()
+        return composite.generate_store(config)
+
     @abc.abstractmethod
     def generate_processes(
             self,

--- a/vivarium/core/store.py
+++ b/vivarium/core/store.py
@@ -214,6 +214,10 @@ class Store:
             path = (path,)
         self.set_path(path, value)
 
+    def connect_port(self, port, path):
+        assert port in self.topology, f'there is no port {port} in topology {self.topology}'
+        self.topology[port] = path
+
     def set_path(self, path, value):
         if isinstance(self.value, Process) and isinstance(value, Store):
             if self.independent_store(value):

--- a/vivarium/core/store.py
+++ b/vivarium/core/store.py
@@ -965,6 +965,7 @@ class Store:
 
         # use dividers to find initial states for daughters
         mother = divide['mother']
+        mother_path = (mother,)
         daughters = divide['daughters']
         initial_state = self.inner[mother].get_value(
             condition=lambda child: not
@@ -986,11 +987,9 @@ class Store:
 
             # if no processes or topology provided, copy the mother's processes and topology
             processes = daughter.get(
-                'processes', copy.deepcopy(self.get_path(tuple(mother)).get_processes()))
+                'processes', copy.deepcopy(self.get_path(mother_path).get_processes()))
             topology = daughter.get(
-                'topology', copy.deepcopy(self.get_path(tuple(mother)).get_topology()))
-            initial_state = daughter.get(
-                'initial_state', {})
+                'topology', copy.deepcopy(self.get_path(mother_path).get_topology()))
 
             self.generate(
                 daughter_path,
@@ -1012,7 +1011,7 @@ class Store:
             target.apply_defaults()
             target.set_value(initial_state)
 
-        mother_path = (mother,)
+
         self.delete_path(mother_path)
         deletions.append(tuple(here + mother_path))
 

--- a/vivarium/core/store.py
+++ b/vivarium/core/store.py
@@ -647,7 +647,11 @@ class Store:
         if self.inner:
             inner_processes = {}
             for key, child in self.inner.items():
-                if isinstance(child.value, Process):
+                if child.inner:
+                    child_processes = child.get_processes()
+                    if child_processes:
+                        inner_processes[key] = child_processes
+                elif isinstance(child.value, Process):
                     inner_processes[key] = child.value
             if inner_processes:
                 return inner_processes
@@ -662,9 +666,9 @@ class Store:
         if self.inner:
             inner_topology = {}
             for key, child in self.inner.items():
-                topology = child.get_topology()
-                if topology:
-                    inner_topology[key] = topology
+                child_topology = child.get_topology()
+                if child_topology:
+                    inner_topology[key] = child_topology
             if inner_topology:
                 return inner_topology
         elif self.topology:

--- a/vivarium/core/store.py
+++ b/vivarium/core/store.py
@@ -946,11 +946,15 @@ class Store:
             daughter_key = daughter['key']
             daughter_path = (daughter_key,)
 
+            processes = daughter.get('processes', copy.deepcopy(self.get_path(here).get_processes()))
+            topology = daughter.get('topology', copy.deepcopy(self.get_path(here).get_topology()))
+            initial_state = daughter.get('initial_state', {})
+
             self.generate(
                 daughter_path,
-                daughter['processes'],
-                daughter['topology'],
-                daughter['initial_state'])
+                processes,
+                topology,
+                initial_state)
 
             root = here + daughter_path
             process_paths = dict_to_paths(root, daughter['processes'])

--- a/vivarium/core/store.py
+++ b/vivarium/core/store.py
@@ -528,11 +528,11 @@ class Store:
 
         else:
             if self.leaf and config:
-                raise Exception(
-                    'trying to assign create inner for leaf node: {}'.format(
-                        self.path_for()))
-
-            # self.value = None
+                if self.value:
+                    raise Exception(
+                        f'trying to assign create inner for leaf node: '
+                        f'{self.path_for()} with value {self.value}')
+                self.leaf = False
 
             for key, child in config.items():
                 if key not in self.inner:
@@ -991,6 +991,8 @@ class Store:
                 'processes', copy.deepcopy(self.get_path(mother_path).get_processes()))
             topology = daughter.get(
                 'topology', copy.deepcopy(self.get_path(mother_path).get_topology()))
+            processes = processes or {}
+            topology = topology or {}
 
             self.generate(
                 daughter_path,
@@ -999,12 +1001,12 @@ class Store:
                 initial_state)
 
             root = here + daughter_path
-            process_paths = dict_to_paths(root, daughter['processes'])
+            process_paths = dict_to_paths(root, processes)
             process_updates.extend(process_paths)
 
             topology_paths = [
-                (root + (key,), topology)
-                for key, topology in daughter['topology'].items()]
+                (root + (key,), ports)
+                for key, ports in topology.items()]
             topology_updates.extend(topology_paths)
 
             self.apply_subschema_path(daughter_path)

--- a/vivarium/experiments/store_api.py
+++ b/vivarium/experiments/store_api.py
@@ -143,6 +143,8 @@ def test_run_store_in_experiment() -> None:
     # retrieve the processes and topology
     processes = store.get_processes()
     topology = store.get_topology()
+    _ = processes  # set to _ to pass lint test
+    _ = topology
 
     # run the experiment with a topology
     experiment = Engine({'store': store})

--- a/vivarium/experiments/store_api.py
+++ b/vivarium/experiments/store_api.py
@@ -182,26 +182,25 @@ def test_port_connect() -> None:
     # create the root
     store = Store({})
 
+    # create a new store at a path
+    store.create(['top', 'store1'])
+    store.create(['top', 'store2'])
+
     # create a process at a path
     store.create(['top', 'process1'], ToyProcess({}))
-
-    # create a new store at a path
-    store.create(['top', 'store1', 'X'])
-
-    # connect a port
-    store['top', 'process1'].connect('port1', 'store1')
+    store.create(['top', 'process2'], ToyProcess({}))
 
     # connect port using a relative path
-    store['top', 'process2'].connect('port1', 'store2')
+    store['top', 'process1'].connect('port1', 'store1')
 
     # connect using store target through a different port
-    store['top', 'process1'].connect('port1', store['top', 'process2', 'port1'])
+    store['top', 'process1'].connect('port2', store['top', 'process1', 'port1'])
 
     # connect using absolute path
     store['top', 'process1'].connect('port2', ('top', 'store2'), absolute=True)
 
-    assert store['top', 'process2'].topology == {'port1': ('store2',)}
-    assert store['top', 'process1'].topology == {'port1': ('store2',), 'port2': ('store2',)}
+    assert store['top', 'process1'].topology == {
+        'port1': ('store1',), 'port2': ('store2',)}
 
 
 test_library = {

--- a/vivarium/experiments/store_api.py
+++ b/vivarium/experiments/store_api.py
@@ -139,6 +139,12 @@ def test_set_value() -> None:
 def test_run_store_in_experiment() -> None:
     """put a store in an experiment and run it"""
     store = get_toy_store()
+
+    # retrieve the processes and topology
+    processes = store.get_processes()
+    topology = store.get_topology()
+
+    # run the experiment with a topology
     experiment = Engine({'store': store})
     experiment.update(10)
     data = experiment.emitter.get_data()

--- a/vivarium/experiments/store_api.py
+++ b/vivarium/experiments/store_api.py
@@ -154,7 +154,7 @@ def test_divide_store():
     store = Store({})  # create the root
 
     store.create(['top', 'process1'], ToyProcess({}))  # create a process at a path
-    store.create(['top', 'store1'], _subschema={})  # create a new store at a path
+    store.create(['top', 'store1', 'X'])  # create a new store at a path
     store['top', 'process1'].connect('port1', 'store1')  # connect a port
 
     # divide store1 into two daughters
@@ -165,13 +165,17 @@ def test_divide_store():
             {'key': 'store3'}
         ]})
 
+    final_state = store.get_value()
+    assert 'store2' in final_state['top']
+    assert 'store3' in final_state['top']
+    assert 'store1' not in final_state['top']
+
 
 def test_update_schema():
     store = Store({})  # create the root
     store.create(['top', 'process1'], ToyProcess({}))  # create a process at a path
     store.create(['top', 'store1'], _updater='set')  # create a new store at a path
     assert store['top', 'store1'].updater == 'set', 'updater is not set correctly'
-
 
 
 def test_port_connect():
@@ -181,11 +185,15 @@ def test_port_connect():
     store['top'].create('store2')  # create a new store at a path
 
     # connect some ports
-    store['top', 'process2'].connect('port1', 'store2')  # connect using a relative path
-    store['top', 'process1'].connect('port1', store['top', 'process2', 'port1'])  # connect using store target through a different port
-    store['top', 'process1'].connect('port2', ('top', 'store2'), absolute=True)  # connect using absolute path
+    store['top', 'process2'].connect(
+        'port1', 'store2')  # connect using a relative path
+    store['top', 'process1'].connect(
+        'port1', store['top', 'process2', 'port1'])  # connect using store target through a different port
+    store['top', 'process1'].connect(
+        'port2', ('top', 'store2'), absolute=True)  # connect using absolute path
 
-    # TODO -- add asserts
+    assert store['top', 'process2'].topology == {'port1': ('store2',)}
+    assert store['top', 'process1'].topology == {'port1': ('store2',), 'port2': ('store2',)}
 
 
 test_library = {

--- a/vivarium/experiments/store_api.py
+++ b/vivarium/experiments/store_api.py
@@ -154,14 +154,10 @@ def test_run_store_in_experiment() -> None:
 
 
 def test_divide_store():
-    pass
-
-
-def test_port_connect():
     store = Store({})  # create the root
     store['top', 'process1'] = ToyProcess({})  # create a process at a path
     store['top', 'store1'] = Store({})  # create a new store at a path
-    store['top', 'process1'].connect_port('port1', ('top', 'store1'))  # connect a port
+    store['top', 'process1'].connect_port('port1', 'store1')  # connect a port
 
     # divide store1 into two daughters
     store['top'].divide({
@@ -171,7 +167,29 @@ def test_port_connect():
             {'key': 'store3'}
         ]})
 
+def test_update_schema():
+    store = Store({})  # create the root
+    store['top', 'process1'] = ToyProcess({})  # create a process at a path
+    store['top', 'store1'] = Store({'_updater': 'set'})  # create a new store at a path
 
+    # TODO -- assert set updater
+
+    store['top', 'store1'].updater = 'accumulate'
+
+    # TODO -- assert accumulate updater
+
+
+
+def test_port_connect():
+    store = Store({})  # create the root
+    store['top', 'process1'] = ToyProcess({})  # create a process at a path
+    store['top', 'store1'] = Store({})  # create a new store at a path
+
+    # TODO -- test all of these port-connection methods
+    store['top', 'process1'].connect_port('port1', absolute=('top', 'store1'))  # connect a port using absolute path
+    store['top', 'process1'].connect_port('port1', relative='store1')  # connect a port using relative path
+    store['top', 'process1'].connect_port('port1',
+                                          store=store['top', 'process2', 'port1'])  # connect a port using store target
     import ipdb; ipdb.set_trace()
 
 

--- a/vivarium/experiments/store_api.py
+++ b/vivarium/experiments/store_api.py
@@ -153,6 +153,28 @@ def test_run_store_in_experiment() -> None:
     print(data)
 
 
+def test_divide_store():
+    pass
+
+
+def test_port_connect():
+    store = Store({})  # create the root
+    store['top', 'process1'] = ToyProcess({})  # create a process at a path
+    store['top', 'store1'] = Store({})  # create a new store at a path
+    store['top', 'process1'].connect_port('port1', ('top', 'store1'))  # connect a port
+
+    # divide store1 into two daughters
+    store['top'].divide({
+        'mother': 'store1',
+        'daughters': [
+            {'key': 'store2'},
+            {'key': 'store3'}
+        ]})
+
+
+    import ipdb; ipdb.set_trace()
+
+
 test_library = {
     '1': test_insert_process,
     '2': test_rewire_ports,
@@ -162,6 +184,7 @@ test_library = {
     # '6': test_connect_to_new_store,
     '7': test_set_value,
     '8': test_run_store_in_experiment,
+    '9': test_port_connect,
 }
 
 

--- a/vivarium/experiments/store_api.py
+++ b/vivarium/experiments/store_api.py
@@ -150,12 +150,11 @@ def test_run_store_in_experiment() -> None:
     print(data)
 
 
-def test_divide_store():
-    store = Store({})  # create the root
-
-    store.create(['top', 'process1'], ToyProcess({}))  # create a process at a path
-    store.create(['top', 'store1', 'X'])  # create a new store at a path
-    store['top', 'process1'].connect('port1', 'store1')  # connect a port
+def test_divide_store() -> None:
+    store = Store({})
+    store.create(['top', 'process1'], ToyProcess({}))
+    store.create(['top', 'store1', 'X'])
+    store['top', 'process1'].connect('port1', 'store1')
 
     # divide store1 into two daughters
     store['top'].divide({
@@ -171,26 +170,35 @@ def test_divide_store():
     assert 'store1' not in final_state['top']
 
 
-def test_update_schema():
-    store = Store({})  # create the root
-    store.create(['top', 'process1'], ToyProcess({}))  # create a process at a path
-    store.create(['top', 'store1'], _updater='set')  # create a new store at a path
-    assert store['top', 'store1'].updater == 'set', 'updater is not set correctly'
+def test_update_schema() -> None:
+    store = Store({})
+    store.create(['top', 'process1'], ToyProcess({}))
+    store.create(['top', 'store1'], _updater='set')
+    assert store['top', 'store1'].updater == 'set', \
+        'updater is not set correctly'
 
 
-def test_port_connect():
-    store = Store({})  # create the root
-    store.create(['top', 'process1'], ToyProcess({}))  # create a process at a path
-    store.create(['top', 'process2'], ToyProcess({}))  # create another process at a path
-    store['top'].create('store2')  # create a new store at a path
+def test_port_connect() -> None:
+    # create the root
+    store = Store({})
 
-    # connect some ports
-    store['top', 'process2'].connect(
-        'port1', 'store2')  # connect using a relative path
-    store['top', 'process1'].connect(
-        'port1', store['top', 'process2', 'port1'])  # connect using store target through a different port
-    store['top', 'process1'].connect(
-        'port2', ('top', 'store2'), absolute=True)  # connect using absolute path
+    # create a process at a path
+    store.create(['top', 'process1'], ToyProcess({}))
+
+    # create a new store at a path
+    store.create(['top', 'store1', 'X'])
+
+    # connect a port
+    store['top', 'process1'].connect('port1', 'store1')
+
+    # connect port using a relative path
+    store['top', 'process2'].connect('port1', 'store2')
+
+    # connect using store target through a different port
+    store['top', 'process1'].connect('port1', store['top', 'process2', 'port1'])
+
+    # connect using absolute path
+    store['top', 'process1'].connect('port2', ('top', 'store2'), absolute=True)
 
     assert store['top', 'process2'].topology == {'port1': ('store2',)}
     assert store['top', 'process1'].topology == {'port1': ('store2',), 'port2': ('store2',)}

--- a/vivarium/experiments/store_api.py
+++ b/vivarium/experiments/store_api.py
@@ -167,6 +167,7 @@ def test_divide_store():
             {'key': 'store3'}
         ]})
 
+
 def test_update_schema():
     store = Store({})  # create the root
     store['top', 'process1'] = ToyProcess({})  # create a process at a path
@@ -179,17 +180,32 @@ def test_update_schema():
     # TODO -- assert accumulate updater
 
 
-
 def test_port_connect():
     store = Store({})  # create the root
-    store['top', 'process1'] = ToyProcess({})  # create a process at a path
-    store['top', 'store1'] = Store({})  # create a new store at a path
+    store.create(['top', 'process1'], ToyProcess({})) # create a process at a path
 
-    # TODO -- test all of these port-connection methods
-    store['top', 'process1'].connect_port('port1', absolute=('top', 'store1'))  # connect a port using absolute path
-    store['top', 'process1'].connect_port('port1', relative='store1')  # connect a port using relative path
-    store['top', 'process1'].connect_port('port1',
-                                          store=store['top', 'process2', 'port1'])  # connect a port using store target
+
+    # store['top'].create('process1', value=ToyProcess({}), topology={})
+
+
+    store['top', 'process1', 'port1'] = store['top', 'process2', 'port2']
+
+
+    store['top', 'store1'] = 1
+    store['top'].create('store1', _default=1)
+
+    store['top'].create('store2', _updater='set') #= Store({'_subschema': {}})  # create a new store at a path
+
+
+    # These two should be the same
+    # store.connect(['top', 'process1', 'port1'], store=store['top', 'process2', 'port1'])
+    store['top', 'process1'].connect('port1', store=store['top', 'process2', 'port1'])  # connect a port using store target
+
+
+    # more ways to connect
+    store['top', 'process1'].connect('port1', absolute=('top', 'store1'))  # connect a port using absolute path
+    store['top', 'process1'].connect('port1', 'store1')  # connect a port using relative path
+
     import ipdb; ipdb.set_trace()
 
 


### PR DESCRIPTION
This PR enhances the Store API changes introduced in #84. This includes requiring explicit `.create()` to make new stores at a path, and `.connect()` for connecting ports. We found that it is best if the API aligns with the mental model of the bigraph, even if it means more complicated syntax. By calling `.connect()` the user will have to recognize that it is working with processes and ports, and `.create()` will keep them from creating unintended stores.

Here is an example of the api:
```
    store = Store({})  # create the root
    store.create(['top', 'process1'], ToyProcess({}))  # create a process at a path
    store.create(['top', 'process2'], ToyProcess({}))  # create another process at a path
    store['top'].create('store2')  # create a new store at a path

    # connect some ports
    store['top', 'process2'].connect('port1', 'store2')  # connect using a relative path
    store['top', 'process1'].connect( 'port1', store['top', 'process2', 'port1'])  # connect using store through a different port
    store['top', 'process1'].connect( 'port2', ('top', 'store2'), absolute=True)  # connect using absolute path
```

This PR also makes `store.divide` simpler, deepcopying a branches' processes and topology if they are not provided. This allows for division like this:
```
    store = Store({})  # create the root
    store.create(['top', 'process1'], ToyProcess({}))  # create a process at a path
    store.create(['top', 'store1', 'X'])  # create a new store at a path
    store['top', 'process1'].connect('port1', 'store1')  # connect a port

    # divide store1 into two daughters
    store['top'].divide({
        'mother': 'store1',
        'daughters': [
            {'key': 'store2'},
            {'key': 'store3'}
        ]})
```

Finally, `Composer` now has a `.generate_store()` method, which creates a composite and returns its `generate_store()`, so that the intermediate composite is no longer required.