### PR TITLE
`get_history_data_db` remove time key requirement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v1.1.1
+
+* (#169) `get_history_data_db` no longer requires a 'time' key. It
+  asserts an 'assembly_id' key instead.
+
 ## v1.1.0
 
 * (#164) Add a `_no_original_parameters` configuration to `Process`

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import re
 from setuptools import setup
 
 
-VERSION = '1.1.0'
+VERSION = '1.1.1'
 
 
 if __name__ == '__main__':

--- a/vivarium/core/emitter.py
+++ b/vivarium/core/emitter.py
@@ -422,7 +422,7 @@ def get_history_data_db(
     cursor = history_collection.find(experiment_query, projection)
     raw_data = []
     for document in cursor:
-        if document['data'].get('time'):
+        if document.get('assembly_id'):
             raw_data.append(document)
 
     # re-assemble data

--- a/vivarium/core/emitter.py
+++ b/vivarium/core/emitter.py
@@ -422,8 +422,9 @@ def get_history_data_db(
     cursor = history_collection.find(experiment_query, projection)
     raw_data = []
     for document in cursor:
-        if document.get('assembly_id'):
-            raw_data.append(document)
+        assert document.get('assembly_id'), \
+            "all database documents require an assembly_id"
+        raw_data.append(document)
 
     # re-assemble data
     assembly = assemble_data(raw_data)


### PR DESCRIPTION
Some unassembled data might not have a 'time' variable -- this includes some large 'unique' states in vivarium-ecoli that need to get merged into a dict with ['bulk', 'listeners', 'time'] keys, which has time. Removing this requirement for a 'time' key from `get_history_data_db` recovers some lost 'unique' states.

-----------------------------------------------------------------------

By creating this pull request, I agree to the Contributor License
Agreement, which is available in `CLA.md` at the top level of this
repository.
