### PR TITLE
Add _no_original_parameters config to Process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## v1.1.0
+
+* (#164) Add a `_no_original_parameters` configuration to `Process`
+  that, if `True`, disables the copying of parameters that
+  `Process.__init__()` does by default. Disabling this copying decreases
+  memory usage, but it puts the user in charge of ensuring that
+  parameters are not mutated.
+
+## v1.0.2
+
+* (#163) Fix two bugs:
+
+  * In `divide_condition.py`, use a divider that sets the division
+    variable to `False` instead of `0`.
+  * In `engine.py`, fix the function that checks that every dependency
+    in the flow is also in the dictionary of steps. This function did
+    not correctly handle cases where steps were nested in
+    sub-dictionaries.
+
 ## v1.0.1
 
 * (#151) Make `Engine._run_steps()` public.

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import re
 from setuptools import setup
 
 
-VERSION = '1.0.2'
+VERSION = '1.1.0'
 
 
 if __name__ == '__main__':

--- a/vivarium/core/process.py
+++ b/vivarium/core/process.py
@@ -104,6 +104,12 @@ class Process(metaclass=abc.ABCMeta):
                 * ``name``: Saved to ``self.name``.
                 * ``_original_parameters``: Returned by
                   ``__getstate__()`` for serialization.
+                * ``_no_original_parameters``: If specified with a value
+                  of ``True``, original parameters will not be copied
+                  during initialization, and ``__getstate__()`` will
+                  instead return ``self.parameters``. This puts the
+                  responsibility on the user to not mutate process
+                  parameters.
                 * ``_schema``: Overrides the schema.
                 * ``_parallel``: Indicates that the process should be
                   parallelized. ``self.parallel`` will be set to True.
@@ -118,13 +124,16 @@ class Process(metaclass=abc.ABCMeta):
             original_parameters = parameters.pop('_original_parameters')
         else:
             original_parameters = parameters
-        try:
-            self._original_parameters: Optional[dict] = copy.deepcopy(
-                original_parameters)
-        except TypeError:
-            # Copying the parameters failed because some parameters do
-            # not support being copied.
+        if parameters.get('_no_original_parameters', False):
             self._original_parameters = None
+        else:
+            try:
+                self._original_parameters: Optional[dict] = copy.deepcopy(
+                    original_parameters)
+            except TypeError:
+                # Copying the parameters failed because some parameters do
+                # not support being copied.
+                self._original_parameters = None
 
         if 'name' in parameters:
             self.name = parameters['name']
@@ -160,6 +169,8 @@ class Process(metaclass=abc.ABCMeta):
         so any later changes to the parameters will be lost during
         serialization.
         """
+        if self.parameters.get('_no_original_parameters', False):
+            return self.parameters
         if self._original_parameters is None:
             raise TypeError(
                 'Parameters could not be copied, so serialization is '

--- a/vivarium/core/process.py
+++ b/vivarium/core/process.py
@@ -125,10 +125,10 @@ class Process(metaclass=abc.ABCMeta):
         else:
             original_parameters = parameters
         if parameters.get('_no_original_parameters', False):
-            self._original_parameters = None
+            self._original_parameters: Optional[dict] = None
         else:
             try:
-                self._original_parameters: Optional[dict] = copy.deepcopy(
+                self._original_parameters = copy.deepcopy(
                     original_parameters)
             except TypeError:
                 # Copying the parameters failed because some parameters do


### PR DESCRIPTION
In cases where parameters are large, users may want to save memory by preventing Process from saving a copy of the parameters. This PR adds an option to allow this. When using this option, the user must make sure that the parameters are not mutated.

<!-- DO NOT MODIFY ANYTHING BELOW THIS LINE -->
-----------------------------------------------------------------------

By creating this pull request, I agree to the Contributor License
Agreement, which is available in `CLA.md` at the top level of this
repository.
