### PR TITLE
Fix topology_view errors found in vivarium-notebooks

### DIFF
--- a/vivarium/composites/toys.py
+++ b/vivarium/composites/toys.py
@@ -122,6 +122,27 @@ class ToyDeath(Process):
         return update
 
 
+class ToyEnvironment(Process):
+    def __init__(self, parameters=None):
+        super().__init__(parameters)
+    def ports_schema(self):
+        return {
+            'agents': {
+                '*': {
+                    'internal': {'_default': {}},
+                    'external': {'_default': {}},
+                    'membrane': {'_default': {}},
+                }
+            }
+        }
+    def next_update(self, timestep, state):
+        agents = state['agents']
+
+        import ipdb; ipdb.set_trace()
+
+        return {}
+
+
 class ToyCompartment(Composer):
     '''
     a toy compartment for testing

--- a/vivarium/composites/toys.py
+++ b/vivarium/composites/toys.py
@@ -123,24 +123,30 @@ class ToyDeath(Process):
 
 
 class ToyEnvironment(Process):
+    port_ids = ['external', 'membrane']
     def __init__(self, parameters=None):
         super().__init__(parameters)
     def ports_schema(self):
         return {
             'agents': {
                 '*': {
-                    'internal': {'_default': {}},
-                    'external': {'_default': {}},
-                    'membrane': {'_default': {}},
+                    port_id: {
+                        '_default': {}
+                    } for port_id in self.port_ids
                 }
             }
         }
     def next_update(self, timestep, state):
         agents = state['agents']
 
+        agents_update = {}
+        for agent_id, agent_state in agents.items():
+            assert set(agent_state.keys()) == set(self.port_ids), 'view is getting states not in ports_schema'
+            agents_update[agent_id]['external'] = 1
+
         import ipdb; ipdb.set_trace()
 
-        return {}
+        return {'agents': agents_update}
 
 
 class ToyCompartment(Composer):

--- a/vivarium/composites/toys.py
+++ b/vivarium/composites/toys.py
@@ -125,9 +125,6 @@ class ToyDeath(Process):
 class ToyEnvironment(Process):
     port_ids = ['external', 'membrane']
 
-    def __init__(self, parameters=None):
-        super().__init__(parameters)
-
     def ports_schema(self):
         return {
             'agents': {
@@ -139,12 +136,13 @@ class ToyEnvironment(Process):
             }
         }
 
-    def next_update(self, timestep, state):
-        agents = state['agents']
+    def next_update(self, timestep, states):
+        agents = states['agents']
 
         agents_update = {}
         for agent_id, agent_state in agents.items():
-            assert set(agent_state.keys()) == set(self.port_ids), 'view is getting states not in ports_schema'
+            assert set(agent_state.keys()) == set(self.port_ids), \
+                'view is getting states not in ports_schema'
             agents_update[agent_id] = {}
             agents_update[agent_id]['external'] = 1
 

--- a/vivarium/composites/toys.py
+++ b/vivarium/composites/toys.py
@@ -124,27 +124,29 @@ class ToyDeath(Process):
 
 class ToyEnvironment(Process):
     port_ids = ['external', 'membrane']
+
     def __init__(self, parameters=None):
         super().__init__(parameters)
+
     def ports_schema(self):
         return {
             'agents': {
                 '*': {
                     port_id: {
-                        '_default': {}
+                        '_default': 0.0
                     } for port_id in self.port_ids
                 }
             }
         }
+
     def next_update(self, timestep, state):
         agents = state['agents']
 
         agents_update = {}
         for agent_id, agent_state in agents.items():
             assert set(agent_state.keys()) == set(self.port_ids), 'view is getting states not in ports_schema'
+            agents_update[agent_id] = {}
             agents_update[agent_id]['external'] = 1
-
-        import ipdb; ipdb.set_trace()
 
         return {'agents': agents_update}
 

--- a/vivarium/core/composer.py
+++ b/vivarium/core/composer.py
@@ -32,7 +32,10 @@ def _get_composite_state(
     initial_state = initial_state or {}
     config = config or {}
 
-    processes = copy.deepcopy(processes)
+    try:
+        processes = copy.deepcopy(processes)
+    except Exception as e:
+        print(e)
     deep_merge_check(processes, steps)
 
     for key, node in processes.items():

--- a/vivarium/core/composer.py
+++ b/vivarium/core/composer.py
@@ -34,7 +34,7 @@ def _get_composite_state(
 
     try:
         processes = copy.deepcopy(processes)
-    except Exception as e:
+    except TypeError as e:
         print(e)
     deep_merge_check(processes, steps)
 

--- a/vivarium/core/engine.py
+++ b/vivarium/core/engine.py
@@ -1786,14 +1786,19 @@ def test_runtime_order() -> None:
 
 def test_glob_schema():
     processes = {
-        'agents': {'0': ToyTransport()},
+        'agents': {'0': {'transport': ToyTransport()}},
         'environment': ToyEnvironment()}
     topology = {
-        'environment': {'agents': ('agents',)},
+        'environment': {
+            'agents': {
+                '_path': ('agents',),
+                '*': {
+                    'external': ('external', 'GLC')}}},
         'agents': {
             '0': {
-                'internal': ('internal',),
-                'external': ('external',)}}}
+                'transport': {
+                    'internal': ('internal',),
+                    'external': ('external',)}}}}
     experiment = Engine(
         processes=processes,
         topology=topology)
@@ -1802,7 +1807,8 @@ def test_glob_schema():
     # declare processes in reverse order
     processes_reverse = {
         'environment': ToyEnvironment(),
-        'agents': {'0': ToyTransport()}}
+        'agents': {'0': {'transport': ToyTransport()}}}
+
     experiment_reverse = Engine(
         processes=processes_reverse,
         topology=topology)

--- a/vivarium/core/engine.py
+++ b/vivarium/core/engine.py
@@ -1808,6 +1808,19 @@ def test_glob_schema():
     )
     experiment.update(10)
 
+    # declare processes in reverse order
+    processes_reverse = {
+        'environment': ToyEnvironment(),
+        'agents': {
+            '0': ToyTransport(),
+        },
+    }
+    experiment = Engine(
+        processes=processes_reverse,
+        topology=topology,
+    )
+    experiment.update(10)
+
 
 if __name__ == '__main__':
     # test_recursive_store()

--- a/vivarium/core/engine.py
+++ b/vivarium/core/engine.py
@@ -1786,40 +1786,27 @@ def test_runtime_order() -> None:
 
 def test_glob_schema():
     processes = {
-        'agents': {
-            '0': ToyTransport(),
-        },
-        'environment': ToyEnvironment(),
-    }
+        'agents': {'0': ToyTransport()},
+        'environment': ToyEnvironment()}
     topology = {
-        'environment': {
-            'agents': ('agents',)
-        },
+        'environment': {'agents': ('agents',)},
         'agents': {
             '0': {
                 'internal': ('internal',),
-                'external': ('external',),
-            }
-        }
-    }
+                'external': ('external',)}}}
     experiment = Engine(
         processes=processes,
-        topology=topology,
-    )
+        topology=topology)
     experiment.update(10)
 
     # declare processes in reverse order
     processes_reverse = {
         'environment': ToyEnvironment(),
-        'agents': {
-            '0': ToyTransport(),
-        },
-    }
-    experiment = Engine(
+        'agents': {'0': ToyTransport()}}
+    experiment_reverse = Engine(
         processes=processes_reverse,
-        topology=topology,
-    )
-    experiment.update(10)
+        topology=topology)
+    experiment_reverse.update(10)
 
 
 if __name__ == '__main__':

--- a/vivarium/core/engine.py
+++ b/vivarium/core/engine.py
@@ -20,7 +20,8 @@ import warnings
 
 import networkx as nx
 
-from vivarium.composites.toys import Proton, Electron, Sine, PoQo, ToyDivider
+from vivarium.composites.toys import (
+    Proton, Electron, Sine, PoQo, ToyDivider, ToyEnvironment, ToyTransport)
 from vivarium.core.store import hierarchy_depth, Store, generate_state
 from vivarium.core.emitter import get_emitter
 from vivarium.core.process import (
@@ -1783,6 +1784,31 @@ def test_runtime_order() -> None:
             assert set(group) == expected_group
 
 
+def test_glob_schema():
+    processes = {
+        'agents': {
+            '0': ToyTransport(),
+        },
+        'environment': ToyEnvironment(),
+    }
+    topology = {
+        'environment': {
+            'agents': ('agents',)
+        },
+        'agents': {
+            '0': {
+                'internal': ('internal',),
+                'external': ('external',),
+            }
+        }
+    }
+    experiment = Engine(
+        processes=processes,
+        topology=topology,
+    )
+    experiment.update(10)
+
+
 if __name__ == '__main__':
     # test_recursive_store()
     # test_timescales()
@@ -1794,5 +1820,6 @@ if __name__ == '__main__':
     # test_multi_port_merge()
     # test_2_store_1_port()
     # test_units()
-    test_custom_divider()
+    # test_custom_divider()
     # test_runtime_order()
+    test_glob_schema()

--- a/vivarium/core/engine.py
+++ b/vivarium/core/engine.py
@@ -1784,7 +1784,7 @@ def test_runtime_order() -> None:
             assert set(group) == expected_group
 
 
-def test_glob_schema():
+def test_glob_schema() -> None:
     processes = {
         'agents': {'0': {'transport': ToyTransport()}},
         'environment': ToyEnvironment()}

--- a/vivarium/core/types.py
+++ b/vivarium/core/types.py
@@ -13,7 +13,7 @@ HierarchyPath = Tuple[str, ...]
 
 #: Mapping from :term:`ports` to paths that specify which node in the
 #: :term:`hierarchy` should be wired to each port.
-Topology = Dict[str, Union[HierarchyPath, dict]]
+Topology = Dict[str, Union[HierarchyPath, dict, object]]
 
 #: Mapping from processes names to Processes, which can be embedded in
 #: a hierarchy.

--- a/vivarium/library/topology.py
+++ b/vivarium/library/topology.py
@@ -164,7 +164,6 @@ def inverse_topology(outer, update, topology, inverse=None):
 
     for key, path in topology.items():
         if key == '*':
-
             if isinstance(path, dict):
                 node = inverse
                 if '_path' in path:
@@ -199,7 +198,7 @@ def inverse_topology(outer, update, topology, inverse=None):
                     path = without(path, '_path')
 
                     for update_key in update[key].keys():
-                        if update_key not in path:
+                        if update_key not in path and '*' not in path:
                             path[update_key] = (update_key,)
                 else:
                     inner = outer


### PR DESCRIPTION
This PR isolates and aims to fix some errors found in vivarium-notebooks resulting from the `Store.topology_view` caching introduced in #96.