### PR TITLE
Make Serializers Robust and Structured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v1.2.0
+
+* (#167) Make serialization more structured and robust with serializer
+  classes that know what kinds of data they can serialize and
+  deserialize.
+
 ## v1.1.0
 
 * (#164) Add a `_no_original_parameters` configuration to `Process`

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import re
 from setuptools import setup
 
 
-VERSION = '1.1.0'
+VERSION = '1.2.0'
 
 
 if __name__ == '__main__':

--- a/vivarium/__init__.py
+++ b/vivarium/__init__.py
@@ -94,16 +94,14 @@ divider_registry.register('set_value', divide_set_value)
 divider_registry.register('null', divide_null)
 
 # register serializers
-serializer_registry.register('identity', IdentitySerializer())
-serializer_registry.register('numpy', NumpySerializer())
-serializer_registry.register('sequence', SequenceSerializer())
-serializer_registry.register('numpy_scalar', NumpyScalarSerializer())
-serializer_registry.register('units', UnitsSerializer())
-serializer_registry.register('process', ProcessSerializer())
-serializer_registry.register('composer', ComposerSerializer())
-serializer_registry.register('function', FunctionSerializer())
-serializer_registry.register('object_id', ObjectIdSerializer())
-serializer_registry.register('dict', DictSerializer())
+for SerializerClass in (
+        IdentitySerializer, NumpySerializer, SequenceSerializer,
+        NumpyScalarSerializer, UnitsSerializer, ProcessSerializer,
+        ComposerSerializer, FunctionSerializer, ObjectIdSerializer,
+        DictSerializer):
+    serializer = SerializerClass()
+    serializer_registry.register(
+        serializer.name, serializer, serializer.alternate_keys)
 
 # register emitters
 emitter_registry.register('print', Emitter)

--- a/vivarium/__init__.py
+++ b/vivarium/__init__.py
@@ -38,11 +38,15 @@ from vivarium.processes.mass_adaptor import (
 # import updaters, dividers, serializers
 from vivarium.core.registry import (
     update_accumulate, update_set, update_merge, update_null,
-    update_nonnegative_accumulate, update_dictionary,
-    divide_set, divide_split, divide_split_dict, divide_zero,
-    assert_no_divide, divide_null, divide_binomial, divide_set_value,
-    NumpySerializer, NumpyScalarSerializer, UnitsSerializer,
-    ProcessSerializer, ComposerSerializer, FunctionSerializer,
+    update_nonnegative_accumulate, update_dictionary, divide_set,
+    divide_split, divide_split_dict, divide_zero, assert_no_divide,
+    divide_null, divide_binomial, divide_set_value,
+)
+from vivarium.core.serialize import (
+    IdentitySerializer, NumpySerializer, SequenceSerializer,
+    NumpyScalarSerializer, UnitsSerializer, ProcessSerializer,
+    ComposerSerializer, FunctionSerializer, ObjectIdSerializer,
+    DictSerializer,
 )
 
 # import emitters
@@ -90,12 +94,16 @@ divider_registry.register('set_value', divide_set_value)
 divider_registry.register('null', divide_null)
 
 # register serializers
+serializer_registry.register('identity', IdentitySerializer())
 serializer_registry.register('numpy', NumpySerializer())
+serializer_registry.register('sequence', SequenceSerializer())
 serializer_registry.register('numpy_scalar', NumpyScalarSerializer())
 serializer_registry.register('units', UnitsSerializer())
 serializer_registry.register('process', ProcessSerializer())
 serializer_registry.register('composer', ComposerSerializer())
 serializer_registry.register('function', FunctionSerializer())
+serializer_registry.register('object_id', ObjectIdSerializer())
+serializer_registry.register('dict', DictSerializer())
 
 # register emitters
 emitter_registry.register('print', Emitter)

--- a/vivarium/core/engine.py
+++ b/vivarium/core/engine.py
@@ -636,14 +636,15 @@ class Engine:
             'metadata': self.metadata,
             'topology': self.topology
             if self.emit_topology else None,
-            'processes': serialize_value(self.processes)
+            'processes': self.processes
             if self.emit_processes else None,
-            'state': serialize_value(self.state.get_config())
+            'state': self.state.get_config()
             if self.emit_config else None,
         }
         emit_config: Dict[str, Any] = {
             'table': 'configuration',
-            'data': data}
+            'data': serialize_value(data)
+        }
         self.emitter.emit(emit_config)
 
     def _emit_store_data(self) -> None:

--- a/vivarium/core/process.py
+++ b/vivarium/core/process.py
@@ -232,7 +232,9 @@ class Process(metaclass=abc.ABCMeta):
 
         return {
             'processes': assoc_in({}, path, processes),
+            'steps': {},
             'topology': assoc_in({}, path, topology),
+            'flow': {},
         }
 
     def get_schema(self, override: Optional[Schema] = None) -> dict:

--- a/vivarium/core/registry.py
+++ b/vivarium/core/registry.py
@@ -373,7 +373,7 @@ class Serializer:
             The serialized data.
         """
         string_serialization = self.serialize_to_string(data)
-        if (not isinstance(string_serialization, str)):
+        if not isinstance(string_serialization, str):
             raise ValueError(
                 f'{self}.serialize_to_string() returned invalid '
                 f'serialization: {string_serialization}')
@@ -414,7 +414,8 @@ class Serializer:
         Returns:
             The deserialized data.
         """
-        string_serialization = self.regex_for_serialized.fullmatch(data).group(1)
+        string_serialization = self.regex_for_serialized.fullmatch(
+            data).group(1)
         return self.deserialize_from_string(string_serialization)
 
     def can_deserialize(self, data):

--- a/vivarium/core/registry.py
+++ b/vivarium/core/registry.py
@@ -339,16 +339,7 @@ class Serializer:
 
     def __init__(self, name=''):
         self.name = name or self.__class__.__name__
-        assert self.check_string_sanitary(self.name)
         self.regex_for_serialized = re.compile(f'!{self.name}\\[(.*)\\]')
-
-    @staticmethod
-    def check_string_sanitary(string):
-        prohibited_chars = ('[', ']', '!')
-        for char in prohibited_chars:
-            if char in string:
-                return False
-        return True
 
     def serialize_to_string(self, data):
         """Serialize some data.
@@ -382,9 +373,7 @@ class Serializer:
             The serialized data.
         """
         string_serialization = self.serialize_to_string(data)
-        if (
-                not isinstance(string_serialization, str)
-                or not self.check_string_sanitary(string_serialization)):
+        if (not isinstance(string_serialization, str)):
             raise ValueError(
                 f'{self}.serialize_to_string() returned invalid '
                 f'serialization: {string_serialization}')

--- a/vivarium/core/registry.py
+++ b/vivarium/core/registry.py
@@ -85,7 +85,7 @@ class Registry(object):
             item: The item to add.
             alternate_keys: Additional keys under which to register the
                 item. These keys will not be included in the list
-                returned by Registry.list().
+                returned by ``Registry.list()``.
 
                 This may be useful if you want to be able to look up an
                 item in the registry under multiple keys. For example,

--- a/vivarium/core/registry.py
+++ b/vivarium/core/registry.py
@@ -359,7 +359,7 @@ class Serializer:
         """Serialize some data.
 
         Subclasses that are serializing to strings can just implement
-        :py:meth:`vivarium.core.registry.Serialize.serialize_to_string`,
+        :py:meth:`vivarium.core.registry.Serializer.serialize_to_string`,
         and this method will use that implementation to generate a
         string that serializes the data.
 

--- a/vivarium/core/registry.py
+++ b/vivarium/core/registry.py
@@ -86,6 +86,14 @@ class Registry(object):
             alternate_keys: Additional keys under which to register the
                 item. These keys will not be included in the list
                 returned by Registry.list().
+
+                This may be useful if you want to be able to look up an
+                item in the registry under multiple keys. For example,
+                in a registry of serializers, you could register a
+                serializer with its name as ``key`` and the types it can
+                serialize under ``alternate_keys``. Then, when presented
+                with an object to serialize, you could use the object's
+                type to look up the appropriate serializer.
         """
         keys = [key]
         keys.extend(alternate_keys)

--- a/vivarium/core/serialize.py
+++ b/vivarium/core/serialize.py
@@ -56,10 +56,10 @@ class IdentitySerializer(Serializer):
     '''Serializer for base types that get serialized as themselves.'''
 
     def can_serialize(self, data):
-        if isinstance(data, (int, float, bool)):
+        if (
+                isinstance(data, (int, float, bool, str))
+                and not NumpyScalarSerializer.can_serialize(data)):
             return True
-        if isinstance(data, str):
-            return not self.REGEX_FOR_SERIALIZED_ANY_TYPE.fullmatch(data)
         if data is None:
             return True
         return False
@@ -68,7 +68,13 @@ class IdentitySerializer(Serializer):
         return data
 
     def can_deserialize(self, data):
-        return self.can_serialize(data)
+        if isinstance(data, (int, float, bool)):
+            return True
+        if isinstance(data, str):
+            return not self.REGEX_FOR_SERIALIZED_ANY_TYPE.fullmatch(data)
+        if data is None:
+            return True
+        return False
 
     def deserialize(self, data):
         return data
@@ -155,7 +161,8 @@ class NumpyScalarSerializer(Serializer):
     scalars.
     """
 
-    def can_serialize(self, data):
+    @staticmethod
+    def can_serialize(data):
         return isinstance(data, (np.integer, np.floating, np.bool_))
 
     def serialize(self, data):

--- a/vivarium/core/serialize.py
+++ b/vivarium/core/serialize.py
@@ -408,9 +408,6 @@ def composite_specification(
         initial_state: bool = False,
 ) -> dict:
     """Return the serialized specification for a :term:`composite` instance"""
-    warnings.warn(
-        'composite_specification() is deprecated.',
-        DeprecationWarning)
     composite_dict = serialize_value(composite)
     composite_dict.pop('_schema')
     if initial_state:

--- a/vivarium/core/serialize.py
+++ b/vivarium/core/serialize.py
@@ -26,11 +26,11 @@ def serialize_value(value):
             compatible_serializers.append(serializer)
     if not compatible_serializers:
         raise ValueError(
-            f'No serializer found for {value}')
+            f'No serializer found for {value} of type {type(value)}')
     if len(compatible_serializers) > 1:
         raise ValueError(
             f'Multiple serializers ({compatible_serializers}) found '
-            f'for {value}')
+            f'for {value} of type {type(value)}')
     serializer = compatible_serializers[0]
     return serializer.serialize(value)
 

--- a/vivarium/core/serialize.py
+++ b/vivarium/core/serialize.py
@@ -1,20 +1,357 @@
+from collections.abc import Sequence
 from typing import Any, cast, Callable, Dict
+import warnings
 
 import numpy as np
 from bson import ObjectId
-from pint import Unit, UndefinedUnitError
+from pint import Unit
 from pint.quantity import Quantity
 
-from vivarium.core.registry import serializer_registry
+from vivarium.core.registry import serializer_registry, Serializer
 from vivarium.core.composer import Composer, Composite
 from vivarium.core.process import Process
 from vivarium.library.dict_utils import remove_multi_update
+from vivarium.library.units import units
+
+
+# Serialization and deserialization functions that handle arbitrary data
+# types.
+
+
+def serialize_value(value):
+    compatible_serializers = []
+    for serializer_name in serializer_registry.list():
+        serializer = serializer_registry.access(serializer_name)
+        if serializer.can_serialize(value):
+            compatible_serializers.append(serializer)
+    if not compatible_serializers:
+        raise ValueError(
+            f'No serializer found for {value}')
+    if len(compatible_serializers) > 1:
+        raise ValueError(
+            f'Multiple serializers ({compatible_serializers}) found '
+            f'for {value}')
+    serializer = compatible_serializers[0]
+    return serializer.serialize(value)
+
+
+def deserialize_value(value):
+    compatible_serializers = []
+    for serializer_name in serializer_registry.list():
+        serializer = serializer_registry.access(serializer_name)
+        if serializer.can_deserialize(value):
+            compatible_serializers.append(serializer)
+    if not compatible_serializers:
+        raise ValueError(
+            f'No deserializer found for {value}')
+    if len(compatible_serializers) > 1:
+        raise ValueError(
+            f'Multiple deserializers ({compatible_serializers}) found '
+            f'for {value}')
+    serializer = compatible_serializers[0]
+    return serializer.deserialize(value)
+
+
+class IdentitySerializer(Serializer):
+    '''Serializer for base types that get serialized as themselves.'''
+
+    def can_serialize(self, data):
+        if isinstance(data, (int, float, bool)):
+            return True
+        if isinstance(data, str):
+            return not self.REGEX_FOR_SERIALIZED_ANY_TYPE.fullmatch(data)
+        if data is None:
+            return True
+        return False
+
+    def serialize(self, data):
+        return data
+
+    def can_deserialize(self, data):
+        return self.can_serialize(data)
+
+    def deserialize(self, data):
+        return data
+
+
+class NumpySerializer(Serializer):
+    """Serializer for Numpy arrays.
+
+    Numpy array serialization is lossy--we serialize to Python lists, so
+    deserialization will produce a Python list instead of a Numpy array.
+    """
+
+    def can_serialize(self, data):
+        return isinstance(data, np.ndarray)
+
+    def serialize(self, data):
+        """Returns ``data.tolist()``."""
+        lst = data.tolist()
+        return serialize_value(lst)
+
+    def can_deserialize(self, data):
+        return False
+
+    def deserialize(self, data):
+        raise NotImplementedError(
+            'There is no deserializer for numpy arrays.')
+
+
+class SequenceSerializer(Serializer):
+
+    def can_serialize(self, data):
+        return isinstance(data, Sequence) and not isinstance(data, str)
+
+    def serialize(self, data):
+        '''Serialize sequence to list of serialized elements.
+
+        Note that sequence serialization is lossy. For example, a tuple
+        will be serialized as a list, which will then be deserialized to
+        a list.
+        '''
+        return [serialize_value(value) for value in data]
+
+    def can_deserialize(self, data):
+        return isinstance(data, list)
+
+    def deserialize(self, data):
+        return [deserialize_value(value) for value in data]
+
+
+class DictSerializer(Serializer):
+
+    def can_serialize(self, data):
+        return isinstance(data, dict)
+
+    def serialize(self, data):
+        '''Serialize to dict of serialized elements.
+
+        Note that dict serialization of keys is lossy. For example, a
+        float key will be serialized as a string, which will then be
+        deserialized to a string.
+        '''
+        serialized = {}
+        for key, value in data.items():
+            if not isinstance(key, str):
+                key = str(key)
+            serialized[key] = serialize_value(value)
+        return serialized
+
+    def can_deserialize(self, data):
+        return isinstance(data, dict)
+
+    def deserialize(self, data):
+        return {
+            key: deserialize_value(value)
+            for key, value in data.items()
+        }
+
+
+class NumpyScalarSerializer(Serializer):
+    """Serializer for Numpy scalars.
+
+    Note that this serialization is lossy. Upon deserialization, the
+    serialized values will remain Python builtin types, not Numpy
+    scalars.
+    """
+
+    def can_serialize(self, data):
+        return isinstance(data, (np.integer, np.floating, np.bool_))
+
+    def serialize(self, data):
+        if isinstance(data, np.integer):
+            return int(data)
+        if isinstance(data, np.floating):
+            return float(data)
+        return bool(data)
+
+    def can_deserialize(self, data):
+        return False
+
+    def deserialize(self, data):
+        raise NotImplementedError(
+            'Deserializing serialized Numpy scalars is not supported.')
+
+
+class UnitsSerializer(Serializer):
+    """Serializer for data with units."""
+
+    def can_serialize(self, data):
+        return isinstance(data, (Quantity, Unit))
+
+    def serialize_to_string(self, data):
+        return str(data)
+
+    def serialize(self, data, unit=None):
+        """Serialize data with units into a human-readable string.
+
+        Args:
+            data: The data to serialize. Should be a Pint object or a
+                list of such objects. Note that providing a list is
+                deprecated. You should use :py:func:`serialize_value`
+                instead, which uses a separate list serializer.
+            unit: The units to convert ``data`` to before serializing.
+                Optional. If omitted, no conversion occurs. This option
+                is deprecated and should not be used.
+
+        Returns:
+            The string representation of ``data`` if ``data`` is a
+            single Pint object. Otherwise, a list of string
+            representations.
+        """
+        if unit is not None:
+            warnings.warn(
+                'The `unit` argument to `UnitsSerializer.serialize` is '
+                'deprecated.',
+                DeprecationWarning,
+            )
+
+        if isinstance(data, list):
+            warnings.warn(
+                'Passing a list to `UnitsSerializer.serialize` is '
+                'deprecated. Please use `serialize_value()` instead.',
+                DeprecationWarning,
+            )
+            if unit is not None:
+                data = [d.to(unit) for d in data]
+            return [str(d) for d in data]
+        else:
+            if unit is not None:
+                data.to(unit)
+            # The superclass serialize() method uses
+            # `serialize_to_string()`.
+            return super().serialize(data)
+
+    def deserialize_from_string(self, data):
+        return units(data)
+
+    def deserialize(self, data, unit=None):
+        """Deserialize data with units from a human-readable string.
+
+        Args:
+            data: The data to deserialize. Providing a list here is
+                deprecated. You should use :py:func:`deserialize_value`
+                instead, which uses a separate list deserializer.
+            unit: The units to convert ``data`` to after deserializing.
+                If omitted, no conversion occurs. This option is
+                deprecated.
+
+        Returns:
+            A single deserialized object or, if ``data`` is a list, a
+            list of deserialized objects.
+        """
+        if unit is not None:
+            warnings.warn(
+                'The `unit` argument to `UnitsSerializer.deserialize` is '
+                'deprecated.',
+                DeprecationWarning,
+            )
+        if isinstance(data, list):
+            warnings.warn(
+                'Passing a list to `UnitsSerializer.deserialize` is '
+                'deprecated. Please use `deserialize_value()` instead.',
+                DeprecationWarning,
+            )
+            unit_data = [units(d) for d in data]
+            if unit is not None:
+                unit_data = [d.to(unit) for d in data]
+        else:
+            # The superclass deserialize() uses
+            # deserialize_from_string().
+            unit_data = super().deserialize(data)
+            if unit is not None:
+                unit_data.to(unit)
+        return unit_data
+
+
+class ProcessSerializer(Serializer):
+    """Serializer for processes.
+
+    Currently only supports serialization (for emitting simulation
+    configs).
+    """
+    def can_serialize(self, data):
+        return isinstance(data, Process)
+
+    def serialize_to_string(self, data):
+        """Create a dictionary of process name and parameters."""
+        return str(dict(data.parameters, _name=data.name))
+
+    def can_deserialize(self, data):
+        return False
+
+    def deserialize(self, data):
+        raise NotImplementedError(
+            'Processes cannot be deserialized.')
+
+
+class ComposerSerializer(Serializer):
+    """Serializer for composers.
+
+    Currently only supports serialization (for emitting simulation
+    configs).
+    """
+    def can_serialize(self, data):
+        return isinstance(data, Composer)
+
+    def serialize_to_string(self, data):
+        """Create a dictionary of composer name and parameters."""
+        return dict(data.config, _name=str(type(data)))
+
+    def can_deserialize(self, data):
+        return False
+
+    def deserialize(self, data):
+        raise NotImplementedError(
+            'Composers cannot be deserialized.')
+
+
+class FunctionSerializer(Serializer):
+    """Serializer for functions.
+
+    Currently only supports serialization (for emitting simulation
+    configs).
+    """
+    def can_serialize(self, data):
+        return callable(data)
+
+    def serialize_to_string(self, data):
+        return str(data)
+
+    def can_deserialize(self, data):
+        return False
+
+    def deserialize(self, data):
+        raise NotImplementedError(
+            'Functions cannot be deserialized.')
+
+
+class ObjectIdSerializer(Serializer):
+    """Serializer for BSON ObjectIds.
+
+    Currently only supports serialization.
+    """
+    def can_serialize(self, data):
+        return isinstance(data, ObjectId)
+
+    def serialize_to_string(self, data):
+        return str(data)
+
+    def can_deserialize(self, data):
+        return False
+
+    def deserialize(self, data):
+        raise NotImplementedError(
+            'ObjectIds cannot be deserialized.')
 
 
 def composite_specification(
         composite: Composite,
         initial_state: bool = False,
 ) -> dict:
+    warnings.warn(
+        'composite_specification() is deprecated.',
+        DeprecationWarning)
     composite_dict = serialize_value(composite)
     composite_dict.pop('_schema')
     if initial_state:
@@ -23,145 +360,3 @@ def composite_specification(
             composite_dict,
             initial_state=composite_initial_state)
     return composite_dict
-
-
-def serialize_value(value: Any) -> Any:
-    """Attempt to serialize a value.
-
-    For this function, consider "serializable" to mean serializiable by
-    this function.  This function can serialize the following kinds of
-    values:
-
-    * :py:class:`dict` whose keys implement ``__str__`` and whose values
-      are serializable. Keys are serialized by calling ``__str__`` and
-      values are serialized by this function.
-    * :py:class:`list` and :py:class:`tuple`, whose values are
-      serializable. The value is serialized as a list of the serialized
-      values.
-    * Numpy ndarray objects are handled by
-      :py:class:`vivarium.core.registry.NumpySerializer`.
-    * :py:class:`pint.Quantity` objects are handled by
-      :py:class:`vivarium.core.registry.UnitsSerializer`.
-    * Functions are handled by
-      :py:class:`vivarium.core.registry.FunctionSerializer`.
-    * :py:class:`vivarium.core.process.Process` objects are handled by
-      :py:class:`vivarium.core.registry.ProcessSerializer`.
-    * :py:class:`vivarium.core.process.Composer` objects are handled by
-      :py:class:`vivarium.core.registry.ComposerSerializer`.
-    * Numpy scalars are handled by
-      :py:class:`vivarium.core.registry.NumpyScalarSerializer`.
-    * ``ObjectId`` objects are serialized by calling its ``__str__``
-      function.
-
-    When provided with a serializable value, the returned serialized
-    value is suitable for inclusion in a JSON object.
-
-    Args:
-        value: The value to serialize.
-
-    Returns:
-        The serialized value if ``value`` is serializable. Otherwise,
-        ``value`` is returned unaltered.
-    """
-    if isinstance(value, dict):
-        value = cast(dict, value)
-        return _serialize_dictionary(value)
-    if isinstance(value, list):
-        value = cast(list, value)
-        return _serialize_list(value)
-    if isinstance(value, tuple):
-        value = cast(tuple, value)
-        return _serialize_list(list(value))
-    if isinstance(value, np.ndarray):
-        value = cast(np.ndarray, value)
-        return serializer_registry.access('numpy').serialize(value)
-    if isinstance(value, Quantity):
-        value = cast(Quantity, value)
-        return serializer_registry.access('units').serialize(value)
-    if isinstance(value, Unit):
-        value = cast(Unit, value)
-        return serializer_registry.access('units').serialize(value)
-    if callable(value):
-        value = cast(Callable, value)
-        return serializer_registry.access('function').serialize(value)
-    if isinstance(value, Process):
-        value = cast(Process, value)
-        return _serialize_dictionary(
-            serializer_registry.access('process').serialize(value))
-    if isinstance(value, Composer):
-        value = cast(Composer, value)
-        return _serialize_dictionary(
-            serializer_registry.access('composer').serialize(value))
-    if isinstance(value, (np.integer, np.floating, np.bool_)):
-        return serializer_registry.access(
-            'numpy_scalar').serialize(value)
-    if isinstance(value, ObjectId):
-        value = cast(ObjectId, value)
-        return str(value)
-    return value
-
-
-def deserialize_value(value: Any) -> Any:
-    """Attempt to deserialize a value.
-
-    Supports deserializing the following kinds ov values:
-
-    * :py:class:`dict` with serialized values and keys that need not be
-      deserialized. The values will be deserialized with this function.
-    * :py:class:`list` of serialized values. The values will be
-      deserialized with this function.
-    * :py:class:`str` which are serialized :py:class:`pint.Quantity`
-      values.  These will be deserialized with
-      :py:class:`vivarium.core.registry.UnitsSerializer`.
-
-    Args:
-        value: The value to deserialize.
-
-    Returns:
-        The deserialized value if ``value`` is of a supported type.
-        Otherwise, returns ``value`` unmodified.
-    """
-    if isinstance(value, dict):
-        value = cast(dict, value)
-        return _deserialize_dictionary(value)
-    if isinstance(value, list):
-        value = cast(list, value)
-        return _deserialize_list(value)
-    if isinstance(value, str):
-        value = cast(str, value)
-        try:
-            return serializer_registry.access(
-                'units').deserialize(value)
-        except UndefinedUnitError:
-            return value
-    return value
-
-
-def _serialize_list(lst: list) -> list:
-    serialized = []
-    for value in lst:
-        serialized.append(serialize_value(value))
-    return serialized
-
-
-def _serialize_dictionary(d: dict) -> Dict[str, Any]:
-    serialized = {}
-    for key, value in d.items():
-        if not isinstance(key, str):
-            key = str(key)
-        serialized[key] = serialize_value(value)
-    return serialized
-
-
-def _deserialize_list(lst: list) -> list:
-    deserialized = []
-    for value in lst:
-        deserialized.append(deserialize_value(value))
-    return deserialized
-
-
-def _deserialize_dictionary(d: dict) -> dict:
-    deserialized = {}
-    for key, value in d.items():
-        deserialized[key] = deserialize_value(value)
-    return deserialized

--- a/vivarium/core/serialize.py
+++ b/vivarium/core/serialize.py
@@ -102,7 +102,6 @@ class NumpySerializer(Serializer):
     def __init__(self) -> None:
         super().__init__(exclusive_types=(np.ndarray,))
 
-
     def can_serialize(self, data: Any) -> bool:
         return isinstance(data, np.ndarray)
 

--- a/vivarium/core/serialize.py
+++ b/vivarium/core/serialize.py
@@ -219,6 +219,7 @@ class UnitsSerializer(Serializer):
 
     def __init__(self) -> None:
         super().__init__(
+            name='units',
             exclusive_types=(type(units.fg), type(1 * units.fg)))
 
     def can_serialize(self, data: Any) -> bool:

--- a/vivarium/core/serialize.py
+++ b/vivarium/core/serialize.py
@@ -233,9 +233,13 @@ class UnitsSerializer(Serializer):
                 DeprecationWarning,
             )
             if unit is not None:
+                # We can't convert `Unit` objects.
+                assert isinstance(data, Quantity)
                 data = [d.to(unit) for d in data]
             return [str(d) for d in data]
         if unit is not None:
+            # We can't convert `Unit` objects.
+            assert isinstance(data, Quantity)
             data.to(unit)
         # The superclass serialize() method uses
         # `serialize_to_string()`.

--- a/vivarium/core/serialize_test.py
+++ b/vivarium/core/serialize_test.py
@@ -1,0 +1,88 @@
+import re
+
+import numpy as np
+
+from vivarium.core.process import Process
+from vivarium.core.serialize import serialize_value, deserialize_value
+from vivarium.library.units import units
+
+
+class SerializeProcess(Process):
+
+    def ports_schema(self):
+        return {}
+
+    def next_update(self, timestep, states):
+        return {}
+
+
+def serialize_function():
+    pass
+
+
+def test_serialization():
+    to_serialize = {
+        'process': SerializeProcess(),
+        1: True,
+        'numpy_int': np.array([1, 2, 3]),
+        'numpy_float': np.array([1.1, 2.2, 3.3]),
+        'numpy_str': np.array(['a', 'b', 'c']),
+        'numpy_bool': np.array([True, True, False]),
+        'numpy_matrix': np.array([[1, 2], [3, 4]]),
+        'list_units': [1 * units.fg, 2 * units.fg],
+        'list': [True, False, 'test', 1, None],
+        'quantity': 5 * units.fg,
+        'unit': units.fg,
+        'dict': {
+            'a': False,
+        },
+        'function': serialize_function,
+    }
+    serialized = serialize_value(to_serialize)
+    assert re.fullmatch(
+        '!FunctionSerializer\\[<function serialize_function at 0x[0-9a-f]+>\\]',
+        serialized.pop('function'))
+    expected_serialized = {
+        'process': (
+            "!ProcessSerializer[{'time_step': 1.0, '_name': "
+            "'SerializeProcess'}]"
+        ),
+        '1': True,
+        'numpy_int': [1, 2, 3],
+        'numpy_float': [1.1, 2.2, 3.3],
+        'numpy_str': ['a', 'b', 'c'],
+        'numpy_bool': [True, True, False],
+        'numpy_matrix': [[1, 2], [3, 4]],
+        'list_units': [
+            '!UnitsSerializer[1 femtogram]',
+            '!UnitsSerializer[2 femtogram]',
+        ],
+        'list': [True, False, 'test', 1, None],
+        'quantity': '!UnitsSerializer[5 femtogram]',
+        'unit': '!UnitsSerializer[femtogram]',
+        'dict': {
+            'a': False,
+        },
+    }
+    assert serialized == expected_serialized
+
+    # Processes cannot be deserialized.
+    expected_serialized.pop('process')
+
+    deserialized = deserialize_value(expected_serialized)
+    expected_deserialized = {
+        '1': True,
+        'numpy_int': [1, 2, 3],
+        'numpy_float': [1.1, 2.2, 3.3],
+        'numpy_str': ['a', 'b', 'c'],
+        'numpy_bool': [True, True, False],
+        'numpy_matrix': [[1, 2], [3, 4]],
+        'list_units': [1 * units.fg, 2 * units.fg],
+        'list': [True, False, 'test', 1, None],
+        'quantity': 5 * units.fg,
+        'unit': 1 * units.fg,
+        'dict': {
+            'a': False,
+        },
+    }
+    assert deserialized == expected_deserialized

--- a/vivarium/core/serialize_test.py
+++ b/vivarium/core/serialize_test.py
@@ -1,4 +1,5 @@
 import re
+from typing import Any
 
 import numpy as np
 
@@ -10,88 +11,86 @@ from vivarium.library.units import units
 
 class SerializeProcess(Process):
 
-    def ports_schema(self):
+    def ports_schema(self) -> dict:
         return {}
 
-    def next_update(self, timestep, states):
+    def next_update(self, timestep: float, states: dict) -> dict:
         return {}
 
 
-def serialize_function():
+def serialize_function() -> None:
     pass
 
 
 class TestSerializer(Serializer):
 
-    def __init__(self, prefix='', suffix=''):
+    def __init__(self, prefix: str = '', suffix: str = '') -> None:
         super().__init__()
         self.prefix = prefix
         self.suffix = suffix
 
-    def can_serialize(self, data):
+    def can_serialize(self, data: Any) -> bool:
         return isinstance(data, str) and data.startswith('!!')
 
-    def serialize_to_string(self, data):
+    def serialize_to_string(self, data: str) -> str:
         return f'{self.prefix}{data}{self.suffix}'
 
-    def deserialize_from_string(self, data):
-        print(data, self.prefix, self.suffix)
+    def deserialize_from_string(self, data: str) -> str:
         if self.suffix:
             return data[len(self.prefix):-len(self.suffix)]
-        else:
-            return data[len(self.prefix):]
+        return data[len(self.prefix):]
 
 
-def test_serialized_in_serializer_string():
+def test_serialized_in_serializer_string() -> None:
     serializer = TestSerializer(prefix='![', suffix=']')
     serialized = serializer.serialize('hi there!')
     assert serializer.deserialize(serialized) == 'hi there!'
 
 
-def test_unmatched_closing_bracket_in_serializer_string():
+def test_unmatched_closing_bracket_in_serializer_string() -> None:
     serializer = TestSerializer(prefix='', suffix=']')
     serialized = serializer.serialize('hi there!')
     assert serializer.deserialize(serialized) == 'hi there!'
 
 
-def test_unmatched_opening_bracket_in_serializer_string():
+def test_unmatched_opening_bracket_in_serializer_string() -> None:
     serializer = TestSerializer(prefix='[', suffix='')
     serialized = serializer.serialize('hi there!')
     print(serialized)
     assert serializer.deserialize(serialized) == 'hi there!'
 
 
-def test_open_bracket_deep_in_serializer_string():
+def test_open_bracket_deep_in_serializer_string() -> None:
     serializer = TestSerializer(prefix='abc[', suffix='')
     serialized = serializer.serialize('hi there!')
     assert serializer.deserialize(serialized) == 'hi there!'
 
 
-def test_close_bracket_deep_in_serializer_string():
+def test_close_bracket_deep_in_serializer_string() -> None:
     serializer = TestSerializer(prefix='abc]', suffix='')
     serialized = serializer.serialize('hi there!')
     assert serializer.deserialize(serialized) == 'hi there!'
 
 
-def test_serialized_prefixing_serializer_string():
+def test_serialized_prefixing_serializer_string() -> None:
     serializer = TestSerializer(prefix='!TestSerializer[test]', suffix='')
     serialized = serializer.serialize('hi there!')
     assert serializer.deserialize(serialized) == 'hi there!'
 
 
-def test_exclamation_point_prefixing_serializer_string():
+def test_exclamation_point_prefixing_serializer_string() -> None:
     serializer = TestSerializer(prefix='!', suffix='')
     serialized = serializer.serialize('hi there!')
     assert serializer.deserialize(serialized) == 'hi there!'
 
 
-def test_exclamation_point_suffixing_serializer_string():
+def test_exclamation_point_suffixing_serializer_string() -> None:
     serializer = TestSerializer(prefix='', suffix='!')
     serialized = serializer.serialize('hi there!')
     assert serializer.deserialize(serialized) == 'hi there!'
 
 
-def test_serialization_full():
+def test_serialization_full() -> None:
     to_serialize = {
         'process': SerializeProcess(),
         1: True,

--- a/vivarium/core/serialize_test.py
+++ b/vivarium/core/serialize_test.py
@@ -124,12 +124,12 @@ def test_serialization_full() -> None:
         'numpy_bool': [True, True, False],
         'numpy_matrix': [[1, 2], [3, 4]],
         'list_units': [
-            '!UnitsSerializer[1 femtogram]',
-            '!UnitsSerializer[2 femtogram]',
+            '!units[1 femtogram]',
+            '!units[2 femtogram]',
         ],
         'list': [True, False, 'test', 1, None],
-        'quantity': '!UnitsSerializer[5 femtogram]',
-        'unit': '!UnitsSerializer[femtogram]',
+        'quantity': '!units[5 femtogram]',
+        'unit': '!units[femtogram]',
         'dict': {
             'a': False,
         },


### PR DESCRIPTION
Make our handling of serialization more structured and robust. Now, we create classes that inherit from `Serializer` to define serializers. These serializers each know what kinds of objects they can serialize and deserialize, so the `serialize_value` and `deserialize_value` functions can automatically find the correct serializer for a given object. We also throw an error if no serializer or multiple serializers are found for an object to make serialization more robust.

<!-- DO NOT MODIFY ANYTHING BELOW THIS LINE -->
-----------------------------------------------------------------------

By creating this pull request, I agree to the Contributor License
Agreement, which is available in `CLA.md` at the top level of this
repository.
