### PR TITLE
Fix version for parallel profile PR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v0.4.8
+## v0.4.9
 
 * Add `profile` argument to the `Engine` constructor. When this argument is set to `True`, the simulation, including any parallel processes, will be profiled by `cProfile`. Once `Engine.end()` is called, the profile stats will be saved to `Engine.stats` for analysis.
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from distutils.core import setup
 _ = setuptools  # don't warn about this unused import; it might have side effects
 
 
-VERSION = '0.4.8'
+VERSION = '0.4.9'
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
When I bumped the version in #113, I missed that the version had already been bumped to v0.4.8 by another PR. This PR fixes my mistake by bumping the version up again to v0.4.9