### PR TITLE
make Engine.run_steps public again

### DIFF
--- a/vivarium/core/engine.py
+++ b/vivarium/core/engine.py
@@ -483,7 +483,7 @@ class Engine:
             for path in self.process_paths}
 
         # run the steps
-        self._run_steps()
+        self.run_steps()
 
         # run the emitter
         self._emit_configuration()
@@ -840,7 +840,7 @@ class Engine:
                         raise e
                 del self._step_paths[path]
 
-    def _run_steps(self) -> None:
+    def run_steps(self) -> None:
         """Run all the steps in the simulation."""
         layers = self._step_graph.get_execution_layers()
         for layer in layers:
@@ -887,7 +887,7 @@ class Engine:
         if view_expire:
             self.state.build_topology_views()
 
-        self._run_steps()
+        self.run_steps()
 
     def update(
             self,


### PR DESCRIPTION
I regret making `Engine.run_steps` private, since I think this should be one of the main methods for `Engine`. Making it public again before people start using the private method.

<!-- DO NOT MODIFY ANYTHING BELOW THIS LINE -->
-----------------------------------------------------------------------

By creating this pull request, I agree to the Contributor License
Agreement, which is available in `CLA.md` at the top level of this
repository.
