### PR TITLE
override schema directly in Engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+
+## v1.2.2
+
+* (#175) `store_schema` arg to `Engine` allows us to override schema directly.
+
 ## v1.2.1
 
 * (#172) bug fix to keep assembly_ids when passing queries to the DB.

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import re
 from setuptools import setup
 
 
-VERSION = '1.2.1'
+VERSION = '1.2.2'
 
 
 if __name__ == '__main__':

--- a/vivarium/core/engine.py
+++ b/vivarium/core/engine.py
@@ -371,6 +371,7 @@ class Engine:
             description: str = '',
             emitter: Union[str, dict] = 'timeseries',
             store_emit: Optional[dict] = None,
+            store_schema: Optional[dict] = None,
             emit_topology: bool = True,
             emit_processes: bool = False,
             emit_config: bool = False,
@@ -484,6 +485,8 @@ class Engine:
         self.emitter: Emitter = get_emitter(emitter_config)
 
         # override emit settings in store
+        if store_schema:
+            self.state._apply_config(store_schema)
         if store_emit:
             self.state.set_emit_values(
                 paths=store_emit.get('off', []), emit=False)

--- a/vivarium/core/engine.py
+++ b/vivarium/core/engine.py
@@ -370,8 +370,8 @@ class Engine:
             metadata: Optional[dict] = None,
             description: str = '',
             emitter: Union[str, dict] = 'timeseries',
-            store_emit: Optional[dict] = None,
             store_schema: Optional[dict] = None,
+            store_emit: Optional[dict] = None,
             emit_topology: bool = True,
             emit_processes: bool = False,
             emit_config: bool = False,
@@ -425,6 +425,10 @@ class Engine:
                 provide as the value for the key ``experiment_id``.
             display_info: prints experiment info
             progress_bar: shows a progress bar
+            store_schema: An optional dictionary to expand the store hierarchy
+                configuration. This includes adding new values and turning emits
+                on. The dictionary needs to be structured as a hierarchy, which will
+                expand the existing store hierarchy.
             store_emit: An optional dictionary to turn emits on or off. This
                 dictionary may contain the keys (`on`,`off`), mapping to a list
                 of paths in the Store hierarchy to be turned on or off. The

--- a/vivarium/core/engine.py
+++ b/vivarium/core/engine.py
@@ -426,15 +426,10 @@ class Engine:
             display_info: prints experiment info
             progress_bar: shows a progress bar
             store_schema: An optional dictionary to expand the store hierarchy
-                configuration. This includes adding new values and turning emits
-                on. The dictionary needs to be structured as a hierarchy, which will
-                expand the existing store hierarchy.
-            store_emit: An optional dictionary to turn emits on or off. This
-                dictionary may contain the keys (`on`,`off`), mapping to a list
-                of paths in the Store hierarchy to be turned on or off. The
-                on configs take precedence over the off configs in that all
-                paths in `off` are turn off first, and can be turned on again
-                by the paths in `on`.
+                configuration, and also to turn emits on or off. The dictionary
+                needs to be structured as a hierarchy, which will expand the
+                existing store hierarchy. Setting an emit value for a branch node
+                will set the emits of all the branch's leaves to that value.
             emit_topology: If True, this will emit the topology with the
                 configuration data.
             emit_processes: If True, this will emit the serialized
@@ -491,11 +486,6 @@ class Engine:
         # override emit settings in store
         if store_schema:
             self.state._apply_config(store_schema)
-        if store_emit:
-            self.state.set_emit_values(
-                paths=store_emit.get('off', []), emit=False)
-            self.state.set_emit_values(
-                paths=store_emit.get('on', []), emit=True)
 
         # settings for self._emit_configuration()
         self.emit_topology = emit_topology

--- a/vivarium/core/engine.py
+++ b/vivarium/core/engine.py
@@ -371,7 +371,6 @@ class Engine:
             description: str = '',
             emitter: Union[str, dict] = 'timeseries',
             store_schema: Optional[dict] = None,
-            store_emit: Optional[dict] = None,
             emit_topology: bool = True,
             emit_processes: bool = False,
             emit_config: bool = False,
@@ -428,8 +427,8 @@ class Engine:
             store_schema: An optional dictionary to expand the store hierarchy
                 configuration, and also to turn emits on or off. The dictionary
                 needs to be structured as a hierarchy, which will expand the
-                existing store hierarchy. Setting an emit value for a branch node
-                will set the emits of all the branch's leaves to that value.
+                existing store hierarchy. Setting an emit value for a branch
+                node will set the emits of all the leaves to that value.
             emit_topology: If True, this will emit the topology with the
                 configuration data.
             emit_processes: If True, this will emit the serialized

--- a/vivarium/core/store.py
+++ b/vivarium/core/store.py
@@ -598,7 +598,15 @@ class Store:
             self.divider = new_divider
             config = without(config, '_divider')
 
+        # if emit set in branch, set the entire branch to the emit value
+        if '_emit' in config:
+            if self.inner:
+                emit_value = config['_emit']
+                self.set_emit_value(emit=emit_value)
+                config = without(config, '_emit')
+
         if self.schema_keys & set(config.keys()):
+
             if self.inner:
                 raise Exception(
                     'trying to assign leaf values to a branch at: {}'.format(

--- a/vivarium/core/store.py
+++ b/vivarium/core/store.py
@@ -599,8 +599,7 @@ class Store:
             config = without(config, '_divider')
 
         # if emit set in branch, set the entire branch to the emit value
-        if '_emit' in config:
-            if self.inner:
+        if '_emit' in config and self.inner:
                 emit_value = config['_emit']
                 self.set_emit_value(emit=emit_value)
                 config = without(config, '_emit')

--- a/vivarium/core/store.py
+++ b/vivarium/core/store.py
@@ -613,7 +613,6 @@ class Store:
                 config = without(config, '_emit')
 
         if self.schema_keys & set(config.keys()):
-
             if self.inner:
                 raise Exception(
                     'trying to assign leaf values to a branch at: {}'.format(
@@ -659,7 +658,7 @@ class Store:
                 '_updater',
                 self.updater or 'accumulate',
             )
-            
+
             # All leaf nodes must have a divider, even though a divider
             # on a branch node higher in the tree will take precedence.
             self.divider = self.divider or DEFAULT_SCHEMA

--- a/vivarium/core/store.py
+++ b/vivarium/core/store.py
@@ -654,10 +654,13 @@ class Store:
                 if isinstance(self.value, Quantity):
                     self.units = self.value.units
 
-            self.updater = config.get(
-                '_updater',
-                self.updater or 'accumulate',
-            )
+            if '_updater' in config:
+                new_updater = config['_updater']
+                self.updater = self._check_schema_support_defaults(
+                    'updater', new_updater, updater_registry)
+
+            # All leaf nodes must have an updater
+            self.updater = self.updater or DEFAULT_SCHEMA
 
             # All leaf nodes must have a divider, even though a divider
             # on a branch node higher in the tree will take precedence.
@@ -713,7 +716,10 @@ class Store:
         if isinstance(update, dict) and '_updater' in update:
             updater = update['_updater']
 
-        if isinstance(updater, str):
+        if updater == DEFAULT_SCHEMA:
+            # For all nodes, by default we use an 'accumulate' updater.
+            return updater_registry.access('accumulate')
+        elif isinstance(updater, str):
             updater = updater_registry.access(updater)
         return updater
 

--- a/vivarium/core/store.py
+++ b/vivarium/core/store.py
@@ -499,7 +499,7 @@ class Store:
         return new_schema
 
     def _check_schema_set_default(self, schema_key, new_schema, schema_registry):
-        current_schema = self.__dict__[schema_key]
+        current_schema = getattr(self, schema_key)
         if isinstance(new_schema, str):
             new_schema = schema_registry.access(new_schema)
         if isinstance(new_schema, dict) and isinstance(

--- a/vivarium/core/store.py
+++ b/vivarium/core/store.py
@@ -498,7 +498,7 @@ class Store:
                 f"which already has the value {current_schema_value}.")
         return new_schema
 
-    def _check_schema_methods(self, schema_key, new_schema, schema_registry):
+    def _check_schema_support_defaults(self, schema_key, new_schema, schema_registry):
         current_schema_value = getattr(self, schema_key)
         if isinstance(new_schema, str):
             new_schema = schema_registry.access(new_schema)
@@ -602,7 +602,7 @@ class Store:
 
         if '_divider' in config:
             new_divider = config['_divider']
-            self.divider = self._check_schema_methods(
+            self.divider = self._check_schema_support_defaults(
                 'divider', new_divider, divider_registry)
             config = without(config, '_divider')
 

--- a/vivarium/core/store.py
+++ b/vivarium/core/store.py
@@ -490,16 +490,16 @@ class Store:
             Exception: If the store schema already has a value and the new
                 value is different from the existing one.
         """
-        current_schema = self.__dict__[schema_key]
-        if current_schema is not None and current_schema != new_schema:
+        current_schema_value = getattr(self, schema_key)
+        if current_schema_value is not None and current_schema_value != new_schema:
             raise ValueError(
-                f"incompatible {schema_key} schema assignment: {new_schema} "
-                f"at {self.path_for()}. "
-                f"schema {current_schema} is already assigned.")
+                f"Incompatible schema assignment at {self.path_for()}. "
+                f"Trying to assign the value {new_schema} to key {schema_key}, "
+                f"which already has the value {current_schema_value}.")
         return new_schema
 
-    def _check_schema_set_default(self, schema_key, new_schema, schema_registry):
-        current_schema = getattr(self, schema_key)
+    def _check_schema_methods(self, schema_key, new_schema, schema_registry):
+        current_schema_value = getattr(self, schema_key)
         if isinstance(new_schema, str):
             new_schema = schema_registry.access(new_schema)
         if isinstance(new_schema, dict) and isinstance(
@@ -507,13 +507,13 @@ class Store:
             new_schema[schema_key] = schema_registry.access(
                 new_schema[schema_key])
         if (
-                current_schema
-                and current_schema != DEFAULT_SCHEMA
-                and current_schema != new_schema):
+                current_schema_value
+                and current_schema_value != DEFAULT_SCHEMA
+                and current_schema_value != new_schema):
             raise ValueError(
-                f"incompatible {schema_key} schema assignment: {new_schema} "
-                f"at {self.path_for()}. "
-                f"schema {current_schema} is already assigned.")
+                f"Incompatible schema assignment at {self.path_for()}. "
+                f"Trying to assign the value {new_schema} to key {schema_key}, "
+                f"which already has the value {current_schema_value}.")
         return new_schema
 
     def _merge_subtopology(self, subtopology):
@@ -602,7 +602,7 @@ class Store:
 
         if '_divider' in config:
             new_divider = config['_divider']
-            self.divider = self._check_schema_set_default(
+            self.divider = self._check_schema_methods(
                 'divider', new_divider, divider_registry)
             config = without(config, '_divider')
 

--- a/vivarium/experiments/engine_tests.py
+++ b/vivarium/experiments/engine_tests.py
@@ -1160,15 +1160,6 @@ def test_set_branch_emit() -> None:
     assert data[run_time]['ccc'] == {}, 'this emit should be off'
     print(pf(data))
 
-    # test store_emit with None
-    composite = composer.generate()
-    exp = Engine(
-        composite=composite,
-        store_emit={
-            'on': None,
-        })
-    exp.update(run_time)
-
 
 def test_add_new_state() -> None:
     agent_id = '1'

--- a/vivarium/experiments/engine_tests.py
+++ b/vivarium/experiments/engine_tests.py
@@ -1121,7 +1121,7 @@ def test_engine_run_for() -> None:
             f"process at path {path} did not complete"
 
 
-def emit_control() -> None:
+def test_emit_control() -> None:
     run_time = 5
     # get the composer
     composer = PoQo({})
@@ -1169,6 +1169,24 @@ def emit_control() -> None:
     exp.update(run_time)
 
 
+def test_add_new_state():
+    agent_id = '1'
+    composite = get_toy_transport_in_env_composite(agent_id=agent_id)
+    new_schema = {'agents': {agent_id: {'extra': {'_emit': True, '_value': 1.0}}}}
+    experiment = Engine(
+        processes=composite.processes,
+        topology=composite.topology,
+        store_schema=new_schema,
+    )
+
+    assert experiment.state['agents', agent_id, 'extra'].get_value() == 1.0
+
+    total_time = 5
+    experiment.update(total_time)
+    timeseries = experiment.emitter.get_timeseries()
+    assert len(timeseries['agents'][agent_id]['extra']) == total_time + 1
+
+
 engine_tests = {
     '0': test_recursive_store,
     '1': test_topology_ports,
@@ -1189,7 +1207,8 @@ engine_tests = {
     '16': test_hyperdivision,
     '17': test_output_port,
     '18': test_engine_run_for,
-    '19': emit_control,
+    '19': test_emit_control,
+    '20': test_add_new_state,
 }
 
 

--- a/vivarium/experiments/engine_tests.py
+++ b/vivarium/experiments/engine_tests.py
@@ -1121,7 +1121,7 @@ def test_engine_run_for() -> None:
             f"process at path {path} did not complete"
 
 
-def test_emit_control() -> None:
+def test_set_branch_emit() -> None:
     run_time = 5
     # get the composer
     composer = PoQo({})
@@ -1130,7 +1130,8 @@ def test_emit_control() -> None:
     composite = composer.generate()
     exp = Engine(
         composite=composite,
-        store_emit={'on': [()]})
+        store_schema={'_emit': True}
+    )
     exp.update(run_time)
     data = exp.emitter.get_data()
     assert data[run_time]['bbb'] != {}, 'this emit should be on'
@@ -1140,7 +1141,8 @@ def test_emit_control() -> None:
     composite = composer.generate()
     exp = Engine(
         composite=composite,
-        store_emit={'off': [()]})
+        store_schema={'_emit': False}
+    )
     exp.update(run_time)
     data = exp.emitter.get_data()
     assert data[run_time]['bbb'] == {}, 'this emit should be off'
@@ -1150,9 +1152,8 @@ def test_emit_control() -> None:
     composite = composer.generate()
     exp = Engine(
         composite=composite,
-        store_emit={
-            'on': [('bbb', 'e2',)],
-        })
+        store_schema={'bbb': {'e2': {'_emit': True}}},
+    )
     exp.update(run_time)
     data = exp.emitter.get_data()
     assert data[run_time]['bbb']['e2'] != {}, 'this emit should be on'
@@ -1210,7 +1211,7 @@ engine_tests = {
     '16': test_hyperdivision,
     '17': test_output_port,
     '18': test_engine_run_for,
-    '19': test_emit_control,
+    '19': test_set_branch_emit,
     '20': test_add_new_state,
 }
 

--- a/vivarium/experiments/engine_tests.py
+++ b/vivarium/experiments/engine_tests.py
@@ -1169,10 +1169,13 @@ def test_emit_control() -> None:
     exp.update(run_time)
 
 
-def test_add_new_state():
+def test_add_new_state() -> None:
     agent_id = '1'
     composite = get_toy_transport_in_env_composite(agent_id=agent_id)
-    new_schema = {'agents': {agent_id: {'extra': {'_emit': True, '_value': 1.0}}}}
+    new_schema = {
+        'agents': {
+            agent_id: {
+                'extra': {'_emit': True, '_value': 1.0}}}}
     experiment = Engine(
         processes=composite.processes,
         topology=composite.topology,

--- a/vivarium/experiments/store_api.py
+++ b/vivarium/experiments/store_api.py
@@ -207,7 +207,7 @@ def test_update_schema() -> None:
     store = Store({})
     store.create(['top', 'process1'], ToyProcess({}))
     store.create(['top', 'store1'], _updater='set')
-    assert store['top', 'store1'].updater == 'set', \
+    assert store['top', 'store1'].updater.__name__ == 'update_set', \
         'updater is not set correctly'
 
 


### PR DESCRIPTION
A new `store_schema` arg to `Engine` allows us to override schema directly. This includes state values, emits, etc. This replaces the `store_emit` argument introduced in #170, since the new `store_schema` dict can turn emits on/off more directly. A new check in `Store._apply_config` lets us use schema to set the emit values for all leaf nodes under a given branch, by setting the `_emit` schema of that branch node to `True` or `False`.

In the new `test_add_new_state`, this feature is demonstrated by adding an `extra` key to the agent state, and turning its emit to true:
```
    new_schema = {'agents': {agent_id: {'extra': {'_emit': True, '_value': 1.0}}}}
    experiment = Engine(
        processes=composite.processes,
        topology=composite.topology,
        store_schema=new_schema,
    )
```

As an example of how to set branch emit values, here we set the entire tree to emit by setting the top-level emit value to True:
```
    exp = Engine(
        composite=composite,
        store_schema={'_emit': True}
    )
```

TODO:
 - [X] document `store_schema`
 - [x] expand schema enforcement of updaters
 
-----------------------------------------------------------------------

By creating this pull request, I agree to the Contributor License
Agreement, which is available in `CLA.md` at the top level of this
repository.
