### PR TITLE
Use initial instead of mother state for division

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.4.14
+
+* (#121) Fix a bug in `Store.divide()` where daughter cell states were
+  by default the mother cell state. Instead, add support for an
+  `initial_state` key in the `_divide` dictionary.
 
 ## v0.4.13
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from distutils.core import setup
 _ = setuptools  # don't warn about this unused import; it might have side effects
 
 
-VERSION = '0.4.13'
+VERSION = '0.4.14'
 
 
 if __name__ == '__main__':

--- a/vivarium/core/store.py
+++ b/vivarium/core/store.py
@@ -1229,10 +1229,6 @@ class Store:
         mother = divide['mother']
         mother_path = (mother,)
         daughters = divide['daughters']
-        initial_state = self.inner[mother].get_value(
-            condition=lambda child: not
-            (isinstance(child.value, Process)),
-            f=lambda child: copy.deepcopy(child))
         daughter_states = self.inner[mother].divide_value()
 
         here = self.path_for()
@@ -1241,8 +1237,7 @@ class Store:
                 zip(daughters, daughter_states):
             # use initial state as default, merge in divided values
             merged_initial_state = deep_merge(
-                copy.deepcopy(initial_state),
-                daughter_state)
+                daughter_state, daughter.get('initial_state', {}))
 
             daughter_key = daughter['key']
             daughter_path = (daughter_key,)


### PR DESCRIPTION
Division used the mother cell state as the default state and deep-merged the result of running the dividers into that default. This led to daughter cells getting molecules that were sent by the dividers to the other daughter.

Instead, we should use the result of running the dividers as the default daughter state. Then, we can deep-merge in any state provided by the meta-division process as part of the `_divide` update.