### PR TITLE
View subtree with **

### DIFF
--- a/vivarium/composites/toys.py
+++ b/vivarium/composites/toys.py
@@ -28,16 +28,17 @@ class ToyTransport(Process):
         super().__init__(parameters)
 
     def ports_schema(self):
-        ports = {
-            'external': ['GLC'],
-            'internal': ['GLC']}
         return {
-            port_id: {
-                key: {
+            'external': {
+                'GLC': {
                     '_default': 0.0,
-                    '_emit': True}
-                for key in keys}
-            for port_id, keys in ports.items()}
+                    '_emit': True,
+                    '_divider': 'set'}},
+            'internal': {
+                'GLC': {
+                    '_default': 0.0,
+                    '_emit': True,
+                    '_divider': 'split'}}}
 
     def next_update(self, timestep, states):
         update = {}

--- a/vivarium/core/engine.py
+++ b/vivarium/core/engine.py
@@ -509,8 +509,9 @@ class Engine:
     ) -> None:
         """
         If a :term:`Store` is provided, retrieve the :term:`Processes`,
-        :term:`Steps`, :term:`Flow`, and :term:`Topology`. If a :term:`Composite`
-        or its attributes are provided, create a store. These are interchangeable.
+        :term:`Steps`, :term:`Flow`, and :term:`Topology`. If a
+        :term:`Composite` or its attributes are provided, create a
+        store. These are interchangeable.
         """
         if not store:
             if processes and topology:

--- a/vivarium/core/engine.py
+++ b/vivarium/core/engine.py
@@ -355,6 +355,7 @@ class _StepGraph:
 class Engine:
     def __init__(
             self,
+            composite: Optional[Topology] = None,
             processes: Optional[Processes] = None,
             steps: Optional[Steps] = None,
             flow: Optional[Flow] = None,
@@ -378,6 +379,10 @@ class Engine:
         """Defines simulations
 
         Args:
+            composite: A :term:`Composite`, which specifies the processes,
+                steps, flow, and topology. This is an alternative to passing
+                in processes and topology dict, which can not be loaded
+                at the same time.
             processes: A dictionary that maps :term:`process` names to
                 process objects. You will usually get this from the
                 ``processes`` key of the dictionary from
@@ -436,6 +441,20 @@ class Engine:
             self.steps = steps or {}
             self.flow = flow or {}
             self.topology = topology
+            # initialize the store
+            self.state: Store = generate_state(
+                self.processes,
+                self.topology,
+                self.initial_state,
+                self.steps,
+                self.flow,
+            )
+
+        elif composite:
+            self.processes = composite.processes
+            self.steps = composite.steps
+            self.flow = composite.flow
+            self.topology = composite.topology
             # initialize the store
             self.state: Store = generate_state(
                 self.processes,

--- a/vivarium/core/process.py
+++ b/vivarium/core/process.py
@@ -323,13 +323,45 @@ class Process(metaclass=abc.ABCMeta):
 
         This must be overridden by any subclasses.
 
+        Use the glob '*' schema to declare expected sub-store structure,
+        and view all child values of the store:
+
+          .. code-block:: python
+
+            schema = {
+                'port1': {
+                    '*': {
+                        '_default': 1.0
+                    }
+                }
+            }
+
+        Use the glob '**' schema to connect to an entire sub-branch, including
+        child nodes, grandchild nodes, etc:
+
+          .. code-block:: python
+
+            schema = {
+                'port1': '**'
+            }
+
+        Ports flagged as output-only won't be viewed through the next_update's
+        states, which can save some overhead time:
+
+          .. code-block:: python
+
+            schema = {
+              'port1': {
+                 '_output': True,
+                 'A': {'_default': 1.0},
+              }
+            }
+
         Returns:
             A dictionary that declares which states are expected by the
             processes, and how each state will behave. State keys can be
             assigned properties through schema_keys declared in
-            :py:class:`vivarium.core.store.Store`. Ports flagged with
-            {'_output': True} make it an output-only port, that won't
-            be viewed through the next_update's states.
+            :py:class:`vivarium.core.store.Store`.
         """
         return {}  # pragma: no cover
 

--- a/vivarium/core/store.py
+++ b/vivarium/core/store.py
@@ -550,6 +550,9 @@ class Store:
           node holds a step.
         """
 
+        if config == '**':
+            config = {}  # config needs to be a dict
+
         # remove _output special key. This is used only by schema_topology.
         config = without(config, '_output')
 
@@ -1602,7 +1605,7 @@ class Store:
 
         state = {}
 
-        if self.leaf:
+        if self.leaf or schema == '**':
             state = self
         elif not schema.get('_output'):
             for key, subschema in schema.items():

--- a/vivarium/core/store.py
+++ b/vivarium/core/store.py
@@ -787,11 +787,8 @@ class Store:
         if self.subschema:
             return {}
         elif self.topology:
-            # this is a process, return it in a dict with the topology
-            return {
-                '_process': self.value,
-                '_topology': self.topology
-            }
+            # this is a process, return it with the topology
+            return (self.value, self.topology)
         return self.value
 
     def get_processes(self):

--- a/vivarium/core/store.py
+++ b/vivarium/core/store.py
@@ -786,6 +786,12 @@ class Store:
                 if condition(child)}
         if self.subschema:
             return {}
+        elif self.topology:
+            # this is a process, return it in a dict with the topology
+            return {
+                '_process': self.value,
+                '_topology': self.topology
+            }
         return self.value
 
     def get_processes(self):

--- a/vivarium/core/store.py
+++ b/vivarium/core/store.py
@@ -1927,5 +1927,5 @@ class Store:
         target._generate_paths(processes, flow, topology)
         target._generate_paths(steps, flow, topology)
         target.apply_subschemas()
-        target.generate_value(initial_state)
+        target.set_value(initial_state)
         target.apply_defaults()

--- a/vivarium/experiments/bigraph_view.py
+++ b/vivarium/experiments/bigraph_view.py
@@ -3,6 +3,7 @@ from vivarium.core.control import run_library_cli
 from vivarium.experiments.engine_tests import get_env_view_composite
 from vivarium.core.process import Step
 
+
 class TopView(Step):
     defaults = {}
 
@@ -11,10 +12,9 @@ class TopView(Step):
 
     def ports_schema(self):
         return {
-            'top': {
-                '_default': {}
-            }
-        },
+            'top': '**',
+            'log': {}
+        }
 
     def next_update(self, timestep, states):
         top = states['top']
@@ -28,6 +28,7 @@ def test_bigraph_view():
     top_view_topology = {
         'top_view': {
             'top': (),  # connect to the top
+            'log': ('log_update',),
         }
     }
 

--- a/vivarium/experiments/bigraph_view.py
+++ b/vivarium/experiments/bigraph_view.py
@@ -2,9 +2,8 @@ from vivarium.core.engine import Engine, pf
 from vivarium.core.control import run_library_cli
 from vivarium.experiments.engine_tests import get_toy_transport_in_env_composite
 from vivarium.core.process import Step
-from typing import Optional, Dict, Any, Union
 from vivarium.core.types import (
-    Schema, Update, State, Flow, Topology)
+    Schema, Union, Update, State, Flow, Topology)
 from vivarium.processes.meta_division import daughter_phylogeny_id
 
 
@@ -13,12 +12,6 @@ class TopView(Step):
     defaults = {
         'division_threshold': 6.0
     }
-
-    def __init__(
-            self,
-            parameters: Optional[Dict[str, Any]] = None
-    ):
-        super().__init__(parameters)
 
     def ports_schema(self) -> Schema:
         return {

--- a/vivarium/experiments/bigraph_view.py
+++ b/vivarium/experiments/bigraph_view.py
@@ -2,12 +2,14 @@ from vivarium.core.engine import Engine, pf
 from vivarium.core.control import run_library_cli
 from vivarium.experiments.engine_tests import get_toy_transport_in_env_composite
 from vivarium.core.process import Step
+from vivarium.core.types import (
+    Schema, Update, Union, State, Flow, Topology)
 from vivarium.processes.meta_division import daughter_phylogeny_id
 
 
 class TopView(Step):
 
-    def ports_schema(self):
+    def ports_schema(self) -> Schema:
         return {
             'top': '**',
             'other': {
@@ -15,13 +17,14 @@ class TopView(Step):
             }
         }
 
-    def next_update(self, timestep, states):
+    def next_update(
+            self, timestep: Union[float, int], states: State) -> Update:
         assert states['other'] == 2.0, 'not getting access to other state'
         top = states['top']
         agents = top['agents']
 
         # update the bigraph directly
-        update = {'top': {'agents': {}}}
+        update: Update = {'top': {'agents': {}}}
         for agent_id, agent_state in agents.items():
             internal_glc = agent_state['internal']['GLC']
             if internal_glc >= 6.0:
@@ -37,12 +40,12 @@ class TopView(Step):
         return update
 
 
-def test_bigraph_view():
+def test_bigraph_view() -> None:
     agent_id = '1'
 
     top_view_steps = {'top_view': TopView()}
-    top_view_flow = {'top_view': []}
-    top_view_topology = {
+    top_view_flow: Flow = {'top_view': []}
+    top_view_topology: Topology = {
         'top_view': {
             'top': (),  # connect to the top
             'other': ('other',),
@@ -66,7 +69,6 @@ def test_bigraph_view():
 
     print(pf(data))
     len(data[20.0]['agents'])
-    # import ipdb; ipdb.set_trace()
 
 
 scans_library = {

--- a/vivarium/experiments/bigraph_view.py
+++ b/vivarium/experiments/bigraph_view.py
@@ -1,0 +1,56 @@
+from vivarium.core.engine import Engine
+from vivarium.core.control import run_library_cli
+from vivarium.experiments.engine_tests import get_env_view_composite
+from vivarium.core.process import Step
+
+class TopView(Step):
+    defaults = {}
+
+    def __init__(self, parameters=None):
+        super().__init__(parameters)
+
+    def ports_schema(self):
+        return {
+            'top': {
+                '_default': {}
+            }
+        },
+
+    def next_update(self, timestep, states):
+        top = states['top']
+        import ipdb; ipdb.set_trace()
+        return {}
+
+
+def test_bigraph_view():
+    top_view_steps = {'top_view': TopView()}
+    top_view_flow = {'top_view': []}
+    top_view_topology = {
+        'top_view': {
+            'top': (),  # connect to the top
+        }
+    }
+
+    composite = get_env_view_composite()
+    composite.merge(
+        steps=top_view_steps,
+        topology=top_view_topology,
+        flow=top_view_flow,
+    )
+
+    # run the simulation
+    experiment = Engine(composite=composite)
+    experiment.update(20)
+    data = experiment.emitter.get_data()
+
+    import ipdb;
+    ipdb.set_trace()
+
+
+scans_library = {
+    '0': test_bigraph_view,
+}
+
+# python vivarium/experiments/bigraph_view.py -n [name]
+if __name__ == '__main__':
+    run_library_cli(scans_library)

--- a/vivarium/experiments/bigraph_view.py
+++ b/vivarium/experiments/bigraph_view.py
@@ -1,7 +1,7 @@
 from vivarium.core.engine import Engine, pf
 from vivarium.core.control import run_library_cli
 from vivarium.experiments.engine_tests import get_toy_transport_in_env_composite
-from vivarium.core.process import Step
+from vivarium.core.process import Process, Step
 from vivarium.core.types import (
     Schema, Union, Update, State, Flow, Topology)
 from vivarium.processes.meta_division import daughter_phylogeny_id
@@ -45,10 +45,10 @@ class TopView(Step):
         # examine agent processes
         for agent_id, agent_state in agents.items():
             transport = agent_state['transport']
-            transport_process = transport['_process']
-            transport_topology = transport['_topology']
-            assert transport_process
-            assert transport_topology
+            transport_process = transport[0]
+            transport_topology = transport[1]
+            assert isinstance(transport_process, Process)
+            assert isinstance(transport_topology, dict)
 
         return update
 

--- a/vivarium/experiments/engine_tests.py
+++ b/vivarium/experiments/engine_tests.py
@@ -784,7 +784,7 @@ def test_runtime_order() -> None:
             assert set(group) == expected_group
 
 
-def get_toy_transport_in_env_composite(agent_id='0') -> Composite:
+def get_toy_transport_in_env_composite(agent_id: Any = '0') -> Composite:
     processes = {
         'agents': {agent_id: {'transport': ToyTransport()}},
         'environment': ToyEnvironment()}
@@ -823,7 +823,7 @@ def test_glob_schema() -> None:
     experiment_reverse.update(10)
 
 
-def get_env_view_composite(agent_id='1') -> Composite:
+def get_env_view_composite(agent_id: Any = '1') -> Composite:
     agent_composer = ToyDivider({
         'agent_id': agent_id,
         'divider': {

--- a/vivarium/experiments/engine_tests.py
+++ b/vivarium/experiments/engine_tests.py
@@ -784,7 +784,7 @@ def test_runtime_order() -> None:
             assert set(group) == expected_group
 
 
-def test_glob_schema() -> None:
+def get_toy_transport_in_env_composite() -> Composite:
     processes = {
         'agents': {'0': {'transport': ToyTransport()}},
         'environment': ToyEnvironment()}
@@ -799,9 +799,17 @@ def test_glob_schema() -> None:
                 'transport': {
                     'internal': ('internal',),
                     'external': ('external',)}}}}
+    return Composite({
+        'processes': processes,
+        'topology': topology,
+    })
+
+
+def test_glob_schema() -> None:
+    composite = get_toy_transport_in_env_composite()
     experiment = Engine(
-        processes=processes,
-        topology=topology)
+        processes=composite.processes,
+        topology=composite.topology)
     experiment.update(10)
 
     # declare processes in reverse order
@@ -811,11 +819,11 @@ def test_glob_schema() -> None:
 
     experiment_reverse = Engine(
         processes=processes_reverse,
-        topology=topology)
+        topology=composite.topology)
     experiment_reverse.update(10)
 
 
-def test_environment_view_with_division() -> None:
+def get_env_view_composite() -> Composite:
     agent_id = '1'
     agent_composer = ToyDivider({
         'agent_id': agent_id,
@@ -845,7 +853,11 @@ def test_environment_view_with_division() -> None:
         processes=environment_process,
         topology=environment_topology,
     )
+    return composite
 
+
+def test_environment_view_with_division() -> None:
+    composite = get_env_view_composite()
     experiment = Engine(
         processes=composite.processes,
         topology=composite.topology)

--- a/vivarium/experiments/engine_tests.py
+++ b/vivarium/experiments/engine_tests.py
@@ -784,9 +784,9 @@ def test_runtime_order() -> None:
             assert set(group) == expected_group
 
 
-def get_toy_transport_in_env_composite() -> Composite:
+def get_toy_transport_in_env_composite(agent_id='0') -> Composite:
     processes = {
-        'agents': {'0': {'transport': ToyTransport()}},
+        'agents': {agent_id: {'transport': ToyTransport()}},
         'environment': ToyEnvironment()}
     topology = {
         'environment': {
@@ -795,7 +795,7 @@ def get_toy_transport_in_env_composite() -> Composite:
                 '*': {
                     'external': ('external', 'GLC')}}},
         'agents': {
-            '0': {
+            agent_id: {
                 'transport': {
                     'internal': ('internal',),
                     'external': ('external',)}}}}
@@ -823,8 +823,7 @@ def test_glob_schema() -> None:
     experiment_reverse.update(10)
 
 
-def get_env_view_composite() -> Composite:
-    agent_id = '1'
+def get_env_view_composite(agent_id='1') -> Composite:
     agent_composer = ToyDivider({
         'agent_id': agent_id,
         'divider': {


### PR DESCRIPTION
This adds a new schema option for connecting a port to an entire subtree. To do this, the port in `ports_schema` can use `**`:
```
    def ports_schema(self):
        return {
            'top': '**',
            'other': {
                '_default': 2.0
            }
        }
```

This port can connect at any point in the bigraph. To connect at the top, you can use a an empty path `()`:
```
topology = {
        'top_view': {
            'top': (),
            'other': ('other',),
        }
    }
```

When viewed in `next_update` this gives the full subtree, include processes as tuples with their topology:
```
ipdb> pp top
{'agents': {'1': {'external': {'GLC': 10.0},
                  'internal': {'GLC': 0.0},
                  'membrane': 0.0,
                  'transport': (<vivarium.composites.toys.ToyTransport object at 0x110b6ea90>,
                                {'external': ('external',),
                                 'internal': ('internal',)})}},
 'environment': (<vivarium.composites.toys.ToyEnvironment object at 0x110b6eb50>,
                 {'agents': {'*': {'external': ('external', 'GLC')},
                             '_path': ('agents',)}}),
 'other': 2.0,
 'top_view': (<__main__.TopView object at 0x110b6e940>,
              {'other': ('other',), 'top': ()})}
```

