### PR TITLE
Store API tests which fail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## v0.4.17
 
+* (#127) build a `store` argument's topology views in `Engine` constructor to support the store API.
+
+## v0.4.17
+
 * (#126) A new method, `Engine.run_for`, can be called iteratively without completing 
   processes on the front. `Engine.update` keeps the same behavior as before. `Engine.complete`
   forces all processes to complete at the current global time.

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from distutils.core import setup
 _ = setuptools  # don't warn about this unused import; it might have side effects
 
 
-VERSION = '0.4.17'
+VERSION = '0.4.18'
 
 
 if __name__ == '__main__':

--- a/vivarium/core/engine.py
+++ b/vivarium/core/engine.py
@@ -41,7 +41,7 @@ from vivarium.core.types import (
     HierarchyPath, Topology, State, Update, Processes, Steps,
     Flow)
 
-pretty = pprint.PrettyPrinter(indent=2, sort_dicts=False)
+pretty = pprint.PrettyPrinter(indent=2)
 
 
 def pp(x: Any) -> None:

--- a/vivarium/core/engine.py
+++ b/vivarium/core/engine.py
@@ -447,6 +447,8 @@ class Engine:
 
         elif store:
             self.state = store
+            # build the process' views
+            self.state.build_topology_views()
             # get processes and topology from the store
             self.processes = self.state.get_processes()
             self.steps = self.state.get_steps() or {}

--- a/vivarium/experiments/store_api.py
+++ b/vivarium/experiments/store_api.py
@@ -163,6 +163,7 @@ def test_run_store_in_experiment() -> None:
 
     print(data)
 
+
 def test_run_inserted_store() -> None:
     """Make a store using the API, run it as a simulation"""
     store = Store({})
@@ -171,7 +172,6 @@ def test_run_inserted_store() -> None:
     sim = Engine(store = store)
     sim.update(1.0)
 
-    assert "I do not know what a proper check should be here" == True
 
 def test_run_rewired_store() -> None:
     """Make a store using the API, run it as a simulation"""
@@ -181,8 +181,6 @@ def test_run_rewired_store() -> None:
     store["p1"].connect(('port1',), store['p2', "port2"])
     sim = Engine(store = store)
     sim.update(1.0)
-
-    assert "I do not know what a proper check should be here" == True
 
 
 def test_divide_store() -> None:
@@ -279,8 +277,11 @@ test_library = {
     '10': test_update_schema,
     '11': test_port_connect,
     '12': test_add_store,
+    '13': test_run_inserted_store,
+    '14': test_run_rewired_store,
 }
 
 
+# python vivarium/experiments/store_api.py -n [test number]
 if __name__ == '__main__':
     run_library_cli(test_library)

--- a/vivarium/experiments/store_api.py
+++ b/vivarium/experiments/store_api.py
@@ -59,6 +59,9 @@ def test_rewire_ports() -> None:
     # store['process2', 'port2', 'var_a'] = store['store_A', 'var_b']
     assert store['process2', 'port2', 'var_a'] == store['store_A', 'var_b']
 
+    sim = Engine(store = store)
+    sim.update(1.0)
+
 
 def test_embedded_rewire_ports() -> None:
     """rewire process ports embedded down in the hierarchy"""
@@ -94,7 +97,6 @@ def test_replace_process() -> None:
     store['process1'] = ToyProcess({})
     assert store['A', 'a'].value == 11
 
-
 def test_disconnected_store_failure() -> None:
     """Test that inserting a Store into the tree results in an exception"""
     store = get_toy_store()
@@ -105,6 +107,8 @@ def test_disconnected_store_failure() -> None:
 
     with pytest.raises(Exception):
         store['process1', 'port1'] = Store({'_value': 'NEW STORE'})
+
+
 
 
 # def test_connect_to_new_store() -> None:
@@ -158,6 +162,27 @@ def test_run_store_in_experiment() -> None:
     assert data[10.0] != data[0.0]
 
     print(data)
+
+def test_run_inserted_store() -> None:
+    """Make a store using the API, run it as a simulation"""
+    store = Store({})
+    store["p1"] = ToyProcess({'name': 'p1'})
+    store["p2"] = ToyProcess({'name': 'p2'})
+    sim = Engine(store = store)
+    sim.update(1.0)
+
+    assert "I do not know what a proper check should be here" == True
+
+def test_run_rewired_store() -> None:
+    """Make a store using the API, run it as a simulation"""
+    store = Store({})
+    store["p1"] = ToyProcess({'name': 'p1'})
+    store["p2"] = ToyProcess({'name': 'p2'})
+    store["p1"].connect(('port1',), store['p2', "port2"])
+    sim = Engine(store = store)
+    sim.update(1.0)
+
+    assert "I do not know what a proper check should be here" == True
 
 
 def test_divide_store() -> None:


### PR DESCRIPTION
This PR creates two new tests in store_api.py which currently fail. 

The first is `test_run_inserted_store` which produces an error `store at path ('p1',) does not have a topology_view` by creating a store and manually inserting a process using the API.

The second is similar to the first, but two processes are rewired after being created using store.connect. This results in a different error: `'ToyProcess' object is not subscriptable`

