### PR TITLE
Composite API

### DIFF
--- a/vivarium/composites/toys.py
+++ b/vivarium/composites/toys.py
@@ -129,7 +129,8 @@ class ToyEnvironment(Process):
             'agents': {
                 '*': {
                     port_id: {
-                        '_default': 0.0
+                        '_default': 0.0,
+                        '_emit': True,
                     } for port_id in self.port_ids
                 }
             }

--- a/vivarium/core/composer.py
+++ b/vivarium/core/composer.py
@@ -143,6 +143,12 @@ class Composite(Datum):
     def __setitem__(self, path, value):
         self.store[path] = value
 
+    def get_data(self):
+        self.sim.emitter.get_data()
+
+    def run_for(self, interval):
+        self.sim.run_for(interval)
+
     def generate(self):
         from vivarium.core.engine import Engine
         # make simulation, with new store

--- a/vivarium/core/composer.py
+++ b/vivarium/core/composer.py
@@ -118,9 +118,11 @@ class Composite(Datum):
         config = config or {}
         initial_state = self.initial_state(config)
         return generate_state(
-            self.processes,
-            self.topology,
-            initial_state)
+            processes=self.processes,
+            steps=self.steps,
+            topology=self.topology,
+            flow=self.flow,
+            initial_state=initial_state)
 
     def initial_state(self, config: Optional[dict] = None) -> Optional[State]:
         """ Merge all processes' initial states

--- a/vivarium/core/store.py
+++ b/vivarium/core/store.py
@@ -903,7 +903,6 @@ class Store:
             return self.flow
         return {}
 
-
     def get_subcomposite(self, path):
         from vivarium.core.composer import Composite  # TODO -- circular import requires this
         sub_store = self[path]

--- a/vivarium/core/store.py
+++ b/vivarium/core/store.py
@@ -904,13 +904,16 @@ class Store:
         return {}
 
     def get_subcomposite(self, path):
-        from vivarium.core.composer import Composite  # TODO -- circular import requires this
         sub_store = self[path]
+        return sub_store.get_composite()
+
+    def get_composite(self):
+        from vivarium.core.composer import Composite  # TODO -- circular import requires this
         return Composite({
-            'processes': sub_store.get_processes(),
-            'steps': sub_store.get_steps(),
-            'topology': sub_store.get_topology(),
-            'flow': sub_store.get_flow()
+            'processes': self.get_processes(),
+            'steps': self.get_steps(),
+            'topology': self.get_topology(),
+            'flow': self.get_flow()
         })
 
     def get_path(self, path):

--- a/vivarium/core/store.py
+++ b/vivarium/core/store.py
@@ -811,7 +811,7 @@ class Store:
                 return inner_processes
         elif isinstance(self.value, Process):
             return self.value
-        return {}
+        return None
 
     def get_steps(self):
         """Get all steps under this store."""
@@ -830,8 +830,7 @@ class Store:
                 return inner_processes
         elif isinstance(self.value, Process):
             return self.value
-        return {}
-
+        return None
 
     def get_topology(self):
         """
@@ -848,7 +847,7 @@ class Store:
                 return inner_topology
         elif self.topology:
             return self.topology
-        return {}
+        return None
 
     def get_flow(self):
         """Get the flow for all :term:`steps` under this node.
@@ -901,7 +900,7 @@ class Store:
                 return inner_flow
         elif self.flow is not None:
             return self.flow
-        return {}
+        return None
 
     def get_subcomposite(self, path):
         sub_store = self[path]
@@ -910,10 +909,10 @@ class Store:
     def get_composite(self):
         from vivarium.core.composer import Composite  # TODO -- circular import requires this
         return Composite({
-            'processes': self.get_processes(),
-            'steps': self.get_steps(),
-            'topology': self.get_topology(),
-            'flow': self.get_flow()
+            'processes': self.get_processes() or {},
+            'steps': self.get_steps() or {},
+            'topology': self.get_topology() or {},
+            'flow': self.get_flow() or {},
         })
 
     def get_path(self, path):

--- a/vivarium/core/store.py
+++ b/vivarium/core/store.py
@@ -811,7 +811,7 @@ class Store:
                 return inner_processes
         elif isinstance(self.value, Process):
             return self.value
-        return None
+        return {}
 
     def get_steps(self):
         """Get all steps under this store."""
@@ -830,7 +830,7 @@ class Store:
                 return inner_processes
         elif isinstance(self.value, Process):
             return self.value
-        return None
+        return {}
 
 
     def get_topology(self):
@@ -848,7 +848,7 @@ class Store:
                 return inner_topology
         elif self.topology:
             return self.topology
-        return None
+        return {}
 
     def get_flow(self):
         """Get the flow for all :term:`steps` under this node.
@@ -901,7 +901,18 @@ class Store:
                 return inner_flow
         elif self.flow is not None:
             return self.flow
-        return None
+        return {}
+
+
+    def get_subcomposite(self, path):
+        from vivarium.core.composer import Composite  # TODO -- circular import requires this
+        sub_store = self[path]
+        return Composite({
+            'processes': sub_store.get_processes(),
+            'steps': sub_store.get_steps(),
+            'topology': sub_store.get_topology(),
+            'flow': sub_store.get_flow()
+        })
 
     def get_path(self, path):
         """

--- a/vivarium/experiments/composite_merge.py
+++ b/vivarium/experiments/composite_merge.py
@@ -1,6 +1,7 @@
-from vivarium.composites.toys import ExchangeA
+from vivarium.composites.toys import ExchangeA, ToyComposer
 from vivarium.core.composer import Composite
-
+from vivarium.core.control import run_library_cli
+from vivarium.experiments.engine_tests import get_toy_transport_in_env_composite
 
 
 def test_multi_composite() -> None:
@@ -34,8 +35,19 @@ def test_multi_composite() -> None:
     print(f"composite4 topology: {composite4['topology']}")
 
 
+def test_store_composite():
+    composite = get_toy_transport_in_env_composite()
+    store = composite.generate_store()
+    agent_composite = store.get_subcomposite(path=('agents', '0'))
+    # import ipdb; ipdb.set_trace()
 
 
+test_library = {
+    '1': test_multi_composite,
+    '2': test_store_composite,
+}
 
+
+# python vivarium/experiments/composite_merge.py -n [test number]
 if __name__ == '__main__':
-    test_multi_composite()
+    run_library_cli(test_library)

--- a/vivarium/experiments/composite_merge.py
+++ b/vivarium/experiments/composite_merge.py
@@ -40,6 +40,9 @@ def test_store_composite():
     composite = get_toy_transport_in_env_composite()
     agent_composite = composite['agents', '0']
 
+    initial_state = {
+        'agents': {'0': {'external': {'GLC': 10.0}}}}
+
     composite.run_for(10)
     data = composite.get_data()
     print(pf(data))

--- a/vivarium/experiments/composite_merge.py
+++ b/vivarium/experiments/composite_merge.py
@@ -38,16 +38,28 @@ def test_multi_composite() -> None:
 
 def test_store_composite():
     composite = get_toy_transport_in_env_composite()
-    agent_composite = composite['agents', '0']
+    print('DEFAULT STATE')
+    print(pf(composite.get_value()))
 
     initial_state = {
         'agents': {'0': {'external': {'GLC': 10.0}}}}
+    composite.set_value(initial_state)
+    print('INITIAL STATE')
+    print(pf(composite.get_value()))
 
+    # make a composite from a path
+    agent_composite = composite.make_subcomposite(['agents', '0'])
+    print('AGENT STATE')
+    print(pf(agent_composite.get_value()))
+
+    # run sim
+    composite.generate_sim()
     composite.run_for(10)
     data = composite.get_data()
+    print('SIMULATION OUTPUT')
     print(pf(data))
 
-    import ipdb; ipdb.set_trace()
+    # import ipdb; ipdb.set_trace()
 
 
 

--- a/vivarium/experiments/composite_merge.py
+++ b/vivarium/experiments/composite_merge.py
@@ -37,9 +37,10 @@ def test_multi_composite() -> None:
 
 def test_store_composite():
     composite = get_toy_transport_in_env_composite()
-    store = composite.generate_store()
-    agent_composite = store.get_subcomposite(path=('agents', '0'))
+    agent_composite = composite['agents', '0']
+
     # import ipdb; ipdb.set_trace()
+    # composite.run_for()
 
 
 test_library = {

--- a/vivarium/experiments/composite_merge.py
+++ b/vivarium/experiments/composite_merge.py
@@ -1,5 +1,6 @@
 from vivarium.composites.toys import ExchangeA, ToyComposer
 from vivarium.core.composer import Composite
+from vivarium.core.engine import pf
 from vivarium.core.control import run_library_cli
 from vivarium.experiments.engine_tests import get_toy_transport_in_env_composite
 
@@ -39,8 +40,12 @@ def test_store_composite():
     composite = get_toy_transport_in_env_composite()
     agent_composite = composite['agents', '0']
 
-    # import ipdb; ipdb.set_trace()
-    # composite.run_for()
+    composite.run_for(10)
+    data = composite.get_data()
+    print(pf(data))
+
+    import ipdb; ipdb.set_trace()
+
 
 
 test_library = {


### PR DESCRIPTION
**DO NOT MERGE**

This Draft PR includes some experimental work on a Composite API. This significantly upgrades `Composite`, transforming it from an intermediate class to the main simulation object. The main additions are to provide Composite a store hierarchy (`Composite.store`) and an engine instance (`Composite.sim`).

`vivarium.experiments.composite_merge.test_store_composite` demos some of this new API.

New features:
- Composite's store can be accessed directly with Composite's `__setitem__` and `__getitem__` via the Store API: `value = composite['path', 'to']`
- `Composite.make_subcomposite(path)` returns a new Composite object from a sub-branch at `path` -- this could potentially be just like EngineProcess from vivarium-ecoli.
- `Composite.generate_sim()` initializes the simulation engine. This could alternatively be done automatically in the Composite constructor.
- `Composite.run_for(interval)` runs the simulation.
- `Composite.get_data()` returns the emitter data.

TODO ideas:
- Composite could also have a `tunnel_outer()` method, which would automatically return all the outward-pointing ports -- this could be a lot like `ports_schema`. It might also need `tunnel_inner()` for the internal stores/ports that we may want to connect to.
- `Composite.set_parallel(path)` would take the branch at the path, make a sub-composite, and run it in parallel. The top-level composite would look exactly the same -- this should be transparent.

-----------------------------------------------------------------------

By creating this pull request, I agree to the Contributor License
Agreement, which is available in `CLA.md` at the top level of this
repository.
