### PR TITLE
add/delete test and view caching

### DIFF
--- a/vivarium/core/store.py
+++ b/vivarium/core/store.py
@@ -1409,6 +1409,7 @@ class Store:
                 # add a list of sub-states
                 for added in add_entries:
                     self.add(added)
+                view_expire = True
 
             move_entries = update.pop('_move', None)
             if move_entries is not None:
@@ -1480,6 +1481,7 @@ class Store:
                 for key in delete_keys:
                     delete_deletions = self.delete(key, here)
                     deletions.extend(delete_deletions)
+                view_expire = True
 
             return (
                 topology_updates, process_updates, step_updates,

--- a/vivarium/experiments/engine_tests.py
+++ b/vivarium/experiments/engine_tests.py
@@ -884,11 +884,10 @@ class AddDelete(Process):
             self, timestep: Union[float, int], states: State) -> Update:
         sub_stores = set(states['sub_stores'].keys())
         expected = set(states['expected'])
-
-        assert sub_stores == expected, f"stores don't match expected"
+        assert sub_stores == expected, "stores don't match expected"
 
         # delete current stores, and add the same number of stores
-        sub_stores_update = {
+        sub_stores_update: dict = {
             '_delete': [],
             '_add': []}
         new_sub_stores = []
@@ -905,8 +904,7 @@ class AddDelete(Process):
         }
 
 
-def test_add_delete():
-
+def test_add_delete() -> None:
     process = AddDelete()
     topology = {
         'sub_stores': ('sub_stores',),


### PR DESCRIPTION
`'_add'` and `'_delete'` updates also need to trigger the `view_expire` flag introduced in #109. This PR also adds `test_add_delete` to make sure expected will be maintained.