### PR TITLE
Remove Reference to Leaf From No Path Error Msg

### DIFF
--- a/vivarium/core/store.py
+++ b/vivarium/core/store.py
@@ -917,7 +917,7 @@ class Store:
                     target = self.outer.get_path(towards[0])
                     return target.get_path(towards[1])
             else:
-                raise Exception(f"there is no path from leaf node {self.path_for()} to {path}")
+                raise Exception(f"there is no path from node {self.path_for()} to {path}")
         return self
 
     def get_paths(self, paths):

--- a/vivarium/core/store.py
+++ b/vivarium/core/store.py
@@ -917,7 +917,9 @@ class Store:
                     target = self.outer.get_path(towards[0])
                     return target.get_path(towards[1])
             else:
-                raise Exception(f"there is no path from node {self.path_for()} to {path}")
+                raise Exception(
+                    f'{path} is not a valid path from '
+                    f'{self.path_for()}')
         return self
 
     def get_paths(self, paths):


### PR DESCRIPTION
Consider the following tree:

```
          a
         /  \
       b     c
      /  \     \
     d    e     f
```

The path `('e',)` from node `a` is invalid, but there is a path from `a` to `e` and `a` is not a leaf node. This PR corrects Store's error message to accurately describe cases like this.