### PR TITLE
dictionary updater

### DIFF
--- a/vivarium/__init__.py
+++ b/vivarium/__init__.py
@@ -38,9 +38,9 @@ from vivarium.processes.mass_adaptor import (
 # import updaters, dividers, serializers
 from vivarium.core.registry import (
     update_accumulate, update_set, update_merge, update_null,
-    update_nonnegative_accumulate, divide_set, divide_split,
-    divide_split_dict, divide_zero, assert_no_divide, divide_binomial,
-    divide_set_value,
+    update_nonnegative_accumulate, update_dictionary,
+    divide_set, divide_split, divide_split_dict, divide_zero,
+    assert_no_divide, divide_binomial, divide_set_value,
     NumpySerializer, NumpyScalarSerializer, UnitsSerializer,
     ProcessSerializer, ComposerSerializer, FunctionSerializer,
 )
@@ -77,6 +77,7 @@ updater_registry.register('null', update_null)
 updater_registry.register('merge', update_merge)
 updater_registry.register(
     'nonnegative_accumulate', update_nonnegative_accumulate)
+updater_registry.register('dict_value', update_dictionary)
 
 # register dividers
 divider_registry.register('binomial', divide_binomial)

--- a/vivarium/core/registry.py
+++ b/vivarium/core/registry.py
@@ -178,6 +178,33 @@ def update_nonnegative_accumulate(current_value, new_value):
         return 0 * updated_value
 
 
+def update_dictionary(current, update):
+    """Dictionary Updater
+    Updater that translates _add and _delete -style updates
+    into operations on a dictionary.
+
+    Expects current to be a dictionary, with no restriction on the types of objects
+    stored within it, and no defaults. For enforcing expectations/defaults, try
+    make_dict_value_updater(**defaults).
+    """
+    result = current
+
+    for key, value in update.items():
+        if key == "_add":
+            for added_value in value:
+                added_key = added_value["key"]
+                added_state = added_value["state"]
+                result[added_key] = added_state
+        elif key == "_delete":
+            for k in value:
+                del result[k]
+        elif key in result:
+            result[key].update(value)
+        else:
+            raise Exception(f"Invalid dict_value_updater key: {key}")
+    return result
+
+
 # Divider functions
 def divide_set(state):
     """Set Divider

--- a/vivarium/core/registry.py
+++ b/vivarium/core/registry.py
@@ -184,8 +184,7 @@ def update_dictionary(current, update):
     into operations on a dictionary.
 
     Expects current to be a dictionary, with no restriction on the types of objects
-    stored within it, and no defaults. For enforcing expectations/defaults, try
-    make_dict_value_updater(**defaults).
+    stored within it, and no defaults values.
     """
     result = current
 


### PR DESCRIPTION
This copies over the `dictionary_updater` developed in vivarium-ecoli by @thalassemia and @Robotato. This new updater translates `'_add'` and `'_delete'` -style updates into operations on a dictionary.