### PR TITLE
Prevents tolist serializer on a list.

### DIFF
--- a/vivarium/core/store.py
+++ b/vivarium/core/store.py
@@ -769,6 +769,8 @@ class Store:
                 if self.units:
                     return self.serializer.serialize(
                         self.value.to(self.units))
+                if isinstance(self.value, list):
+                    return self.value
                 return self.serializer.serialize(self.value)
             if self.units:
                 return self.value.to(self.units).magnitude


### PR DESCRIPTION
This change allows vivarium-ecoli to have an initial state that is derived from vivarium-ecoli data, so that tolist is not called on a list and thus does not crash the simulation.