### PR TITLE
set_path with inserted process does not use process.initial_state()

### DIFF
--- a/vivarium/core/store.py
+++ b/vivarium/core/store.py
@@ -362,7 +362,10 @@ class Store:
                 self.insert({
                     'processes': value.generate_processes({'name': final}),
                     'topology': value.generate_topology({'name': final}),
-                    'initial_state': value.initial_state()})
+                    # If a process's initial_state is expected, this will need to use inverse_topology
+                    # 'initial_state': value.initial_state()
+                    'initial_state': {},
+                })
 
             else:
                 down = self.get_path((final,))

--- a/vivarium/core/store.py
+++ b/vivarium/core/store.py
@@ -362,8 +362,6 @@ class Store:
                 self.insert({
                     'processes': value.generate_processes({'name': final}),
                     'topology': value.generate_topology({'name': final}),
-                    # If a process's initial_state is expected, this will need to use inverse_topology
-                    # 'initial_state': value.initial_state()
                     'initial_state': {},
                 })
 


### PR DESCRIPTION
This corrects a bug found by @U8NWXD -- inserting a process with the `Store` api should not assume that the process's initial_state is used.