### PR TITLE
output-only ports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * (#121) Fix a bug in `Store.divide()` where daughter cell states were
   by default the mother cell state. Instead, add support for an
   `initial_state` key in the `_divide` dictionary.
+* Add an `_output` flag option to `Process.ports_schema`, which marks ports as output-only.
 
 ## v0.4.13
 

--- a/vivarium/core/process.py
+++ b/vivarium/core/process.py
@@ -317,7 +317,9 @@ class Process(metaclass=abc.ABCMeta):
             A dictionary that declares which states are expected by the
             processes, and how each state will behave. State keys can be
             assigned properties through schema_keys declared in
-            :py:class:`vivarium.core.store.Store`.
+            :py:class:`vivarium.core.store.Store`. Ports flagged with
+            {'_output': True} make it an output-only port, that won't
+            be viewed through the next_update's states.
         """
         return {}  # pragma: no cover
 

--- a/vivarium/core/store.py
+++ b/vivarium/core/store.py
@@ -548,6 +548,9 @@ class Store:
           node holds a step.
         """
 
+        # remove _output special key. This is used only by schema_topology.
+        config = without(config, '_output')
+
         if '*' in config:
             self.apply_subschema_config(config['*'])
             config = without(config, '*')

--- a/vivarium/core/store.py
+++ b/vivarium/core/store.py
@@ -1579,7 +1579,7 @@ class Store:
 
         if self.leaf:
             state = self
-        else:
+        elif not schema.get('_output'):
             for key, subschema in schema.items():
                 path = topology.get(key)
                 if key == '*':


### PR DESCRIPTION
With this change, ports can be designated as output-only in a Process `ports_schema` by designating with with the special key `_output`. This helps reduce topology views when they are not needed, and lowers Vivarium overhead:

```
schema = {
  'port1': {
     '_output': True,
     'A': {..},
     'B': {..},
     ....
  }
}
```

TODO before merge:
 - [x] add a test that confirms this works.