### PR TITLE
project assembly_id when querying db

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.2.1
+
+* (#172) bug fix to keep assembly_ids when passing queries to the DB.
+
 ## v1.2.0
 
 * (#167) Make serialization more structured and robust with serializer

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import re
 from setuptools import setup
 
 
-VERSION = '1.2.0'
+VERSION = '1.2.1'
 
 
 if __name__ == '__main__':

--- a/vivarium/core/emitter.py
+++ b/vivarium/core/emitter.py
@@ -418,6 +418,7 @@ def get_history_data_db(
     if query:
         projection = {f"data.{'.'.join(field)}": 1 for field in query}
         projection['data.time'] = 1
+        projection['assembly_id'] = 1
 
     cursor = history_collection.find(experiment_query, projection)
     raw_data = []


### PR DESCRIPTION
When passing a query to `get_history_data_db`, the `assembly_id` key was being removed when applying a projection in the DB. This PR adds it in, so it will always be retrieved with the documents.

-----------------------------------------------------------------------

By creating this pull request, I agree to the Contributor License
Agreement, which is available in `CLA.md` at the top level of this
repository.
