### PR TITLE
De/serializer for np.bool_

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,10 @@ out/
 user/*
 !user/user.txt
 *.cprof
+.vscode/*
+Pipfile
+Pipfile.lock
+.env
 
 # Compiled source #
 ###################

--- a/vivarium/core/registry.py
+++ b/vivarium/core/registry.py
@@ -331,6 +331,8 @@ class NumpyScalarSerializer(Serializer):
             return int(data)
         if isinstance(data, (float, np.floating)):
             return float(data)
+        if isinstance(data, (bool, np.bool_)):
+            return bool(data)
         raise ValueError(
             'Cannot serialize numpy scalar {} of type {}.'.format(
                 data, type(data)
@@ -343,6 +345,8 @@ class NumpyScalarSerializer(Serializer):
             return np.int64(data)
         if isinstance(data, float):
             return np.float64(data)
+        if isinstance(data, bool):
+            return np.bool_(data)
         raise ValueError(
             'Cannot deserialize scalar {} of type {}.'.format(
                 data, type(data)

--- a/vivarium/core/serialize.py
+++ b/vivarium/core/serialize.py
@@ -92,7 +92,7 @@ def serialize_value(value: Any) -> Any:
         value = cast(Composer, value)
         return _serialize_dictionary(
             serializer_registry.access('composer').serialize(value))
-    if isinstance(value, (np.integer, np.floating)):
+    if isinstance(value, (np.integer, np.floating, np.bool_)):
         return serializer_registry.access(
             'numpy_scalar').serialize(value)
     if isinstance(value, ObjectId):


### PR DESCRIPTION
When emitting to the MongoDB database, vivarium-core currently does not gracefully handle serialization and deserialization of `np.bool_` objects. This PR fixes that behavior by converting the relevant objects to and from python `bool` objects, which Pymongo natively supports.