### PR TITLE
Initial state is not modified when dividing cell.

### DIFF
--- a/vivarium/core/registry.py
+++ b/vivarium/core/registry.py
@@ -58,7 +58,7 @@ the variables in each of the daughter cells.
     For example, a divider splitting an odd, integer-valued value may
     randomly decide which daughter cell receives the remainder.
 """
-
+import copy
 import random
 
 import numpy as np
@@ -129,7 +129,7 @@ def update_merge(current_value, new_value):
     for k, v in current_value.items():
         new = new_value.get(k)
         if isinstance(new, dict):
-            update[k] = deep_merge(dict(v), new)
+            update[k] = deep_merge(copy.deepcopy(v), new)
         else:
             update[k] = new
     return update

--- a/vivarium/core/store.py
+++ b/vivarium/core/store.py
@@ -1227,8 +1227,8 @@ class Store:
         for daughter, daughter_state in \
                 zip(daughters, daughter_states):
             # use initial state as default, merge in divided values
-            initial_state = deep_merge(
-                initial_state,
+            merged_initial_state = deep_merge(
+                copy.deepcopy(initial_state),
                 daughter_state)
 
             daughter_key = daughter['key']
@@ -1268,7 +1268,7 @@ class Store:
                 {},
                 flow,
                 topology,
-                initial_state)
+                merged_initial_state)
 
             root = here + daughter_path
             process_paths = dict_to_paths(root, processes)
@@ -1285,7 +1285,7 @@ class Store:
             self.apply_subschema_path(daughter_path)
             target = self.get_path(daughter_path)
             target.apply_defaults()
-            target.set_value(initial_state)
+            target.set_value(merged_initial_state)
 
 
         self.delete_path(mother_path)

--- a/vivarium/library/dict_utils.py
+++ b/vivarium/library/dict_utils.py
@@ -26,7 +26,7 @@ def deep_merge_check(dct, merge_dct):
 
     Throws exceptions for conflicting values.
     This mutates dct - the contents of merge_dct are added to dct (which is also returned).
-    If you want to keep dct you could call it like deep_merge(dict(dct), merge_dct)
+    If you want to keep dct you could call it like deep_merge_check(copy.deepcopy(dct), merge_dct)
     """
 
     for k, v in merge_dct.items():
@@ -48,7 +48,7 @@ def deep_merge_combine_lists(dct, merge_dct):
 
     Values that are lists are combined into one list without repeating values.
     This mutates dct - the contents of merge_dct are added to dct (which is also returned).
-    If you want to keep dct you could call it like deep_merge(dict(dct), merge_dct)
+    If you want to keep dct you could call it like deep_merge_combine_lists(copy.deepcopy(dct), merge_dct)
     """
     for k, v in merge_dct.items():
         if (k in dct and isinstance(dct[k], dict)
@@ -106,7 +106,7 @@ def deep_merge(dct, merge_dct):
     """ Recursive dict merge
 
     This mutates dct - the contents of merge_dct are added to dct (which is also returned).
-    If you want to keep dct you could call it like deep_merge(dict(dct), merge_dct)
+    If you want to keep dct you could call it like deep_merge(copy.deepcopy(dct), merge_dct)
     """
     if dct is None:
         dct = {}


### PR DESCRIPTION
When applying the divided values of both daughter cells to the default `initial_state` to get the new initial states, we were modifying `initial_state` in place, making it so the daughters shared the same dictionaries in memory for their values even when they had different stores. To get around this, I used `copy.deepcopy(initial_state)` since `dict(initial_state)`, which is recommended by the `deep_merge` function definition, is only a shallow copy, and thus creates the same issue of shared dictionaries.