### PR TITLE
metadata kwarg for Engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
   * `Store.get_processes()` no longer returns steps (formerly "derivers"). Instead, these are returned by `get_steps()`.
   * Makes `Store.generate_paths()` private (now `Store._generate_paths()`).
   * Adds required `step` and `flow` arguments to `Store.generate()`.
+  * Adds `metadata` argument to `Engine`.
 
 * Fixes a bug where parallel derivers were re-instantiated every timestep.
 * Marks the Store API as experimental, including the public use of `Store.move()`, `Store.insert()`, `Store.divide()`, and `Store.delete()`.

--- a/vivarium/core/engine.py
+++ b/vivarium/core/engine.py
@@ -219,6 +219,7 @@ class Engine:
             initial_state: Optional[State] = None,
             experiment_id: Optional[str] = None,
             experiment_name: Optional[str] = None,
+            metadata: Optional[dict] = None,
             description: str = '',
             emitter: Union[str, dict] = 'timeseries',
             emit_topology: bool = True,
@@ -288,6 +289,7 @@ class Engine:
 
         # display settings
         self.experiment_name = experiment_name or self.experiment_id
+        self.metadata = metadata
         self.description = description
         self.display_info = display_info
         self.progress_bar = progress_bar
@@ -362,6 +364,7 @@ class Engine:
             'experiment_id': self.experiment_id,
             'name': self.experiment_name,
             'description': self.description,
+            'metadata': self.metadata,
             'topology': self.topology
             if self.emit_topology else None,
             'processes': serialize_value(self.processes)

--- a/vivarium/core/engine.py
+++ b/vivarium/core/engine.py
@@ -398,6 +398,8 @@ class Engine:
                 initial state of the simulation.
             experiment_id: A unique identifier for the experiment. A
                 UUID will be generated if none is provided.
+            metadata: A dictionary with additional data about the experiment,
+                which is saved by the emitter with the configuration.
             description: A description of the experiment. A blank string
                 by default.
             emitter: An emitter configuration which must conform to the


### PR DESCRIPTION
A request by @Robotato. This PR adds a `metadata` keyword arg to engine, and emits it in `Engine.emit_configuration`. 