### PR TITLE
Make Engine Handle Flows with Nested Dictionaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.4.10
+
+* Fix `Engine` to support flows that are nested dictionaries.
+
 ## v0.4.9
 
 * Add `profile` argument to the `Engine` constructor. When this argument is set to `True`, the simulation, including any parallel processes, will be profiled by `cProfile`. Once `Engine.end()` is called, the profile stats will be saved to `Engine.stats` for analysis.

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from distutils.core import setup
 _ = setuptools  # don't warn about this unused import; it might have side effects
 
 
-VERSION = '0.4.9'
+VERSION = '0.4.10'
 
 
 if __name__ == '__main__':

--- a/vivarium/core/engine.py
+++ b/vivarium/core/engine.py
@@ -564,7 +564,6 @@ class Engine:
     ) -> None:
         tree = hierarchy_depth(steps)
         for path, step in tree.items():
-            name = path[-1]
             self._add_step_path(step, path, get_in(flow, path))
 
     def emit_configuration(self) -> None:

--- a/vivarium/core/engine.py
+++ b/vivarium/core/engine.py
@@ -30,6 +30,7 @@ from vivarium.core.process import (
 )
 from vivarium.core.serialize import serialize_value
 from vivarium.library.topology import (
+    get_in,
     delete_in,
     assoc_path,
     inverse_topology,
@@ -543,8 +544,7 @@ class Engine:
             #     category=FutureWarning,
             # )
             step = cast(Step, process)
-            name = path[-1]
-            self._add_step_path(step, path, flow.get(name))
+            self._add_step_path(step, path, get_in(flow, path))
         else:
             self.process_paths[path] = process
 
@@ -565,7 +565,7 @@ class Engine:
         tree = hierarchy_depth(steps)
         for path, step in tree.items():
             name = path[-1]
-            self._add_step_path(step, path, flow.get(name))
+            self._add_step_path(step, path, get_in(flow, path))
 
     def emit_configuration(self) -> None:
         """Emit experiment configuration."""


### PR DESCRIPTION
Previously, Engine expected a flow to be a flat dictionary with process
names as keys. This requires that processes have unique names, which is
not a general requirement of Vivarium (e.g. two cells can have processes
of the same name). This commit fixes this behavior to support nested
flows.