### PR TITLE
Fix divider and flow bugs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import re
 from setuptools import setup
 
 
-VERSION = '1.0.1'
+VERSION = '1.0.2'
 
 
 if __name__ == '__main__':

--- a/vivarium/core/engine.py
+++ b/vivarium/core/engine.py
@@ -514,6 +514,7 @@ class Engine:
             else:
                 assert isinstance(sub_flow, list)
                 for dependency in sub_flow:
+                    dependency = path + dependency
                     if dependency not in step_paths:
                         raise Exception(
                             f'Unknown dependency step {dependency} is '

--- a/vivarium/processes/divide_condition.py
+++ b/vivarium/processes/divide_condition.py
@@ -21,7 +21,14 @@ class DivideCondition(Deriver):
             'divide': {
                 '_default': False,
                 '_updater': 'set',
-                '_divider': 'zero'}}
+                '_divider': {
+                    'divider': 'set_value',
+                    'config': {
+                        'value': False,
+                    },
+                },
+            },
+        }
 
     def next_update(self, timestep, states):
         if states['variable'] >= self.threshold:

--- a/vivarium/processes/meta_division.py
+++ b/vivarium/processes/meta_division.py
@@ -35,10 +35,6 @@ def daughter_phylogeny_id(mother_id):
         str(mother_id) + '1']
 
 
-def divider_set_false(state):
-    return [False, False]
-
-
 class MetaDivision(Deriver):
     name = NAME
     defaults = {
@@ -64,7 +60,12 @@ class MetaDivision(Deriver):
                 'divide': {
                     '_default': False,
                     '_updater': 'set',
-                    '_divider': divider_set_false,
+                    '_divider': {
+                        'divider': 'set_value',
+                        'config': {
+                            'value': False,
+                        }
+                    },
                 }},
             'agents': {}}
 


### PR DESCRIPTION
Fix a couple bugs:

* In `divide_condition.py`, use a divider that sets the division variable to `False` instead of `0`. `0` worked because it is falsy, but the variable is really supposed to be a boolean.
* In `vivarium/core/engine.py`, our check for step-flow consistency did not correctly handle the case where steps are nested in sub-dicts. This PR fixes the check.

<!-- DO NOT MODIFY ANYTHING BELOW THIS LINE -->
-----------------------------------------------------------------------

By creating this pull request, I agree to the Contributor License
Agreement, which is available in `CLA.md` at the top level of this
repository.
