### PR TITLE
Pass Parameters Positionally in __setstate__

### DIFF
--- a/vivarium/core/process.py
+++ b/vivarium/core/process.py
@@ -151,9 +151,9 @@ class Process(metaclass=abc.ABCMeta):
                 'not supported.')
         return self._original_parameters
 
-    def __setstate__(self, state: dict) -> None:
+    def __setstate__(self, parameters: dict) -> None:
         """Initialize process with parameters"""
-        self.__init__(state)  # type: ignore
+        self.__init__(parameters)  # type: ignore
 
     def initial_state(self, config: Optional[dict] = None) -> State:
         """Get initial state in embedded path dictionary.

--- a/vivarium/core/process.py
+++ b/vivarium/core/process.py
@@ -153,7 +153,7 @@ class Process(metaclass=abc.ABCMeta):
 
     def __setstate__(self, state: dict) -> None:
         """Initialize process with parameters"""
-        self.__init__(parameters=state)  # type: ignore
+        self.__init__(state)  # type: ignore
 
     def initial_state(self, config: Optional[dict] = None) -> State:
         """Get initial state in embedded path dictionary.


### PR DESCRIPTION
If a user creates a process whose constructor accepts parameters under a
customized name (e.g. `parameters` instead of `initial_parameters`),
serialization with `__setstate__` should still work. To support this,
make `__setstate__` pass parameters to the constructor as a positional,
not a keyword, argument.

<!-- DO NOT MODIFY ANYTHING BELOW THIS LINE -->
-----------------------------------------------------------------------

By creating this pull request, I agree to the Contributor License
Agreement, which is available in `CLA.md` at the top level of this
repository.
