### PR TITLE
initial_state added to Composite

### DIFF
--- a/vivarium/core/composer.py
+++ b/vivarium/core/composer.py
@@ -158,7 +158,7 @@ class Composite(Datum):
         """
         config = config or {}
         initial_state = config.get('initial_state', {})
-        initial_state = deep_merge(self.state, initial_state)
+        initial_state = deep_merge(copy.deepcopy(self.state), initial_state)
         return _get_composite_state(
             processes=self.processes,
             steps=self.steps,

--- a/vivarium/core/composer.py
+++ b/vivarium/core/composer.py
@@ -117,16 +117,17 @@ class Composite(Datum):
     ) -> None:
         if not config:
             if store:
-                processes = store.get_processes(),
-                topology = store.get_topology(),
-                steps = store.get_steps() or {},
-                flow = store.get_flow() or {},
-                state = store.get_value(),
+                composite = get_composite_from_store(store)
+                processes = composite.processes
+                topology = composite.topology
+                steps = composite.steps
+                flow = composite.flow
+                state = composite.state
             config = {
                 'processes': processes or {},
+                'topology': topology or {},
                 'steps': steps or {},
                 'flow': flow or {},
-                'topology': topology or {},
                 'state': state or {}
             }
         super().__init__(config)
@@ -238,6 +239,17 @@ class Composite(Datum):
             A map from process names to parameters.
         """
         return _get_parameters(self.processes)
+
+
+def get_composite_from_store(store: Store) -> Composite:
+    """Make a :term:`Composite` from a :term:`Store`"""
+    return Composite(
+        processes=store.get_processes(),
+        topology=store.get_topology(),
+        steps=store.get_steps(),
+        flow=store.get_flow(),
+        state=store.get_value(),
+    )
 
 
 class Composer(metaclass=abc.ABCMeta):

--- a/vivarium/core/composer.py
+++ b/vivarium/core/composer.py
@@ -108,7 +108,6 @@ class Composite(Datum):
     def __init__(
             self,
             config: Optional[Dict[str, Any]] = None,
-            composite=None,
             store: Optional[Store] = None,
             processes: Optional[Processes] = None,
             steps: Optional[Steps] = None,
@@ -123,12 +122,6 @@ class Composite(Datum):
                 steps = store.get_steps() or {},
                 flow = store.get_flow() or {},
                 state = store.get_value(),
-            elif composite:
-                processes = composite.processes
-                steps = composite.steps
-                flow = composite.flow
-                topology = composite.topology
-                state = composite.state
             config = {
                 'processes': processes or {},
                 'steps': steps or {},

--- a/vivarium/core/engine.py
+++ b/vivarium/core/engine.py
@@ -545,6 +545,7 @@ class Engine:
                 self.steps = composite.steps
                 self.flow = composite.flow
                 self.topology = composite.topology
+                self.initial_state = composite.state or self.initial_state
             else:
                 raise Exception(
                     'load either composite, store, or '

--- a/vivarium/core/serialize.py
+++ b/vivarium/core/serialize.py
@@ -15,6 +15,7 @@ def composite_specification(
         composite: Composite,
         initial_state: bool = False,
 ) -> dict:
+    """Return the serialized specification for a :term:`composite` instance"""
     composite_dict = serialize_value(composite)
     composite_dict.pop('_schema')
     if initial_state:

--- a/vivarium/experiments/engine_tests.py
+++ b/vivarium/experiments/engine_tests.py
@@ -386,7 +386,7 @@ def test_complex_topology() -> None:
     pq = PoQo({})
     pq_composite = pq.generate(path=outer_path)
     pq_composite.pop('_schema')
-    experiment = Engine(**pq_composite)
+    experiment = Engine(composite=pq_composite)
 
     # get the initial state
     initial_state = experiment.state.get_value()


### PR DESCRIPTION
Initial_state was always handled separately from composites, which are dicts of processes, steps, topology, and flow. This PR adds `state` to `Composite`, which makes it sufficient to specify a full store hierarchy. 

This PR also adds the function arguments `processes`, `topology`, `steps`, `flow`, `state`, and `store` to `Composite` -- previously it only accepted a `config` dict with these arguments as keys. Function arguments are just a cleaner way of doing the same thing. `config` dicts are still compatible as the 1st positional argument to `Composite`.

-----------------------------------------------------------------------

By creating this pull request, I agree to the Contributor License
Agreement, which is available in `CLA.md` at the top level of this
repository.
