### PR TITLE
Safety improvements: Check that divider configs are consistent and use original parameters for serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,22 @@
 # Changelog
 
+## v0.4.19
+
+* (#130) Raise an exception when a user specifies two different dividers
+  for the same variable, and when serializing a process, use its
+  original parameters without any changes that may have occurred since
+  the process was initialized.
+
 ## v0.4.18
 
 * (#127) build a `store` argument's topology views in `Engine` constructor to support the store API.
 
 ## v0.4.17
 
-* (#126) A new method, `Engine.run_for`, can be called iteratively without completing 
+* (#126) A new method, `Engine.run_for`, can be called iteratively without completing
   processes on the front. `Engine.update` keeps the same behavior as before. `Engine.complete`
   forces all processes to complete at the current global time.
-  
+
 ## v0.4.16
 
 * (#125) Use the `null` divider by default for processes so that upon

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from distutils.core import setup
 _ = setuptools  # don't warn about this unused import; it might have side effects
 
 
-VERSION = '0.4.18'
+VERSION = '0.4.19'
 
 
 if __name__ == '__main__':

--- a/vivarium/core/process.py
+++ b/vivarium/core/process.py
@@ -11,6 +11,7 @@ from multiprocessing import Pipe
 from multiprocessing import Process as Multiprocess
 from multiprocessing.connection import Connection
 import pstats
+import pickle
 from typing import (
     Any, Dict, Optional, Union, List)
 from warnings import warn
@@ -503,8 +504,6 @@ class ToySerializedProcess(Process):
 
 
 def test_serialize_process() -> None:
-    import pickle
-
     proc = ToySerializedProcess()
     proc_pickle = pickle.loads(pickle.dumps(proc))
 


### PR DESCRIPTION
* Fixes #128: Raise an exception when a user-provided configuration specifies different dividers for the same variable.
* Fixes #129: When serializing a process, use its original parameters, without any changes that the subclass might have made.

I don't think there are really any breaking changes here. Technically the dividers exception changes behavior, but it's just raising an error on something users shouldn't have been doing anyway. Even if process parameters cannot be copied (e.g. are not serializable), no error is raised unless the user tries to serialize the process. If a process had non-serializable parameters, they wouldn't have been able to serialize before, so this is not a breaking change.