### PR TITLE
Toggle emits on/off in Store

### DIFF
--- a/vivarium/core/engine.py
+++ b/vivarium/core/engine.py
@@ -424,9 +424,12 @@ class Engine:
                 provide as the value for the key ``experiment_id``.
             display_info: prints experiment info
             progress_bar: shows a progress bar
-            store_emit: An optional dictionary to turn on/off emits. This
-                dictionary requires the keys `on`/`off` mapping to a list
-                of paths in the Store hierarchy to be toggled on or off.
+            store_emit: An optional dictionary to turn emits on or off. This
+                dictionary requires the keys (`on`,`off`), mapping to a list
+                of paths in the Store hierarchy to be turned on or off. The
+                on configs take precedence over the off configs in that all
+                paths in `off` are turn off first, and can be turned on again
+                by the paths in `on`.
             emit_topology: If True, this will emit the topology with the
                 configuration data.
             emit_processes: If True, this will emit the serialized
@@ -482,8 +485,10 @@ class Engine:
 
         # override emit settings in store
         if store_emit:
-            self.state.toggle_emits(emit=False, paths=store_emit.get('off', []))
-            self.state.toggle_emits(emit=True, paths=store_emit.get('on', []))
+            self.state.set_emit_values(
+                paths=store_emit.get('off', []), emit=False)
+            self.state.set_emit_values(
+                paths=store_emit.get('on', []), emit=True)
 
         # settings for self._emit_configuration()
         self.emit_topology = emit_topology

--- a/vivarium/core/engine.py
+++ b/vivarium/core/engine.py
@@ -482,12 +482,8 @@ class Engine:
 
         # override emit settings in store
         if store_emit:
-            turn_off = store_emit.get('off')
-            turn_on = store_emit.get('on')
-            if turn_off:
-                self.state.toggle_emits(emit=False, paths=turn_off)
-            if turn_on:
-                self.state.toggle_emits(emit=True, paths=turn_on)
+            self.state.toggle_emits(emit=False, paths=store_emit.get('off', []))
+            self.state.toggle_emits(emit=True, paths=store_emit.get('on', []))
 
         # settings for self._emit_configuration()
         self.emit_topology = emit_topology

--- a/vivarium/core/engine.py
+++ b/vivarium/core/engine.py
@@ -425,7 +425,7 @@ class Engine:
             display_info: prints experiment info
             progress_bar: shows a progress bar
             store_emit: An optional dictionary to turn emits on or off. This
-                dictionary requires the keys (`on`,`off`), mapping to a list
+                dictionary may contain the keys (`on`,`off`), mapping to a list
                 of paths in the Store hierarchy to be turned on or off. The
                 on configs take precedence over the off configs in that all
                 paths in `off` are turn off first, and can be turned on again

--- a/vivarium/core/engine.py
+++ b/vivarium/core/engine.py
@@ -424,6 +424,9 @@ class Engine:
                 provide as the value for the key ``experiment_id``.
             display_info: prints experiment info
             progress_bar: shows a progress bar
+            store_emit: An optional dictionary to turn on/off emits. This
+                dictionary requires the keys `on`/`off` mapping to a list
+                of paths in the Store hierarchy to be toggled on or off.
             emit_topology: If True, this will emit the topology with the
                 configuration data.
             emit_processes: If True, this will emit the serialized

--- a/vivarium/core/engine.py
+++ b/vivarium/core/engine.py
@@ -370,6 +370,7 @@ class Engine:
             metadata: Optional[dict] = None,
             description: str = '',
             emitter: Union[str, dict] = 'timeseries',
+            store_emit: Optional[dict] = None,
             emit_topology: bool = True,
             emit_processes: bool = False,
             emit_config: bool = False,
@@ -423,8 +424,12 @@ class Engine:
                 provide as the value for the key ``experiment_id``.
             display_info: prints experiment info
             progress_bar: shows a progress bar
-            emit_config: If True, this will emit the serialized
-                processes, topology, and initial state.
+            emit_topology: If True, this will emit the topology with the
+                configuration data.
+            emit_processes: If True, this will emit the serialized
+                processes with the configuration data.
+            emit_config: If True, this will emit the serialized initial
+                state with the configuration data.
             profile: Whether to profile the simulation with cProfile.
         """
         self.profiler: Optional[cProfile.Profile] = None
@@ -472,6 +477,16 @@ class Engine:
         emitter_config['experiment_id'] = self.experiment_id
         self.emitter: Emitter = get_emitter(emitter_config)
 
+        # override emit settings in store
+        if store_emit:
+            turn_off = store_emit.get('off')
+            turn_on = store_emit.get('on')
+            if turn_off:
+                self.state.toggle_emits(emit=False, paths=turn_off)
+            if turn_on:
+                self.state.toggle_emits(emit=True, paths=turn_on)
+
+        # settings for self._emit_configuration()
         self.emit_topology = emit_topology
         self.emit_processes = emit_processes
         self.emit_config = emit_config

--- a/vivarium/core/store.py
+++ b/vivarium/core/store.py
@@ -1007,6 +1007,9 @@ class Store:
         return None
 
     def toggle_emits(self, emit=False, paths=None):
+        """
+        Turn on/off emits for all inner nodes of the list of paths.
+        """
         if paths:
             assert isinstance(paths, list), 'paths must be a list'
             for path in paths:

--- a/vivarium/core/store.py
+++ b/vivarium/core/store.py
@@ -1006,26 +1006,25 @@ class Store:
             return self.value
         return None
 
-    def toggle_emits(self, emit=False, paths=None):
+    def set_emit_values(self, paths=None, emit=False):
         """
         Turn on/off emits for all inner nodes of the list of paths.
         """
         if paths:
-            assert isinstance(paths, list), 'paths must be a list'
             for path in paths:
-                self.toggle_emit(emit=emit, path=path)
+                self.set_emit_value(emit=emit, path=path)
 
-    def toggle_emit(self, emit=False, path=None):
+    def set_emit_value(self, path=None, emit=False):
         """
         Turn on/off emits for all inner nodes of path.
         """
         if path:
             assert isinstance(path, tuple), 'path must be a tuple'
             target = self.get_path(path)
-            target.toggle_emit(emit=emit)
+            target.set_emit_value(emit=emit)
         elif self.inner:
             for child in self.inner.values():
-                child.toggle_emit(emit=emit)
+                child.set_emit_value(emit=emit)
         else:
             self.emit = emit
 

--- a/vivarium/core/store.py
+++ b/vivarium/core/store.py
@@ -1006,6 +1006,26 @@ class Store:
             return self.value
         return None
 
+    def toggle_emits(self, emit=False, paths=None):
+        if paths:
+            assert isinstance(paths, list), 'paths must be a list'
+            for path in paths:
+                self.toggle_emit(emit=emit, path=path)
+
+    def toggle_emit(self, emit=False, path=None):
+        """
+        Turn on/off emits for all inner nodes of path.
+        """
+        if path:
+            assert isinstance(path, tuple), 'path must be a tuple'
+            target = self.get_path(path)
+            target.toggle_emit(emit=emit)
+        elif self.inner:
+            for child in self.inner.values():
+                child.toggle_emit(emit=emit)
+        else:
+            self.emit = emit
+
     def _delete_path(self, path):
         """
         Delete the subtree at the given path.

--- a/vivarium/experiments/engine_tests.py
+++ b/vivarium/experiments/engine_tests.py
@@ -1130,37 +1130,43 @@ def emit_control() -> None:
     composite = composer.generate()
     exp = Engine(
         composite=composite,
-        store_emit={'on': [()]}
-    )
+        store_emit={'on': [()]})
     exp.update(run_time)
     data = exp.emitter.get_data()
     assert data[run_time]['bbb'] != {}, 'this emit should be on'
     print(pf(data))
 
     # turn off emits
-    composite2 = composer.generate()
-    exp2 = Engine(
-        composite=composite2,
-        store_emit={'off': [()]}
-    )
-    exp2.update(run_time)
-    data2 = exp2.emitter.get_data()
-    assert data2[run_time]['bbb'] == {}, 'this emit should be off'
-    print(pf(data2))
+    composite = composer.generate()
+    exp = Engine(
+        composite=composite,
+        store_emit={'off': [()]})
+    exp.update(run_time)
+    data = exp.emitter.get_data()
+    assert data[run_time]['bbb'] == {}, 'this emit should be off'
+    print(pf(data))
 
     # selectively turn on emits
-    composite3 = composer.generate()
-    exp3 = Engine(
-        composite=composite3,
+    composite = composer.generate()
+    exp = Engine(
+        composite=composite,
         store_emit={
             'on': [('bbb', 'e2',)],
-        }
-    )
-    exp3.update(run_time)
-    data3 = exp3.emitter.get_data()
-    assert data3[run_time]['bbb']['e2'] != {}, 'this emit should be on'
-    assert data3[run_time]['ccc'] == {}, 'this emit should be off'
-    print(pf(data3))
+        })
+    exp.update(run_time)
+    data = exp.emitter.get_data()
+    assert data[run_time]['bbb']['e2'] != {}, 'this emit should be on'
+    assert data[run_time]['ccc'] == {}, 'this emit should be off'
+    print(pf(data))
+
+    # test store_emit with None
+    composite = composer.generate()
+    exp = Engine(
+        composite=composite,
+        store_emit={
+            'on': None,
+        })
+    exp.update(run_time)
 
 
 engine_tests = {

--- a/vivarium/experiments/engine_tests.py
+++ b/vivarium/experiments/engine_tests.py
@@ -1121,7 +1121,7 @@ def test_engine_run_for() -> None:
             f"process at path {path} did not complete"
 
 
-def emit_control():
+def emit_control() -> None:
     run_time = 5
     # get the composer
     composer = PoQo({})

--- a/vivarium/experiments/engine_tests.py
+++ b/vivarium/experiments/engine_tests.py
@@ -1121,6 +1121,48 @@ def test_engine_run_for() -> None:
             f"process at path {path} did not complete"
 
 
+def emit_control():
+    run_time = 5
+    # get the composer
+    composer = PoQo({})
+
+    # turn on emits
+    composite = composer.generate()
+    exp = Engine(
+        composite=composite,
+        store_emit={'on': [()]}
+    )
+    exp.update(run_time)
+    data = exp.emitter.get_data()
+    assert data[run_time]['bbb'] != {}, 'this emit should be on'
+    print(pf(data))
+
+    # turn off emits
+    composite2 = composer.generate()
+    exp2 = Engine(
+        composite=composite2,
+        store_emit={'off': [()]}
+    )
+    exp2.update(run_time)
+    data2 = exp2.emitter.get_data()
+    assert data2[run_time]['bbb'] == {}, 'this emit should be off'
+    print(pf(data2))
+
+    # selectively turn on emits
+    composite3 = composer.generate()
+    exp3 = Engine(
+        composite=composite3,
+        store_emit={
+            'on': [('bbb', 'e2',)],
+        }
+    )
+    exp3.update(run_time)
+    data3 = exp3.emitter.get_data()
+    assert data3[run_time]['bbb']['e2'] != {}, 'this emit should be on'
+    assert data3[run_time]['ccc'] == {}, 'this emit should be off'
+    print(pf(data3))
+
+
 engine_tests = {
     '0': test_recursive_store,
     '1': test_topology_ports,
@@ -1141,6 +1183,7 @@ engine_tests = {
     '16': test_hyperdivision,
     '17': test_output_port,
     '18': test_engine_run_for,
+    '19': emit_control,
 }
 
 


### PR DESCRIPTION
Previously it was necessary to override variable emits with a '_schema' value passed to the processes or the composite. This was confusing and complicated because it had to be directed through the processes' ports, rather than through the Store hierarchy.

`Store.toggle_emits` allows you to turn emits on/off with more ease. This method has args `emit` and `paths`. `emit` is a boolean True/False to turn the emit on or off. `paths` is a list of paths to toggle on/off -- all nodes below those paths will be set to the `emit` value.

This can be accessed through `Engine` with the `store_emit` keyword, which can be supplied with a dictionary that has `'on'`, `'off'` keys that map to a list of paths to turn on or off: 

```
sim= Engine(
    composite=composite,
    store_emit={
        'on': [('path', '1',), ('path', '2',)],
    }
)
``` 

This allows you to turn off all emits like this:

```
sim= Engine(
    composite=composite,
    store_emit={
        'off': [()],
    }
)
``` 
-----------------------------------------------------------------------

By creating this pull request, I agree to the Contributor License
Agreement, which is available in `CLA.md` at the top level of this
repository.
