### PR TITLE
Engine kwargs

### DIFF
--- a/vivarium/core/composition.py
+++ b/vivarium/core/composition.py
@@ -172,7 +172,7 @@ def compose_experiment(
     for key, setting in settings.items():
         if key in experiment_config_keys:
             experiment_config[key] = setting
-    return Engine(experiment_config)
+    return Engine(**experiment_config)
 
 
 # experiment loading functions
@@ -309,7 +309,7 @@ def composite_in_experiment(
     for key, setting in settings.items():
         if key in experiment_config_keys:
             experiment_config[key] = setting
-    return Engine(experiment_config)
+    return Engine(**experiment_config)
 
 
 def composer_in_experiment(

--- a/vivarium/core/engine.py
+++ b/vivarium/core/engine.py
@@ -204,26 +204,23 @@ class InvokeProcess:
 class Engine:
     def __init__(
             self,
-            processes=None,
-            topology=None,
-            store=None,
-            emitter='timeseries',
-            emit_config=True,
-            invoke=None,
-            experiment_id=None,
-            experiment_name=None,
-            initial_state=None,
-            description='',
-            emit_step=1.0,
-            display_info=True,
-            progress_bar=False,
+            processes: Optional[Processes] = None,
+            topology: Optional[Topology] = None,
+            store: Optional[Store] = None,
+            initial_state: Optional[State] = None,
+            experiment_id: Optional[str] = None,
+            experiment_name: Optional[str] = None,
+            description: str = '',
+            emitter: Union[str, dict] = 'timeseries',
+            emit_config: bool = True,
+            invoke: Optional[Any] = None,
+            emit_step: float = 1.0,
+            display_info: bool = True,
+            progress_bar: bool = False,
     ) -> None:
         """Defines simulations
 
         Arguments:
-            config (dict): A dictionary of configuration options. The
-                required options are:
-
                 * **processes** (:py:class:`dict`): A dictionary that
                     maps :term:`process` names to process objects. You
                     will usually get this from the ``processes``
@@ -236,18 +233,21 @@ class Engine:
                     from the :term:`compartment` root to the
                     :term:`store` that will be passed to the process for
                     that port.
+                * **store** (:py:class:`Store`): A pre-loaded Store. This
+                    is an alternative to passing in processes and topology dict,
+                    which can not be loaded at the same time.
 
-                The following options are optional:
+                The following are optional:
 
+                * **initial_state** (:py:class:`dict`): By default an
+                    empty dictionary, this is the initial state of the
+                    simulation.
                 * **experiment_id** (:py:class:`uuid.UUID` or
                     :py:class:`str`): A unique identifier for the
                     experiment. A UUID will be generated if none is
                     provided.
                 * **description** (:py:class:`str`): A description of
                     the experiment. A blank string by default.
-                * **initial_state** (:py:class:`dict`): By default an
-                    empty dictionary, this is the initial state of the
-                    simulation.
                 * **emitter** (:py:class:`dict`): An emitter
                     configuration which must conform to the
                     specification in the documentation for
@@ -267,9 +267,8 @@ class Engine:
 
         # get the processes, topology, and store
         if processes and topology and not store:
-            self.processes: Processes = processes
-            self.topology: Topology = topology
-
+            self.processes = processes
+            self.topology = topology
             # initialize the store
             self.state: Store = generate_state(
                 self.processes,
@@ -278,7 +277,6 @@ class Engine:
 
         elif store:
             self.state = store
-
             # get processes and topology from the store
             self.processes = self.state.get_processes()
             self.topology = self.state.get_topology()
@@ -981,11 +979,11 @@ def test_timescales() -> None:
         'fast': {'state': ('state',)}}
 
     emitter = {'type': 'null'}
-    experiment = Engine(**{
-        'processes': processes,
-        'topology': topology,
-        'emitter': emitter,
-        'initial_state': states})
+    experiment = Engine(
+        processes=processes,
+        topology=topology,
+        emitter=emitter,
+        initial_state=states)
 
     experiment.update(10.0)
 
@@ -1270,10 +1268,10 @@ def test_custom_divider() -> None:
     })
     composite = composer.generate(path=('agents', agent_id))
 
-    experiment = Engine(**{
-        'processes': composite.processes,
-        'topology': composite.topology,
-    })
+    experiment = Engine(
+        processes=composite.processes,
+        topology=composite.topology,
+    )
 
     experiment.update(80)
     data = experiment.emitter.get_data()

--- a/vivarium/core/engine.py
+++ b/vivarium/core/engine.py
@@ -908,7 +908,7 @@ def test_recursive_store() -> None:
 def test_topology_ports() -> None:
     proton = _make_proton()
 
-    experiment = Engine(proton)
+    experiment = Engine(**proton)
 
     log.debug(pf(experiment.state.get_config(True)))
 
@@ -981,7 +981,7 @@ def test_timescales() -> None:
         'fast': {'state': ('state',)}}
 
     emitter = {'type': 'null'}
-    experiment = Engine({
+    experiment = Engine(**{
         'processes': processes,
         'topology': topology,
         'emitter': emitter,
@@ -1039,7 +1039,7 @@ def test_2_store_1_port() -> None:
     # run experiment
     split_port = SplitPort({})
     network = split_port.generate()
-    exp = Engine({
+    exp = Engine(**{
         'processes': network['processes'],
         'topology': network['topology']})
 
@@ -1099,7 +1099,7 @@ def test_multi_port_merge() -> None:
     # run experiment
     merge_port = MergePort({})
     network = merge_port.generate()
-    exp = Engine({
+    exp = Engine(**{
         'processes': network['processes'],
         'topology': network['topology']})
 
@@ -1118,7 +1118,8 @@ def test_complex_topology() -> None:
     outer_path = ('universe', 'agent')
     pq = PoQo({})
     pq_composite = pq.generate(path=outer_path)
-    experiment = Engine(pq_composite)
+    pq_composite.pop('_schema')
+    experiment = Engine(**pq_composite)
 
     # get the initial state
     initial_state = experiment.state.get_value()
@@ -1143,7 +1144,7 @@ def test_complex_topology() -> None:
 
 def test_parallel() -> None:
     proton = _make_proton(parallel=True)
-    experiment = Engine(proton)
+    experiment = Engine(**proton)
 
     log.debug(pf(experiment.state.get_config(True)))
 
@@ -1236,7 +1237,7 @@ def test_units() -> None:
     # run experiment
     multi_unit = MultiUnits({})
     network = multi_unit.generate()
-    exp = Engine({
+    exp = Engine(**{
         'processes': network['processes'],
         'topology': network['topology']})
 
@@ -1269,7 +1270,7 @@ def test_custom_divider() -> None:
     })
     composite = composer.generate(path=('agents', agent_id))
 
-    experiment = Engine({
+    experiment = Engine(**{
         'processes': composite.processes,
         'topology': composite.topology,
     })

--- a/vivarium/core/engine.py
+++ b/vivarium/core/engine.py
@@ -221,44 +221,35 @@ class Engine:
         """Defines simulations
 
         Arguments:
-                * **processes** (:py:class:`dict`): A dictionary that
-                    maps :term:`process` names to process objects. You
-                    will usually get this from the ``processes``
-                    attribute of the dictionary from
-                    :py:meth:`vivarium.core.composer.Composer.generate`.
-                * **topology** (:py:class:`dict`): A dictionary that
-                    maps process names to sub-dictionaries. These
-                    sub-dictionaries map the process's port names to
-                    tuples that specify a path through the :term:`tree`
-                    from the :term:`compartment` root to the
-                    :term:`store` that will be passed to the process for
-                    that port.
-                * **store** (:py:class:`Store`): A pre-loaded Store. This
-                    is an alternative to passing in processes and topology dict,
-                    which can not be loaded at the same time.
+        * **processes** (:py:class:`dict`): A dictionary that
+        maps :term:`process` names to process objects. You will
+        usually get this from the ``processes`` attribute of the
+        dictionary from :py:meth:`vivarium.core.composer.Composer.generate`.
+        * **topology** (:py:class:`dict`): A dictionary that
+        maps process names to sub-dictionaries. These sub-dictionaries
+        map the process's port names to tuples that specify a path through
+        the :term:`tree` from the :term:`compartment` root to the
+        :term:`store` that will be passed to the process for that port.
+        * **store**: A pre-loaded Store. This is an alternative to
+        passing in processes and topology dict, which can not be
+        loaded at the same time.
+        * **initial_state** (:py:class:`dict`): By default an
+        empty dictionary, this is the initial state of the simulation.
+        * **experiment_id** (:py:class:`uuid.UUID` or :py:class:`str`):
+        A unique identifier for the experiment. A UUID will be generated
+        if none is provided.
+        * **description** (:py:class:`str`): A description of the
+        experiment. A blank string by default.
+        * **emitter** (:py:class:`dict`): An emitter configuration
+        which must conform to the specification in the documentation
+        for :py:func:`vivarium.core.emitter.get_emitter`. The experiment
+        ID will be added to the dictionary you provide as the value for
+        the key ``experiment_id``.
+        * **display_info** (:py:class:`bool`): prints experiment info
+        * **progress_bar** (:py:class:`bool`): shows a progress bar
+        * **emit_config** (:py:class:`bool`): If True, this will emit
+        the serialized processes, topology, and initial state.
 
-                The following are optional:
-
-                * **initial_state** (:py:class:`dict`): By default an
-                    empty dictionary, this is the initial state of the
-                    simulation.
-                * **experiment_id** (:py:class:`uuid.UUID` or
-                    :py:class:`str`): A unique identifier for the
-                    experiment. A UUID will be generated if none is
-                    provided.
-                * **description** (:py:class:`str`): A description of
-                    the experiment. A blank string by default.
-                * **emitter** (:py:class:`dict`): An emitter
-                    configuration which must conform to the
-                    specification in the documentation for
-                    :py:func:`vivarium.core.emitter.get_emitter`. The
-                    experiment ID will be added to the dictionary you
-                    provide as the value for the key ``experiment_id``.
-                * **display_info** (:py:class:`bool`): prints experiment info
-                * **progress_bar** (:py:class:`bool`): shows a progress bar
-                * **emit_config** (:py:class:`bool`): If True, this will
-                    emit the serialized processes, topology, and initial
-                    state.
         """
 
         self.experiment_id = experiment_id or str(uuid.uuid1())
@@ -974,7 +965,7 @@ def test_timescales() -> None:
             'base': 1.0,
             'motion': 0.0}}
 
-    topology = {
+    topology: Topology = {
         'slow': {'state': ('state',)},
         'fast': {'state': ('state',)}}
 

--- a/vivarium/experiments/glucose_phosphorylation.py
+++ b/vivarium/experiments/glucose_phosphorylation.py
@@ -42,7 +42,7 @@ def glucose_phosphorylation_experiment(config=None):
     compartment = InjectedGlcPhosphorylation(
         config['injected_glc_phosphorylation'])
     compartment_dict = compartment.generate()
-    experiment = Engine({
+    experiment = Engine(**{
         'processes': compartment_dict['processes'],
         'topology': compartment_dict['topology'],
         'emitter': config['emitter'],

--- a/vivarium/experiments/store_api.py
+++ b/vivarium/experiments/store_api.py
@@ -147,7 +147,7 @@ def test_run_store_in_experiment() -> None:
     _ = topology
 
     # run the experiment with a topology
-    experiment = Engine({'store': store})
+    experiment = Engine(store=store)
     experiment.update(10)
     data = experiment.emitter.get_data()
 


### PR DESCRIPTION
This PR subtly changes the `Engine` API to use function arguments rather than a big `config` dictionary. This is cleaner-looking, and shows up on editors for easy autocomplete and type hints. It unfortunately breaks previous API, but better to make the change now rather than after the paper is published and people begin using Vivarium.