### PR TITLE
make PyPI name more prominent in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,22 @@
 Vivarium Core provides a process interface and simulation engine for composing 
 and executing integrative multi-scale models.
 
+## Getting Started
+
+Vivarium Core is available on PyPI [here](https://pypi.org/project/vivarium-core/), and can be installed as a python library like this:
+
+```console
+$ pip install vivarium-core
+```
+
+To get started using Vivarium Core, see our
+[documentation](https://vivarium-core.readthedocs.io/en/latest/getting_started.html)
+and [tutorial
+notebook](https://vivarium-core.readthedocs.io/en/latest/tutorials.html).
+
+If you want to contribute to Vivarium Core, see our [contribution
+guidelines](CONTRIBUTING.md).
+
 ## Concept
 
 Computational systems biology requires software for multi-algorithmic model 
@@ -41,22 +57,6 @@ with outer compartments shown above and inner compartments below.
     <img src="https://github.com/vivarium-collective/vivarium-core/blob/master/doc/_static/interface.png?raw=true" width="500">
 </p>
 
-
-## Getting Started
-
-Vivarium Core can be installed as a python library like this:
-
-```console
-$ pip install vivarium-core
-```
-
-To get started using Vivarium Core, see our
-[documentation](https://vivarium-core.readthedocs.io/en/latest/getting_started.html)
-and [tutorial
-notebook](https://vivarium-core.readthedocs.io/en/latest/tutorials.html).
-
-If you want to contribute to Vivarium Core, see our [contribution
-guidelines](CONTRIBUTING.md).
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ $ pip install vivarium-core
 To get started using Vivarium Core, see our
 [documentation](https://vivarium-core.readthedocs.io/en/latest/getting_started.html)
 and [tutorial
-notebook](https://vivarium-core.readthedocs.io/en/latest/tutorials.html).
+notebooks](https://vivarium-core.readthedocs.io/en/latest/tutorials/index.html).
 
 If you want to contribute to Vivarium Core, see our [contribution
 guidelines](CONTRIBUTING.md).


### PR DESCRIPTION
In an effort to make our PyPI project more obvious -- `vivarium-core` as opposed to `vivarium` -- I have move the set up instructions further up in the readme.

-----------------------------------------------------------------------

By creating this pull request, I agree to the Contributor License
Agreement, which is available in `CLA.md` at the top level of this
repository.
