### PR TITLE
Implement Topology Caching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,10 @@ out/
 user/*
 !user/user.txt
 *.cprof
+.env
+Pipfile
+Pipfile.lock
+.vscode/*
 
 # Compiled source #
 ###################

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -19,6 +19,7 @@ more-itertools==8.5.0
 nbsphinx==0.8.7
 networkx==2.5
 numpy==1.19.1
+orjson==3.6.4
 packaging==20.4
 Pillow==7.2.0
 Pint==0.15

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ numpy==1.19.4
 Pint==0.16.1
 pymongo==3.11.0
 scipy==1.5.4
+orjson==3.6.4
 
 # dev tools
 mypy==0.790

--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,7 @@ if __name__ == '__main__':
             'Pint',
             'pymongo',
             'scipy',
+            'orjson'
         ],
         classifiers=[
             'Development Status :: 4 - Beta',

--- a/vivarium/core/engine.py
+++ b/vivarium/core/engine.py
@@ -496,7 +496,7 @@ class Engine:
 
         # translate the values from the tree structure into the form
         # that this process expects, based on its declared topology
-        states = store.outer.schema_topology(process.schema, store.topology)
+        states = store.outer.schema_serialize(process.schema, store.topology)
 
         return store, states
 
@@ -517,11 +517,8 @@ class Engine:
             Tuple of the deferred update (relative to the root of
             ``path``) and the store at ``path``.
         """
-        if process.process_state == ():
-            store, states = self.process_state(path, process)
-            process.process_state = (store, states)
-        store = process.process_state[0]
-        states = view_values(process.process_state[1])
+        store, states = self.process_state(path, process)
+        states = view_values(states)
         if process.update_condition(interval, states):
             return self._process_update(
                 path, process, store, states, interval)
@@ -659,11 +656,12 @@ class Engine:
                 if process_time <= time:
 
                     # get the time step
-                    if process.process_state == ():
-                        store, states = self.process_state(path, process)
-                        process.process_state = (store, states)
-                    store = process.process_state[0]
-                    states = view_values(process.process_state[1])
+                    # if process.process_state == ():
+                    #     store, states = self.process_state(path, process)
+                    #     process.process_state = (store, states)
+                    # store = process.process_state[0]
+                    store, states = self.process_state(path, process)
+                    states = view_values(states)
                     requested_timestep = process.calculate_timestep(states)
 
                     # progress only to the end of interval

--- a/vivarium/core/engine.py
+++ b/vivarium/core/engine.py
@@ -123,13 +123,15 @@ def invoke_process(
 
     return process.next_update(interval, states)
 
-def view_values(states):
-        state_values = {}
-        if isinstance(states, Store):
-            return states.get_value()
-        for key, value in states.items():
-            state_values[key] = view_values(value)
-        return state_values
+def view_values(
+        states: dict
+) -> State:
+    state_values = {}
+    if isinstance(states, Store):
+        return states.get_value()
+    for key, value in states.items():
+        state_values[key] = view_values(value)
+    return state_values
 
 class Defer:
     def __init__(
@@ -515,7 +517,7 @@ class Engine:
             Tuple of the deferred update (relative to the root of
             ``path``) and the store at ``path``.
         """
-        if not hasattr(process, 'process_state'):
+        if process.process_state == ():
             store, states = self.process_state(path, process)
             process.process_state = (store, states)
         store = process.process_state[0]
@@ -657,7 +659,7 @@ class Engine:
                 if process_time <= time:
 
                     # get the time step
-                    if not hasattr(process, 'process_state'):
+                    if process.process_state == ():
                         store, states = self.process_state(path, process)
                         process.process_state = (store, states)
                     store = process.process_state[0]

--- a/vivarium/core/engine.py
+++ b/vivarium/core/engine.py
@@ -675,7 +675,6 @@ class Engine:
     def process_state(
             self,
             path: HierarchyPath,
-            process: Process,
     ) -> Tuple[Store, State]:
         """Get the simulation state for a process's ``next_update``.
 
@@ -684,18 +683,18 @@ class Engine:
 
         Args:
             path: Path to the process.
-            process: The process.
 
         Returns:
             Tuple of the store at ``path`` and a collection of state
             variables in the form the process expects.
         """
         store = self.state.get_path(path)
+        assert isinstance(store.value, Process)
 
         # translate the values from the tree structure into the form
         # that this process expects, based on its declared topology
         states = store.topology_view
-        assert states, "store does not have topology_view"
+        assert states, f"store at path {path} does not have a topology_view"
 
         return store, states
 
@@ -716,7 +715,7 @@ class Engine:
             Tuple of the deferred update (relative to the root of
             ``path``) and the store at ``path``.
         """
-        store, states = self.process_state(path, process)
+        store, states = self.process_state(path)
         states = view_values(states)
         if process.update_condition(interval, states):
             return self._process_update(
@@ -878,7 +877,7 @@ class Engine:
                 if process_time <= time:
 
                     # get the time step
-                    store, states = self.process_state(path, process)
+                    store, states = self.process_state(path)
                     states = view_values(states)
                     requested_timestep = process.calculate_timestep(states)
 

--- a/vivarium/core/engine.py
+++ b/vivarium/core/engine.py
@@ -496,7 +496,8 @@ class Engine:
 
         # translate the values from the tree structure into the form
         # that this process expects, based on its declared topology
-        states = store.outer.schema_serialize(process.schema, store.topology)
+        states = store.topology_view
+        assert states, "store does not have topology_view"
 
         return store, states
 

--- a/vivarium/core/process.py
+++ b/vivarium/core/process.py
@@ -115,6 +115,7 @@ class Process(metaclass=abc.ABCMeta):
 
         self.parameters.setdefault('time_step', DEFAULT_TIME_STEP)
         self.schema = None
+        self.process_state: tuple = ()
 
     def initial_state(self, config: Optional[dict] = None) -> State:
         """Get initial state in embedded path dictionary.

--- a/vivarium/core/store.py
+++ b/vivarium/core/store.py
@@ -1274,7 +1274,7 @@ class Store:
         state = {}
 
         if self.leaf:
-            state = self.get_value()
+            state = self
         else:
             for key, subschema in schema.items():
                 path = topology.get(key)

--- a/vivarium/core/store.py
+++ b/vivarium/core/store.py
@@ -10,8 +10,6 @@ import copy
 import logging as log
 from pprint import pformat
 import uuid
-import functools
-import orjson
 
 import numpy as np
 from pint import Quantity
@@ -20,7 +18,7 @@ from typing import Optional
 from vivarium import divider_registry, serializer_registry, updater_registry
 from vivarium.core.process import Process
 from vivarium.library.dict_utils import deep_merge, MULTI_UPDATE_KEY
-from vivarium.library.topology import without, dict_to_paths, get_in
+from vivarium.library.topology import without, dict_to_paths
 from vivarium.core.types import Processes, Topology, State
 
 EMPTY_UPDATES = None, None, None
@@ -218,6 +216,7 @@ class Store:
         self.leaf = False
         self.serializer = None
         self.topology = {}
+        self.topology_view = None
 
         self.apply_config(config, source)
 
@@ -340,6 +339,11 @@ class Store:
             self.value.schema,
             self.topology,
             source=self.path_for())
+
+        # cache the process's view
+        self.topology_view = self.schema_topology(
+            self.value.schema,
+            self.topology)
 
     def independent_store(self, store):
         return self.top() != store.top()
@@ -1277,21 +1281,6 @@ class Store:
                 state[key] = self.get_path(path).get_value()
         return state
 
-    def schema_serialize(self, *args):
-        '''
-        make schema_topology arguments hashable for lru_cache
-        '''
-        args = tuple(orjson.dumps(arg, default=default, option=orjson.OPT_SERIALIZE_NUMPY | orjson.OPT_NON_STR_KEYS) for arg in args)
-        return self.schema_deserialize(args)
-    
-    @functools.lru_cache
-    def schema_deserialize(self, args):
-        '''
-        wrapper around schema_topology to deserialize arguments
-        '''
-        args = tuple(orjson.loads(arg) for arg in args)
-        return self.schema_topology(*args)
-
     def schema_topology(self, schema, topology):
         """
         Fill in the structure of the given schema with the values
@@ -1571,6 +1560,11 @@ class Store:
                     subprocess.schema,
                     subtopology,
                     source=self.path_for() + (key,))
+
+                # cache the process's view after the required states have been generated
+                process_state.topology_view = self.schema_topology(
+                    subprocess.schema,
+                    process_state.topology)
             else:
                 if key not in self.inner:
                     self.inner[key] = Store({}, outer=self)


### PR DESCRIPTION
Profiling of `vivarium-ecoli` revealed that major time savings can be had by reducing the amount of time spent in the `schema_topology` function. One way to accomplish this is by caching the topology so that it does not have to be filled in again for timesteps where it does not change.

Here is a rudimentary caching implementation that only works if the topology never changes. I played around with `functools.lru_cache`, but it doesn't work OOTB because dictionaries are an unhashable type.