### PR TITLE
Store initial_state

### DIFF
--- a/vivarium/core/engine.py
+++ b/vivarium/core/engine.py
@@ -562,6 +562,7 @@ class Engine:
 
         else:
             self.state = store
+            self.state.set_value(self.initial_state)
             # build the processes' views
             self.state.build_topology_views()
             # get processes and topology from the store


### PR DESCRIPTION
Passing `store` into `Engine` was not setting `initial_state`, now it does.

-----------------------------------------------------------------------

By creating this pull request, I agree to the Contributor License
Agreement, which is available in `CLA.md` at the top level of this
repository.
