### PR TITLE
Add error messages for flows with extra steps and unknown dividers

### DIFF
--- a/vivarium/core/store.py
+++ b/vivarium/core/store.py
@@ -1036,7 +1036,11 @@ class Store:
                 divider_dict = divider
                 divider = divider['divider']
                 if isinstance(divider, str):
-                    divider = divider_registry.access(divider)
+                    divider_str = divider
+                    divider = divider_registry.access(divider_str)
+                    if not divider:
+                        raise Exception(
+                            f'No divider found with name {divider_str}')
                 args = {}
                 if 'topology' in divider_dict:
                     topology = divider_dict['topology']


### PR DESCRIPTION
Add error messages for:

* Flows with extra steps. If a flow has a step in its dependency list that isn't a known step (aka an "extra step"), Engine used to include the extra step in the execution layers but not throw any errors.
* An unknown divider used to raise a cryptic "Type None not callable" (paraphrasing) error. Here, we make the error message clearer

<!-- DO NOT MODIFY ANYTHING BELOW THIS LINE -->
-----------------------------------------------------------------------

By creating this pull request, I agree to the Contributor License
Agreement, which is available in `CLA.md` at the top level of this
repository.
