### PR TITLE
schema_topology * returns self

### DIFF
--- a/vivarium/core/engine.py
+++ b/vivarium/core/engine.py
@@ -715,8 +715,8 @@ class Engine:
             Tuple of the deferred update (relative to the root of
             ``path``) and the store at ``path``.
         """
-        store, states = self.process_state(path)
-        states = view_values(states)
+        store, topology_view = self.process_state(path)
+        states = view_values(topology_view)
         if process.update_condition(interval, states):
             return self._process_update(
                 path, process, store, states, interval)

--- a/vivarium/core/store.py
+++ b/vivarium/core/store.py
@@ -1567,10 +1567,11 @@ class Store:
                             state[child] = child_node.schema_topology(
                                 subschema, path)
                     else:
-                        node = self.get_path(path)
-                        for child, child_node in node.inner.items():
-                            state[child] = child_node.schema_topology(
-                                subschema, {})
+                        state = self
+                        # node = self.get_path(path)
+                        # for child, child_node in node.inner.items():
+                        #     state[child] = child_node.schema_topology(
+                        #         subschema, {})
                 elif key == '_divider':
                     pass
                 elif isinstance(path, dict):

--- a/vivarium/core/store.py
+++ b/vivarium/core/store.py
@@ -1567,11 +1567,10 @@ class Store:
                             state[child] = child_node.schema_topology(
                                 subschema, path)
                     else:
-                        state = self
-                        # node = self.get_path(path)
-                        # for child, child_node in node.inner.items():
-                        #     state[child] = child_node.schema_topology(
-                        #         subschema, {})
+                        node = self.get_path(path)
+                        for child, child_node in node.inner.items():
+                            state[child] = child_node.schema_topology(
+                                subschema, {})
                 elif key == '_divider':
                     pass
                 elif isinstance(path, dict):
@@ -1587,6 +1586,8 @@ class Store:
                         # node is None, it was likely deleted
                         print('{} is None'.format(path))
 
+        if state == {}:
+            state = self
         return state
 
     def state_for(self, path, keys):

--- a/vivarium/core/store.py
+++ b/vivarium/core/store.py
@@ -1549,8 +1549,8 @@ class Store:
 
     def schema_topology(self, schema, topology):
         """
-        Fill in the structure of the given schema with the values
-        located according to the given topology.
+        Fill in the structure of the given schema with the connected stores
+        according to the given topology.
         """
 
         state = {}


### PR DESCRIPTION
This fixes a bug introduced in #96, in which `Store. schema_topology` returned an empty dict if a schema used the glob schema key `'*'`. I solved this by returning `self` instead of `{}`, so that the engine could use `view_values` to access the inner states.