### PR TITLE
Let Vivarium Engine Profile (including parallel processes)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v0.4.8
+
+* Add `profile` argument to the `Engine` constructor. When this argument is set to `True`, the simulation, including any parallel processes, will be profiled by `cProfile`. Once `Engine.end()` is called, the profile stats will be saved to `Engine.stats` for analysis.
 
 ## v0.4.7
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from distutils.core import setup
 _ = setuptools  # don't warn about this unused import; it might have side effects
 
 
-VERSION = '0.4.7'
+VERSION = '0.4.8'
 
 
 if __name__ == '__main__':

--- a/vivarium/core/engine.py
+++ b/vivarium/core/engine.py
@@ -420,6 +420,7 @@ class Engine:
                 processes, topology, and initial state.
             profile: Whether to profile the simulation with cProfile.
         """
+        self.profiler: Optional[cProfile.Profile] = None
         if profile:
             self.profiler = cProfile.Profile()
             self.profiler.enable()

--- a/vivarium/core/process.py
+++ b/vivarium/core/process.py
@@ -400,7 +400,7 @@ def _run_update(
     if profile:
         profiler.disable()
         stats = pstats.Stats(profiler)
-        connection.send(stats.stats)
+        connection.send(stats.stats)  # type: ignore
 
     connection.close()
 
@@ -457,5 +457,5 @@ class ParallelProcess:
         self.parent.send((-1, None))
         if self.profile:
             self.stats = pstats.Stats()
-            self.stats.stats = self.parent.recv()
+            self.stats.stats = self.parent.recv()  # type: ignore
         self.multiprocess.join()

--- a/vivarium/experiments/test_profiler.py
+++ b/vivarium/experiments/test_profiler.py
@@ -1,0 +1,57 @@
+import time
+
+from vivarium.core.engine import Engine
+from vivarium.core.process import Process
+
+
+class ProcessA(Process):
+
+    defaults = {
+        'sleep': 2,
+    }
+
+    def ports_schema(self):
+        return {}
+
+    def next_update(self, timestep, states):
+        time.sleep(self.parameters['sleep'])
+        return {}
+
+
+class ProcessB(Process):
+
+    defaults = {
+        'sleep': 1,
+        '_parallel': True,
+    }
+
+    def ports_schema(self):
+        return {}
+
+    def next_update(self, timestep, states):
+        time.sleep(self.parameters['sleep'])
+        return {}
+
+
+def test_profiler():
+    engine = Engine(
+        processes={
+            'processA': ProcessA(),
+            'processB': ProcessB(),
+        },
+        topology={
+            'processA': {},
+            'processB': {},
+        },
+        profile=True,
+    )
+    engine.update(3)
+    engine.end()
+    stats = engine.stats.strip_dirs()
+    process_a_runtime = stats.stats[
+        ('test_profiler.py', 16, 'next_update')][3]
+    process_b_runtime = stats.stats[
+        ('test_profiler.py', 31, 'next_update')][3]
+
+    assert 6 <= process_a_runtime <= 6.1
+    assert 3 <= process_b_runtime <= 3.1

--- a/vivarium/experiments/test_profiler.py
+++ b/vivarium/experiments/test_profiler.py
@@ -51,9 +51,9 @@ def test_profiler() -> None:
     assert engine.stats is not None
     stats = engine.stats.strip_dirs()
     process_a_runtime = stats.stats[  # type: ignore
-        ('test_profiler.py', 16, 'next_update')][3]
+        ('test_profiler.py', 17, 'next_update')][3]
     process_b_runtime = stats.stats[  # type: ignore
-        ('test_profiler.py', 31, 'next_update')][3]
+        ('test_profiler.py', 32, 'next_update')][3]
 
     assert 6 <= process_a_runtime <= 6.1
     assert 3 <= process_b_runtime <= 3.1

--- a/vivarium/experiments/test_profiler.py
+++ b/vivarium/experiments/test_profiler.py
@@ -2,6 +2,7 @@ import time
 
 from vivarium.core.engine import Engine
 from vivarium.core.process import Process
+from vivarium.core.types import Schema, State, Update
 
 
 class ProcessA(Process):
@@ -10,10 +11,10 @@ class ProcessA(Process):
         'sleep': 2,
     }
 
-    def ports_schema(self):
+    def ports_schema(self) -> Schema:
         return {}
 
-    def next_update(self, timestep, states):
+    def next_update(self, timestep: float, states: State) -> Update:
         time.sleep(self.parameters['sleep'])
         return {}
 
@@ -25,15 +26,15 @@ class ProcessB(Process):
         '_parallel': True,
     }
 
-    def ports_schema(self):
+    def ports_schema(self) -> Schema:
         return {}
 
-    def next_update(self, timestep, states):
+    def next_update(self, timestep: float, states: State) -> Update:
         time.sleep(self.parameters['sleep'])
         return {}
 
 
-def test_profiler():
+def test_profiler() -> None:
     engine = Engine(
         processes={
             'processA': ProcessA(),
@@ -47,10 +48,11 @@ def test_profiler():
     )
     engine.update(3)
     engine.end()
+    assert engine.stats is not None
     stats = engine.stats.strip_dirs()
-    process_a_runtime = stats.stats[
+    process_a_runtime = stats.stats[  # type: ignore
         ('test_profiler.py', 16, 'next_update')][3]
-    process_b_runtime = stats.stats[
+    process_b_runtime = stats.stats[  # type: ignore
         ('test_profiler.py', 31, 'next_update')][3]
 
     assert 6 <= process_a_runtime <= 6.1


### PR DESCRIPTION
If you set `profile=True` in the `Engine` constructor, then when you call `Engine.end()`, Vivarium will compute profile statistics and store them in `Engine.stats` for you to analyze. The Engine also profiles parallel processes and includes those stats in `Engine.stats`, giving you a full picture of what's taking up runtime in your simulation.

See `vivarium/experiments/test_profile.py` for an example of how to use this.