### PR TITLE
Logging updates from processes

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -102,6 +102,7 @@ ignore=injected_glc_phosphorylation.py,
        derive_concentrations.py,
        nonspatial_environment.py,
        store.py,
+       wrappers.py,
 # Good variable names which should be accepted
 good-names=pp,pf,_,
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -165,6 +165,10 @@ disallow_incomplete_defs = False
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
+[mypy-vivarium.library.wrappers.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
 [mypy-vivarium.library.dict_utils.*]
 disallow_untyped_defs = False
 disallow_incomplete_defs = False

--- a/vivarium/library/wrappers.py
+++ b/vivarium/library/wrappers.py
@@ -1,0 +1,42 @@
+from vivarium.core.process import Process
+
+
+def make_logging_process(process_class, logging_port_name="log_update"):
+    """
+    Given a subclass of Process, returns a new subclass that behaves exactly
+    the same except that it logs all of its updates in a port with name given by
+    logging_port_name.
+
+    The returned class has the same name as process_class, but prefixed with 'Logging_'.
+
+    Args:
+        process_class: The Process class to be logged
+        logging_port_name: Name of the port in which updates will be stored
+                           ('log_update' by default.)
+
+    Returns:
+        logging_process: the logging version of process_class.
+    """
+
+    if not issubclass(process_class, Process):
+        raise ValueError(f'process_class must be a subclass of Process.')
+
+    logging_process = type(f"Logging_{process_class.__name__}",
+                           (process_class,),
+                           {})
+    __class__ = logging_process  # set __class__ manually so super() knows what to do
+
+    def ports_schema(self):
+        ports = super().ports_schema()  # get the original port structure
+        ports[logging_port_name] = {'_default': {}, '_updater': 'set', '_emit': True}  # add a new port
+        return ports
+
+    def next_update(self, timestep, states):
+        update = super().next_update(timestep, states)  # get the original update
+        log_update = {logging_port_name: update}  # log the update
+        return {**update, **log_update}
+
+    logging_process.ports_schema = ports_schema
+    logging_process.next_update = next_update
+
+    return logging_process

--- a/vivarium/library/wrappers.py
+++ b/vivarium/library/wrappers.py
@@ -1,13 +1,23 @@
+from typing import Union
+
 from vivarium.core.process import Process
+from vivarium.core.types import Schema, State, Update
+from vivarium.composites.toys import ToyProcess
 
 
-def make_logging_process(process_class, logging_port_name="log_update"):
+
+
+def make_logging_process(
+        process_class,
+        logging_port_name="log_update"
+) -> type:
     """
     Given a subclass of Process, returns a new subclass that behaves exactly
     the same except that it logs all of its updates in a port with name given by
     logging_port_name.
 
-    The returned class has the same name as process_class, but prefixed with 'Logging_'.
+    The returned class has the same name as process_class, but prefixed with
+    'Logging_'.
 
     Args:
         process_class: The Process class to be logged
@@ -26,17 +36,35 @@ def make_logging_process(process_class, logging_port_name="log_update"):
                            {})
     __class__ = logging_process  # set __class__ manually so super() knows what to do
 
-    def ports_schema(self):
-        ports = super().ports_schema()  # get the original port structure
+    def ports_schema(
+            self
+    ) -> Schema:
+        ports = super().ports_schema()  # type: ignore
         ports[logging_port_name] = {'_default': {}, '_updater': 'set', '_emit': True}  # add a new port
         return ports
 
-    def next_update(self, timestep, states):
-        update = super().next_update(timestep, states)  # get the original update
+    def next_update(
+            self,
+            timestep: Union[float, int],
+            states: State
+    ) -> Update:
+        update = super().next_update(timestep, states)  # type: ignore
         log_update = {logging_port_name: update}  # log the update
         return {**update, **log_update}
 
-    logging_process.ports_schema = ports_schema
-    logging_process.next_update = next_update
+    logging_process.ports_schema = ports_schema  # type: ignore
+    logging_process.next_update = next_update  # type: ignore
 
     return logging_process
+
+
+def test_logging_process():
+    logging_toy = make_logging_process(ToyProcess)
+    logging_toy_instance = logging_toy()
+
+    ports = logging_toy_instance.ports_schema()
+    assert 'log_update' in ports
+
+
+if __name__ == '__main__':
+    test_logging_process()


### PR DESCRIPTION
This PR introduces the `make_logging_process` function in `vivarium.library.wrappers`, which was developed originally in vivarium-ecoli. The function takes a subclass of Process, and returns a new subclass that automatically logs its update at each timestep to a new port (`"log_update"` by default).

This is achieved by making a new subclass of the given Process class on-the-fly. For instance, make_logging_process(TfBinding) returns a new class Logging_TfBinding which inherits from TfBinding, and behaves exactly the same except that it automatically logs its own updates. This general approach allows arbitrary processes to be automatically logged while writing minimal new code.