### PR TITLE
Fix Store.generate() to let initial state override _value in schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.4.1
+
+* Fix a bug in `Store.generate()` that caused conflicts between a user-provided initial state and a schema to raise an error instead of the initial state taking priority.
+
 ## v0.4.0
 
 * Replaces `Deriver`s with `Step`s. While derivers were executed sequentially, steps are executed in topological generations according to a dependency graph. This lets some derivers run in parallel. This change mostly preserves backwards-compatibility since `Deriver` is now an alias for `Step`, and we still support legacy derivers that are specified without dependencies. These legacy derivers are executed sequentially before any steps. However, the minor version is incremented because the following public interfaces have changed (though we don't expect this to break dependent code):

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from distutils.core import setup
 _ = setuptools  # don't warn about this unused import; it might have side effects
 
 
-VERSION = '0.4.0'
+VERSION = '0.4.1'
 
 
 if __name__ == '__main__':

--- a/vivarium/core/store.py
+++ b/vivarium/core/store.py
@@ -1859,6 +1859,6 @@ class Store:
         target = self.establish_path(path, {})
         target._generate_paths(processes, flow, topology)
         target._generate_paths(steps, flow, topology)
-        target.generate_value(initial_state)
         target.apply_subschemas()
+        target.generate_value(initial_state)
         target.apply_defaults()


### PR DESCRIPTION
In Engine, we use `vivarium.core.store.generate_state()` to generate `Engine.state`. In vivarium-core==0.3.14, `store.generate_state()` worked like this:

```python
    store = Store({})
    store.generate_paths(processes, topology)
    store.apply_subschemas()
    store.set_value(initial_state)
    store.apply_defaults()
    return store
```

Notice that it applies the subschemas before setting values using `initial_state`.

In vivarium-core==0.4.0, I wanted to make `Store.generate_paths()` private, so I did this instead for `store.generate_state():`

```python
    store = Store({})
    steps = steps or {}
    store.generate(tuple(), processes, steps, flow, topology, initial_state)
    return store
```

I thought that this would work the same way as before, but `Store.generate()` looks like this:

```python
        target = self.establish_path(path, {})
        target._generate_paths(processes, flow, topology)
        target._generate_paths(steps, flow, topology)
        target.generate_value(initial_state)
        target.apply_subschemas()
        target.apply_defaults()
```

Notice that here, we call `generate_value()` before `apply_subschemas()`, which causes errors to be thrown when the initial state conflicts with the schema. 

This PR restores the previous behavior by changing `Store.generate()` to swap `generate_value()` and `apply_subschemas()`. Now anything in initial_state will override anything in the schema.