### PR TITLE
Replace isinstance(..., Step) with Process.is_step() calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v0.4.11
+
+* Assert that when `Engine` treats a process like a step, that process
+  is actually a step.
+* Use `Process.is_step()` to check whether a process is a step instead
+  of using `isinstance`.
+
 ## v0.4.10
 
 * Fix `Engine` to support flows that are nested dictionaries.

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from distutils.core import setup
 _ = setuptools  # don't warn about this unused import; it might have side effects
 
 
-VERSION = '0.4.10'
+VERSION = '0.4.11'
 
 
 if __name__ == '__main__':

--- a/vivarium/core/engine.py
+++ b/vivarium/core/engine.py
@@ -520,6 +520,7 @@ class Engine:
             # None if deriver, empty list if no dependencies.
             relative_dependencies: Optional[Sequence[HierarchyPath]],
     ) -> None:
+        assert step.is_step()
         self._step_paths[path] = step
         if relative_dependencies is None:
             self._step_graph.add_sequential(path)

--- a/vivarium/core/store.py
+++ b/vivarium/core/store.py
@@ -642,7 +642,7 @@ class Store:
                 f'with topology {self.topology}, which is not allowed '
                 f'because the Store value ({self.value}) is not a '
                 'Process.')
-        if self.flow and not isinstance(self.value, Step):
+        if self.flow and not self.value.is_step():
             raise ValueError(
                 f'Attempting to create Store at {self.path_for()} '
                 f'with flow {self.flow}, which is not allowed because '
@@ -761,7 +761,7 @@ class Store:
                         inner_processes[key] = child_processes
                 elif (
                         isinstance(child.value, Process)
-                        and not isinstance(child.value, Step)):
+                        and not child.value.is_step()):
                     inner_processes[key] = child.value
             if inner_processes:
                 return inner_processes
@@ -778,7 +778,9 @@ class Store:
                     child_processes = child.get_steps()
                     if child_processes:
                         inner_processes[key] = child_processes
-                elif isinstance(child.value, Step):
+                elif (
+                        isinstance(child.value, Process)
+                        and child.value.is_step()):
                     inner_processes[key] = child.value
             if inner_processes:
                 return inner_processes
@@ -1132,7 +1134,7 @@ class Store:
                 process_path, process.value))
             topology_updates.append((
                 process_path, process.topology))
-            if isinstance(process, Step):
+            if process.value.is_step():
                 step_updates.append((
                     process_path, process.value))
                 # Note that process.flow may be None, indicating no
@@ -1292,7 +1294,7 @@ class Store:
         deletions.append(tuple(here + mother_path))
 
         for path, process in process_and_step_updates:
-            if isinstance(process, Step):
+            if process.is_step():
                 step_updates.append((path, process))
             else:
                 process_updates.append((path, process))


### PR DESCRIPTION
Instead of using `isinstance` to check whether a process is a step, we should use `Process.is_step()` since some processes don't inherit from `Step` but still override `is_step()` to return `True`.

This PR also adds an assertion to make sure that when Engine treats a process like a step, that process really is a step.