### PR TITLE
expire and recache topology_views after Engine.apply_update

### DIFF
--- a/vivarium/composites/toys.py
+++ b/vivarium/composites/toys.py
@@ -833,9 +833,7 @@ class ToyDividerProcess(Process):
 
     def next_update(self, timestep, states):
         x = states['variable']['x']
-        # print(x, self.parameters['x_division_threshold'])
         if x > self.parameters['x_division_threshold']:
-            # print('DIVIDE!')
             daughter_ids = [
                 str(self.agent_id) + '0',
                 str(self.agent_id) + '1']

--- a/vivarium/composites/toys.py
+++ b/vivarium/composites/toys.py
@@ -877,9 +877,6 @@ class ToyDivider(Composer):
     defaults: Dict[str, Any] = {
         'divider': {'name': 'divider'}}
 
-    def __init__(self, config=None):
-        super().__init__(config)
-
     def generate_processes(self, config):
         agent_id = config['agent_id']
         division_config = dict(

--- a/vivarium/composites/toys.py
+++ b/vivarium/composites/toys.py
@@ -801,14 +801,17 @@ def test_aggregate_composer() -> None:
 
 
 
-def split_divider(value, config):
-    return [value * config['fraction']] * 2
+def split_divider_int(value, config):
+    return [int(value * config['fraction'])] * 2
 
 
 class ToyDividerProcess(Process):
     defaults = {
-        'x_fraction': 0.5,
-        'x_division_threshold': 10}
+        'name': 'divider',
+        'x_growth': 1,
+        'x_division_fraction': 0.5,
+        'x_division_threshold': 10,
+    }
     def __init__(self, parameters = None):
         super().__init__(parameters)
         self.agent_id = self.parameters['agent_id']
@@ -821,24 +824,29 @@ class ToyDividerProcess(Process):
                     '_default': 0,
                     '_emit': True,
                     '_divider': {
-                        'divider': split_divider,
+                        'divider': split_divider_int,
                         'config': {
-                            'fraction': self.parameters['x_fraction']}
+                            'fraction': self.parameters['x_division_fraction']}
                     }
                 }},
             'agents': {'*': {}}}
     def next_update(self, timestep, states):
         x = states['variable']['x']
+        # print(x, self.parameters['x_division_threshold'])
         if x > self.parameters['x_division_threshold']:
+            # print('DIVIDE!')
             daughter_ids = [
                 str(self.agent_id) + '0',
                 str(self.agent_id) + '1']
             divide_update = get_divide_update(
                 self.composer,
                 self.agent_id,
-                daughter_ids)
+                daughter_ids,
+                composer_config={
+                    self.parameters['name']: self.parameters},
+            )
             return {'agents': divide_update}
-        return {'variable': {'x': 1}}
+        return {'variable': {'x': self.parameters['x_growth']}}
 
 
 class ToyDividerStep(Step):
@@ -865,9 +873,10 @@ class ToyDividerStep(Step):
 
 
 class ToyDivider(Composer):
-    defaults: Dict[str, Any] = {'divider': {}}
+    defaults: Dict[str, Any] = {
+        'divider': {'name': 'divider'}}
 
-    def __init__(self, config):
+    def __init__(self, config=None):
         super().__init__(config)
 
     def generate_processes(self, config):

--- a/vivarium/composites/toys.py
+++ b/vivarium/composites/toys.py
@@ -829,7 +829,8 @@ class ToyDividerProcess(Process):
                             'fraction': self.parameters['x_division_fraction']}
                     }
                 }},
-            'agents': {'*': {}}}
+            'agents': {}}
+
     def next_update(self, timestep, states):
         x = states['variable']['x']
         # print(x, self.parameters['x_division_threshold'])

--- a/vivarium/core/control.py
+++ b/vivarium/core/control.py
@@ -256,11 +256,11 @@ def _parse_options(
         str_value: str = p[1]
         value: Any = None
         if str_value.isdigit():
-            value = int(value)
+            value = int(str_value)
         elif is_float(str_value):
-            value = float(value)
+            value = float(str_value)
         elif str_value in ['True', 'False']:
-            value = bool(value)
+            value = bool(str_value)
         else:
             value = str_value
         options[key] = value
@@ -293,10 +293,12 @@ def run_library_cli(library: dict, args: Optional[list] = None) -> None:
 
 
 def test_library_cli() -> None:
-    def run_fun() -> dict:
-        return {}
+    def run_fun(key: Any = False) -> dict:
+        return {'key': key}
     lib = {'1': run_fun}
-    run_library_cli(lib, args=['-n', '1'])
+    run_library_cli(lib, args=['-n', '1', '-o', 'key=True'])
+    run_library_cli(lib, args=['-n', '1', '-o', 'key=0.2'])
+    run_library_cli(lib, args=['-n', '1', '-o', 'key=b'])
 
 
 def test_control() -> None:
@@ -306,5 +308,12 @@ def test_control() -> None:
     control.run_workflow('1')
 
 
+fun_lib = {
+    '0': test_library_cli,
+    '1': test_control,
+}
+
+
+# python vivarium/core/control.py -n [test number]
 if __name__ == '__main__':
-    test_control()  # pragma: no cover
+    run_library_cli(fun_lib)

--- a/vivarium/core/engine.py
+++ b/vivarium/core/engine.py
@@ -21,7 +21,8 @@ import uuid
 
 import networkx as nx
 
-from vivarium.core.store import hierarchy_depth, Store, generate_state, view_values
+from vivarium.core.store import (
+    hierarchy_depth, Store, generate_state, view_values)
 from vivarium.core.emitter import get_emitter
 from vivarium.core.process import (
     Process,
@@ -692,7 +693,8 @@ class Engine:
         # translate the values from the tree structure into the form
         # that this process expects, based on its declared topology
         topology_view = store.topology_view
-        assert topology_view is not None, f"store at path {path} does not have a topology_view"
+        assert topology_view is not None, \
+            f"store at path {path} does not have a topology_view"
         states = view_values(topology_view)
 
         return store, states

--- a/vivarium/core/engine.py
+++ b/vivarium/core/engine.py
@@ -743,8 +743,7 @@ class Engine:
                 the "perspective" from which the update was generated.
 
         Return:
-            view_expire: a bool indicating whether the topology_views
-                expired.
+            a bool indicating whether the topology_views expired.
         """
 
         if not update:

--- a/vivarium/core/engine.py
+++ b/vivarium/core/engine.py
@@ -692,7 +692,7 @@ class Engine:
         # translate the values from the tree structure into the form
         # that this process expects, based on its declared topology
         topology_view = store.topology_view
-        assert topology_view, f"store at path {path} does not have a topology_view"
+        assert topology_view is not None, f"store at path {path} does not have a topology_view"
         states = view_values(topology_view)
 
         return store, states

--- a/vivarium/core/engine.py
+++ b/vivarium/core/engine.py
@@ -748,7 +748,7 @@ class Engine:
         """
 
         if not update:
-            return
+            return False
 
         (
             topology_updates, process_updates, step_updates,

--- a/vivarium/core/store.py
+++ b/vivarium/core/store.py
@@ -981,7 +981,7 @@ class Store:
         Apply the divider for each node to the value in that node to
         assemble two parallel divided states of this subtree.
         """
-
+        deepcopy_state = False
         if self.divider:
             # divider is either a function or a dict with topology and/or config
             if isinstance(self.divider, dict):
@@ -989,24 +989,29 @@ class Store:
                 if isinstance(divider, str):
                     divider = divider_registry.access(divider)
                 args = {}
+
                 if 'topology' in self.divider:
                     topology = self.divider['topology']
                     args.update({'state': self.topology_state(topology)})
                 if 'config' in self.divider:
                     config = self.divider['config']
                     args.update({'config': config})
+                if self.divider.get('deepcopy_state'):
+                    deepcopy_state = True
+                return divider(self.get_value(), **args), deepcopy_state
 
-                return divider(self.get_value(), **args)
-            return self.divider(self.get_value())
+            return self.divider(self.get_value()), deepcopy_state
+
         if self.inner:
             daughters = [{}, {}]
             for key, child in self.inner.items():
-                division = child.divide_value()
+                division, child_deepcopy_state = child.divide_value()
+                deepcopy_state = deepcopy_state or child_deepcopy_state
                 if division:
                     for daughter, divide in zip(daughters, division):
                         daughter[key] = divide
-            return daughters
-        return None
+            return daughters, deepcopy_state
+        return None, deepcopy_state
 
     def reduce(self, reducer, initial=None):
         """
@@ -1220,16 +1225,21 @@ class Store:
             condition=lambda child: not
             (isinstance(child.value, Process)),
             f=lambda child: copy.deepcopy(child))
-        daughter_states = self.inner[mother].divide_value()
+        daughter_states, deepcopy_state = self.inner[mother].divide_value()
 
         here = self.path_for()
 
         for daughter, daughter_state in \
                 zip(daughters, daughter_states):
             # use initial state as default, merge in divided values
-            merged_initial_state = deep_merge(
-                copy.deepcopy(initial_state),
-                daughter_state)
+            if daughter_states:
+                merged_initial_state = deep_merge(
+                    copy.deepcopy(initial_state),
+                    daughter_state)
+            else:
+                merged_initial_state = deep_merge(
+                    dict(initial_state),
+                    daughter_state)
 
             daughter_key = daughter['key']
             daughter_path = (daughter_key,)

--- a/vivarium/core/store.py
+++ b/vivarium/core/store.py
@@ -50,6 +50,17 @@ def generate_state(
     return store
 
 
+def view_values(
+        states: dict
+) -> State:
+    state_values = {}
+    if isinstance(states, Store):
+        return states.get_value()
+    for key, value in states.items():
+        state_values[key] = view_values(value)
+    return state_values
+
+
 def key_for_value(d, looking):
     """Get the key associated with a value in a dictionary.
 

--- a/vivarium/core/store.py
+++ b/vivarium/core/store.py
@@ -1608,8 +1608,6 @@ class Store:
                         # node is None, it was likely deleted
                         print('{} is None'.format(path))
 
-        if state == {}:
-            state = self
         return state
 
     def state_for(self, path, keys):

--- a/vivarium/experiments/engine_tests.py
+++ b/vivarium/experiments/engine_tests.py
@@ -4,12 +4,13 @@ from typing import Optional, Union, Dict, Any, cast, List
 
 from vivarium.composites.toys import (
     PoQo, Sine, ToyDivider, ToyTransport, ToyEnvironment,
-    Proton, Electron, )
+    Proton, Electron)
 from vivarium.core.composer import Composer, Composite
 from vivarium.core.engine import Engine, pf, pp, _StepGraph
 from vivarium.core.process import Process, Step, Deriver
 from vivarium.core.store import Store, hierarchy_depth
-from vivarium.core.types import Schema, State, Update, Topology, Steps
+from vivarium.core.types import (
+    Schema, State, Update, Topology, Steps, Processes)
 from vivarium.library.units import units
 from vivarium.library.wrappers import make_logging_process
 from vivarium.core.control import run_library_cli
@@ -944,7 +945,7 @@ def test_add_delete() -> None:
             assert len(set(current_ids).intersection(set(next_ids))) == 0
 
 
-def test_hyperdivision(profile: bool = True) -> None:
+def test_hyperdivision(profile: bool = False) -> None:
     total_time = 10
     n_agents = 100
     division_thresholds = [3, 4, 5, 6, 7]  # what values of x triggers division?
@@ -969,7 +970,7 @@ def test_hyperdivision(profile: bool = True) -> None:
         composite.merge(agent_composite)
 
     # add an environment
-    environment_process = {'environment': ToyEnvironment()}
+    environment_process: Processes = {'environment': ToyEnvironment()}
     environment_topology: Topology = {
         'environment': {
             'agents': {
@@ -1001,10 +1002,12 @@ def test_hyperdivision(profile: bool = True) -> None:
 
     print(f"n agents initial: {n_agents}")
     print(f"n agents final: {len(data[total_time]['agents'].keys())}")
-    if profile:
-        stats = experiment.stats
-        stats.strip_dirs().sort_stats('cumulative', 'cumtime').print_stats(20)
-        # import ipdb; ipdb.set_trace()
+
+    assert len(data[total_time]['agents'].keys()) >  n_agents
+    # if profile:
+    #     stats = experiment.stats
+    #     stats.strip_dirs().sort_stats(
+    #         'cumulative', 'cumtime').print_stats(20)
 
 
 

--- a/vivarium/experiments/engine_tests.py
+++ b/vivarium/experiments/engine_tests.py
@@ -1003,7 +1003,7 @@ def test_hyperdivision(profile: bool = True) -> None:
     print(f"n agents final: {len(data[total_time]['agents'].keys())}")
     if profile:
         stats = experiment.stats
-        stats.strip_dirs().sort_stats('cumulative', 'cumtime').print_stats(10)
+        stats.strip_dirs().sort_stats('cumulative', 'cumtime').print_stats(20)
         # import ipdb; ipdb.set_trace()
 
 

--- a/vivarium/experiments/engine_tests.py
+++ b/vivarium/experiments/engine_tests.py
@@ -1,6 +1,7 @@
 import random
 import logging as log
 from typing import Optional, Union, Dict, Any, cast, List
+from pstats import SortKey
 
 from vivarium.composites.toys import (
     PoQo, Sine, ToyDivider, ToyTransport, ToyEnvironment,
@@ -944,10 +945,10 @@ def test_add_delete() -> None:
             assert len(set(current_ids).intersection(set(next_ids))) == 0
 
 
-def test_hyperdivision():
+def test_hyperdivision(profile=True):
     total_time = 10
-    n_agents = 2
-    division_thresholds = [3, 4, 5, 6]  # what values of x triggers division?
+    n_agents = 100
+    division_thresholds = [3, 4, 5, 6, 7]  # what values of x triggers division?
 
     # initialize agent composer
     agent_composer = ToyDivider()
@@ -993,13 +994,18 @@ def test_hyperdivision():
         steps=composite.steps,
         flow=composite.flow,
         topology=composite.topology,
+        profile=profile,
     )
     experiment.update(total_time)
+    experiment.end()
     data = experiment.emitter.get_data()
 
     print(f"n agents initial: {len(data[total_time]['agents'].keys())}")
     print(f"n agents final: {n_agents}")
-    # import ipdb; ipdb.set_trace()
+    if profile:
+        stats = experiment.stats
+        stats.strip_dirs().sort_stats(SortKey.CUMULATIVE).print_stats(10)
+        # import ipdb; ipdb.set_trace()
 
 
 

--- a/vivarium/experiments/engine_tests.py
+++ b/vivarium/experiments/engine_tests.py
@@ -999,8 +999,8 @@ def test_hyperdivision(profile: bool = True) -> None:
     experiment.end()
     data = experiment.emitter.get_data()
 
-    print(f"n agents initial: {len(data[total_time]['agents'].keys())}")
-    print(f"n agents final: {n_agents}")
+    print(f"n agents initial: {n_agents}")
+    print(f"n agents final: {len(data[total_time]['agents'].keys())}")
     if profile:
         stats = experiment.stats
         stats.strip_dirs().sort_stats('cumulative', 'cumtime').print_stats(10)

--- a/vivarium/experiments/engine_tests.py
+++ b/vivarium/experiments/engine_tests.py
@@ -1,7 +1,6 @@
 import random
 import logging as log
 from typing import Optional, Union, Dict, Any, cast, List
-from pstats import SortKey
 
 from vivarium.composites.toys import (
     PoQo, Sine, ToyDivider, ToyTransport, ToyEnvironment,
@@ -945,7 +944,7 @@ def test_add_delete() -> None:
             assert len(set(current_ids).intersection(set(next_ids))) == 0
 
 
-def test_hyperdivision(profile=True):
+def test_hyperdivision(profile: bool = True) -> None:
     total_time = 10
     n_agents = 100
     division_thresholds = [3, 4, 5, 6, 7]  # what values of x triggers division?
@@ -1004,7 +1003,7 @@ def test_hyperdivision(profile=True):
     print(f"n agents final: {n_agents}")
     if profile:
         stats = experiment.stats
-        stats.strip_dirs().sort_stats(SortKey.CUMULATIVE).print_stats(10)
+        stats.strip_dirs().sort_stats('cumulative', 'cumtime').print_stats(10)
         # import ipdb; ipdb.set_trace()
 
 

--- a/vivarium/experiments/engine_tests.py
+++ b/vivarium/experiments/engine_tests.py
@@ -945,7 +945,7 @@ def test_add_delete() -> None:
             assert len(set(current_ids).intersection(set(next_ids))) == 0
 
 
-def test_hyperdivision(profile: bool = False) -> None:
+def test_hyperdivision(profile: bool = True) -> None:
     total_time = 10
     n_agents = 100
     division_thresholds = [3, 4, 5, 6, 7]  # what values of x triggers division?
@@ -1002,13 +1002,20 @@ def test_hyperdivision(profile: bool = False) -> None:
 
     print(f"n agents initial: {n_agents}")
     print(f"n agents final: {len(data[total_time]['agents'].keys())}")
+    assert len(data[total_time]['agents'].keys()) > n_agents
 
-    assert len(data[total_time]['agents'].keys()) >  n_agents
-    # if profile:
-    #     stats = experiment.stats
-    #     stats.strip_dirs().sort_stats(
-    #         'cumulative', 'cumtime').print_stats(20)
+    if profile:
+        stats = experiment.stats
+        stats.strip_dirs().sort_stats(  # type: ignore
+            'cumulative', 'cumtime').print_stats(20)
 
+        # make sure view_values is fast
+        stats_view_values = stats.get_print_list(  # type: ignore
+            ('view_values',))[1]
+        view_values_times = stats.stats[  # type: ignore
+            stats_view_values[0]][3]
+        total_runtime = stats.total_tt  # type: ignore
+        assert view_values_times < 0.1 * total_runtime
 
 
 engine_tests = {

--- a/vivarium/experiments/test_profiler.py
+++ b/vivarium/experiments/test_profiler.py
@@ -8,7 +8,7 @@ from vivarium.core.types import Schema, State, Update
 class ProcessA(Process):
 
     defaults = {
-        'sleep': 2,
+        'sleep': 0.2,
     }
 
     def ports_schema(self) -> Schema:
@@ -22,7 +22,7 @@ class ProcessA(Process):
 class ProcessB(Process):
 
     defaults = {
-        'sleep': 1,
+        'sleep': 0.1,
         '_parallel': True,
     }
 
@@ -55,5 +55,5 @@ def test_profiler() -> None:
     process_b_runtime = stats.stats[  # type: ignore
         ('test_profiler.py', 32, 'next_update')][3]
 
-    assert 6 <= process_a_runtime <= 6.1
-    assert 3 <= process_b_runtime <= 3.1
+    assert 0.6 <= process_a_runtime <= 0.7
+    assert 0.3 <= process_b_runtime <= 0.4

--- a/vivarium/processes/division.py
+++ b/vivarium/processes/division.py
@@ -61,8 +61,7 @@ class Division(Deriver):
     def ports_schema(self):
         return {
             'variable': {},
-            'agents': {
-                '*': {}}}
+            'agents': {}}
 
     def next_update(self, timestep, states):
         variable = states['variable']

--- a/vivarium/processes/division.py
+++ b/vivarium/processes/division.py
@@ -17,11 +17,14 @@ def pass_threshold(value, config):
     return False
 
 
-def get_divide_update(daughter_composer, mother_id, daughter_ids):
+def get_divide_update(
+        daughter_composer, mother_id, daughter_ids, composer_config=None):
+    composer_config = composer_config or {}
     daughter_updates = []
     for daughter_id in daughter_ids:
         composer = daughter_composer.generate({
-            'agent_id': daughter_id})
+            'agent_id': daughter_id,
+            **composer_config})
         daughter_updates.append({
             'key': daughter_id,
             'processes': composer['processes'],

--- a/vivarium/processes/meta_division.py
+++ b/vivarium/processes/meta_division.py
@@ -66,8 +66,7 @@ class MetaDivision(Deriver):
                     '_updater': 'set',
                     '_divider': divider_set_false,
                 }},
-            'agents': {
-                '*': {}}}
+            'agents': {}}
 
     def next_update(self, timestep, states):
         divide = states['global']['divide']


### PR DESCRIPTION
`Store.build_topology_views` allows Engine to expire and recache views upon a hierarchy update. This worked great from simulations such as `vivarium-ecoli`, which have infrequent hierarchy updates, but it leads to considerable slowdown for division-heavy simulation such as `tumor-tcell`. This PR attempts to improve the runtime for `tumor-tcell` found by @johnhickey22.

This PR introduces a new `test_hyperdivision` function to `engine_tests.py` which reproduced the high-division simulations and consequent slowdown. This was fixed by removing a line with `state = self` in `Store.schema_topology`, which was returning the entire agents branch for `division` processes that link to agents with the topology `{'agents_port': ('..', '..', 'agents')}`. This would result an enormous slowdown when `view_values` was called on that view of agents.

Additionally, this PR makes it so that schema with `{ 'agents': {'*': {}}` sees the top-level IDs under that port, and `{ 'agents': {}` does not see anything, but can be used for output (especially useful for division updates).