### PR TITLE
Name workflows and create codeowners for permissions

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# All pull requests require approval by the maintainers.
+@vivarium-collective/maintainers

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # All pull requests require approval by the maintainers.
-@vivarium-collective/maintainers
+* @vivarium-collective/maintainers

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,8 +9,7 @@ on:
     branches: [master]
 
 jobs:
-  build:
-
+  build-docs:
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -9,8 +9,7 @@ on:
     branches: [master]
 
 jobs:
-  build:
-
+  check-types:
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -9,8 +9,7 @@ on:
     branches: [master]
 
 jobs:
-  build:
-
+  lint:
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -9,8 +9,7 @@ on:
     branches: [master]
 
 jobs:
-  build:
-
+  run-tests:
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,5 +1,12 @@
 # Authors of Vivarium Core
 
+The maintainers of the Vivarium project (known as the Vivarium Authors)
+are:
+
+* Eran Agmon  (@eagmon)
+* Ryan Spangler (@prismofeverything)
+* Chris Skalnik (@U8NWXD)
+
 Vivarium Core was built by:
 
 * Members of the [Covert Lab](https://covert.stanford.edu) at


### PR DESCRIPTION
Fixes #142 by:

* Naming GitHub Actions workflows so we can require that certain workflows pass before PRs can be merged.
* Creating a CODEOWNERS file so that maintainers have to approve all PRs. See [GitHub's docs](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-syntax) for syntax

<!-- DO NOT MODIFY ANYTHING BELOW THIS LINE -->
-----------------------------------------------------------------------

By creating this pull request, I agree to the Contributor License
Agreement, which is available in `CLA.md` at the top level of this
repository.
