### PR TITLE
Engine.run_for allows iterative engine calls without completing.

### DIFF
--- a/vivarium/composites/toys.py
+++ b/vivarium/composites/toys.py
@@ -19,14 +19,12 @@ electron_orbitals = [
 
 class ToyTransport(Process):
     name = 'toy_transport'
+    defaults = {'intake_rate': 2}
 
     def __init__(
             self,
-            initial_parameters: Optional[Dict[str, Any]] = None
+            parameters: Optional[Dict[str, Any]] = None
     ):
-        initial_parameters = initial_parameters or {}
-        parameters = {'intake_rate': 2}
-        parameters.update(initial_parameters)
         super().__init__(parameters)
 
     def ports_schema(self):

--- a/vivarium/core/engine.py
+++ b/vivarium/core/engine.py
@@ -878,6 +878,9 @@ class Engine:
             self.print_summary(clock_finish)
 
     def complete(self) -> None:
+        """
+        Force all processes on the front to complete at the current global time
+        """
         self.run_for(interval=0, force_complete=True)
 
     def run_for(
@@ -954,7 +957,7 @@ class Engine:
                             self.front[path]['update'] = update
 
                         else:
-                            # mark this path as "quiet" so its time can be advanced
+                            # mark this path "quiet" so its time can be advanced
                             self.front[path]['update'] = (EmptyDefer(), store)
                             quiet_paths.append(path)
 
@@ -985,7 +988,8 @@ class Engine:
                 updates = []
                 paths = []
                 for path, advance in self.front.items():
-                    if advance['time'] <= self.global_time and advance['update']:
+                    if advance['time'] <= self.global_time \
+                            and advance['update']:
                         new_update = advance['update']
                         updates.append(new_update)
                         advance['update'] = {}

--- a/vivarium/core/engine.py
+++ b/vivarium/core/engine.py
@@ -866,9 +866,9 @@ class Engine:
         clock_start = clock.time()
         self.run_for(interval=interval, force_complete=True)
         self.check_complete()
-        clock_finish = clock.time() - clock_start
+        runtime = clock.time() - clock_start
         if self.display_info:
-            self.print_summary(clock_finish)
+            self.print_summary(runtime)
 
     def complete(self) -> None:
         """
@@ -1049,13 +1049,13 @@ class Engine:
 
     def print_summary(
             self,
-            clock_finish: float
+            runtime: float
     ) -> None:
         """Print summary of simulation runtime."""
-        if clock_finish < 1:
-            print('Completed in {:.6f} seconds'.format(clock_finish))
+        if runtime < 1:
+            print('Completed in {:.6f} seconds'.format(runtime))
         else:
-            print('Completed in {:.2f} seconds'.format(clock_finish))
+            print('Completed in {:.2f} seconds'.format(runtime))
 
 
 def print_progress_bar(

--- a/vivarium/core/engine.py
+++ b/vivarium/core/engine.py
@@ -956,8 +956,9 @@ class Engine:
                     if self.front[path]['time'] < next_event:
                         next_event = self.front[path]['time']
                 time = next_event
-            else:
-                # at least one process ran
+
+            elif full_step <= interval:
+                # at least one process ran within the interval
                 # increase the time, apply updates, and continue
                 time += full_step
                 self.experiment_time += full_step
@@ -986,6 +987,12 @@ class Engine:
                     while emit_time <= time:
                         self.emit_data()
                         emit_time += self.emit_step
+                        
+            else:
+                # all processes have run past the interval
+                time = interval
+                self.experiment_time = interval
+
         return time
 
     def end(self) -> None:

--- a/vivarium/core/engine.py
+++ b/vivarium/core/engine.py
@@ -491,11 +491,11 @@ class Engine:
         self.emit_config = emit_config
 
         # initialize global time
-        self.experiment_time = 0.0
+        self.global_time = 0.0
 
         # front tracks how far each process has been simulated in time
         self.front: Dict = {
-            path: empty_front(self.experiment_time)
+            path: empty_front(self.global_time)
             for path in self.process_paths}
 
         # run the steps
@@ -595,7 +595,7 @@ class Engine:
         """
         data = self.state.emit_data()
         data.update({
-            'time': self.experiment_time})
+            'time': self.global_time})
         emit_config = {
             'table': 'history',
             'data': serialize_value(data)}
@@ -863,7 +863,7 @@ class Engine:
         """
         Run each process for the given interval and update the states.
         """
-        current_time = self.experiment_time
+        current_time = self.global_time
         end_time = current_time + interval
 
         clock_start = clock.time()
@@ -891,7 +891,7 @@ class Engine:
             force_complete: a bool indicating whether to force processes
                 to complete at the end of the interval.
         """
-        current_time = self.experiment_time
+        current_time = self.global_time
         end_time = current_time + interval
         emit_time = current_time + self.emit_step
 
@@ -972,7 +972,7 @@ class Engine:
                 # at least one process ran within the interval
                 # increase the time, apply updates, and continue
                 current_time += full_step
-                self.experiment_time += full_step
+                self.global_time += full_step
 
                 # advance all quiet processes to current time
                 for quiet in quiet_paths:
@@ -1002,7 +1002,7 @@ class Engine:
             else:
                 # all processes have run past the interval
                 current_time = end_time
-                self.experiment_time = end_time
+                self.global_time = end_time
 
     def end(self) -> None:
         """Terminate all processes running in parallel.

--- a/vivarium/core/engine.py
+++ b/vivarium/core/engine.py
@@ -863,17 +863,10 @@ class Engine:
         """
         Run each process for the given interval and update the states.
         """
-        end_time = self.global_time + interval
-
         clock_start = clock.time()
         self.run_for(interval=interval, force_complete=True)
+        self.check_complete()
         clock_finish = clock.time() - clock_start
-
-        # post-simulation
-        for advance in self.front.values():
-            assert advance['time'] == end_time
-            assert len(advance['update']) == 0
-
         if self.display_info:
             self.print_summary(clock_finish)
 
@@ -882,6 +875,14 @@ class Engine:
         Force all processes on the front to complete at the current global time
         """
         self.run_for(interval=0, force_complete=True)
+        self.check_complete()
+
+    def check_complete(self) -> None:
+        """Check that all processes completed
+        """
+        for advance in self.front.values():
+            assert advance['time'] == self.global_time
+            assert len(advance['update']) == 0
 
     def run_for(
             self,

--- a/vivarium/experiments/engine_tests.py
+++ b/vivarium/experiments/engine_tests.py
@@ -1052,7 +1052,7 @@ def test_output_port() -> None:
     assert data['output']['B'] == [b_default for _ in range(total_time + 1)]
 
 
-def test_engine_run_for():
+def test_engine_run_for() -> None:
     total_time = 10.0
     time_interval = 1.0
     timestep1 = 0.75

--- a/vivarium/experiments/engine_tests.py
+++ b/vivarium/experiments/engine_tests.py
@@ -1052,6 +1052,64 @@ def test_output_port() -> None:
     assert data['output']['B'] == [b_default for _ in range(total_time + 1)]
 
 
+def test_engine_run_for():
+    total_time = 10.0
+    time_interval = 1.0
+    timestep1 = 0.75
+    timestep2 = 1.25
+
+    topo = {
+        'external': ('external',),
+        'internal': ('internal',),
+    }
+    composite = Composite({
+        'processes': {
+            'process1': ToyTransport({'time_step': timestep1}),
+            'process2': ToyTransport({'time_step': timestep2}),
+        },
+        'topology': {
+            'process1': topo,
+            'process2': topo,
+        }
+    })
+    initial_state = {
+        'external': {'GLC': 100},
+    }
+
+    sim = Engine(
+        processes=composite.processes,
+        topology=composite.topology,
+        initial_state=initial_state)
+
+    time = 0.0
+    while sim.global_time < total_time:
+        sim.run_for(time_interval)
+        time += time_interval
+        assert sim.global_time == time
+
+        # check that the front has advanced correctly
+        front = sim.front
+        for path, advance in front.items():
+            expected_time = 0.0
+            if path[0] == 'process1':
+                expected_time = int(time / timestep1) * timestep1
+            elif path[0] == 'process2':
+                expected_time = int(time / timestep2) * timestep2
+            assert advance['time'] == expected_time, \
+                f"front time {advance['time']} " \
+                f"is not expected {expected_time}"
+
+    # make all the processes complete
+    sim.complete()
+    final_time = time
+    assert sim.global_time == final_time
+
+    front = sim.front
+    for path, advance in front.items():
+        assert advance['time'] == sim.global_time, \
+            f"process at path {path} did not complete"
+
+
 engine_tests = {
     '0': test_recursive_store,
     '1': test_topology_ports,
@@ -1071,6 +1129,7 @@ engine_tests = {
     '15': test_add_delete,
     '16': test_hyperdivision,
     '17': test_output_port,
+    '18': test_engine_run_for,
 }
 
 

--- a/vivarium/processes/toy_gillespie.py
+++ b/vivarium/processes/toy_gillespie.py
@@ -225,12 +225,12 @@ def test_gillespie_process(total_time=1000):
 
         # check that process remains behind global time
         front = gillespie_experiment.front
-        front[('process',)]['time'] < gillespie_experiment.global_time
+        assert front[('process',)]['time'] < gillespie_experiment.global_time
 
     # complete
     gillespie_experiment.complete()
     front = gillespie_experiment.front
-    front[('process',)]['time'] == gillespie_experiment.global_time
+    assert front[('process',)]['time'] == gillespie_experiment.global_time
 
     gillespie_data = gillespie_experiment.emitter.get_timeseries()
     return gillespie_data

--- a/vivarium/processes/toy_gillespie.py
+++ b/vivarium/processes/toy_gillespie.py
@@ -225,6 +225,7 @@ def test_gillespie_process(total_time=1000):
     gillespie_data = gillespie_experiment.emitter.get_timeseries()
     return gillespie_data
 
+
 def test_gillespie_composite(total_time=10000):
     stochastic_tsc_trl = StochasticTscTrl().generate()
 

--- a/vivarium/processes/toy_gillespie.py
+++ b/vivarium/processes/toy_gillespie.py
@@ -218,9 +218,19 @@ def test_gillespie_process(total_time=1000):
         gillespie_process,
         exp_settings)
 
-    # run the experiment in increments
+    # run the experiment in large increments
+    increment = 10
     for _ in range(total_time):
-        gillespie_experiment.update(1)
+        gillespie_experiment.run_for(increment)
+
+        # check that process remains behind global time
+        front = gillespie_experiment.front
+        front[('process',)]['time'] < gillespie_experiment.global_time
+
+    # complete
+    gillespie_experiment.complete()
+    front = gillespie_experiment.front
+    front[('process',)]['time'] == gillespie_experiment.global_time
 
     gillespie_data = gillespie_experiment.emitter.get_timeseries()
     return gillespie_data


### PR DESCRIPTION
In order to update Engine's processes iteratively we have to allow processes to hang on the `front`, and not be forced to update within the given interval. To do this, I separated `Engine.update` from a new method `Engine.run_for`. `Engine.update` completes all the processes within the provided interval, just as it had before. `Engine.run_for` can be called iteratively to advance the front up to the interval, but can leave processes hanging if its argument `force_complete=False`. The new method `Engine.complete()` forces all processes to complete at the current `global_time`.

Note:
 - To get an `EngineProcess` that can handle multi-timestepping will require its `Process.calculate_timestep` to call a currently non-existent `Engine.next_timestep` method, which will return the time to the next process's update. 