### PR TITLE
Fix growth rate next_update and strengthen test

### DIFF
--- a/vivarium/processes/growth_rate.py
+++ b/vivarium/processes/growth_rate.py
@@ -11,6 +11,7 @@ from vivarium.core.process import Process
 from vivarium.core.composition import (
     PROCESS_OUT_DIR,
     process_in_experiment,
+    simulate_experiment,
 )
 from vivarium.plots.simulation_output import plot_simulation_output
 
@@ -58,11 +59,14 @@ class GrowthRate(Process):
         growth_noise = states['rates']['growth_noise']
 
         variable_update = {
-            variable: value * (
-                    np.exp(growth_rate[variable] +
-                           np.random.normal(0, growth_noise[variable]))
-                    * timestep) - value
-            for variable, value in variables.items()}
+            variable: value * np.exp(
+                (
+                    growth_rate[variable]
+                    + np.random.normal(0, growth_noise[variable])
+                ) * timestep
+            ) - value
+            for variable, value in variables.items()
+        }
         return {'variables': variable_update}
 
 
@@ -71,23 +75,23 @@ def test_growth_rate(total_time=1350):
     growth_rate = 0.0005
     config = {
         'variables': ['mass'],
-        'default_growth_rate': growth_rate}
+        'default_growth_rate': growth_rate,
+        'time_step': 2,
+    }
 
     growth_rate_process = GrowthRate(config)
     initial_state = {'variables': {'mass': initial_mass}}
     experiment = process_in_experiment(
         growth_rate_process,
         initial_state=initial_state)
-    experiment.update(total_time)
-    output = experiment.emitter.get_timeseries()
+    output = simulate_experiment(experiment, {'total_time': total_time})
 
     # asserts
     final_mass = output['variables']['mass'][-1]
     expected_mass = initial_mass * np.exp(growth_rate * total_time)
-    decimal_precision = 7
+    decimal_precision = 11
     assert abs(expected_mass - final_mass) < \
            1.5 * 10 ** (-decimal_precision)
-
     return output
 
 


### PR DESCRIPTION
The update calculation in the growth rate process was incorrect. We want to model growth by `m(t + ∆t) = m(t)e^(r∆t)`, but we were actually modeling it as `m(t + ∆t) = m(t)e^(r)∆t`. This PR fixes the process and strengthens the test. The new test would have caught the problem fixed by this PR