### PR TITLE
remove compose_experiment from composition

### DIFF
--- a/vivarium/core/composer.py
+++ b/vivarium/core/composer.py
@@ -191,6 +191,7 @@ class Composite(Datum):
             topology: Optional[Topology] = None,
             steps: Optional[Steps] = None,
             flow: Optional[Flow] = None,
+            state: Optional[State] = None,
             path: Optional[HierarchyPath] = None,
             schema_override: Optional[Schema] = None,
     ) -> None:
@@ -200,6 +201,7 @@ class Composite(Datum):
         steps = steps or {}
         flow = flow or {}
         path = path or tuple()
+        state = state or {}
         schema_override = schema_override or {}
 
         # get the processes and topology to merge
@@ -207,26 +209,31 @@ class Composite(Datum):
         merge_topology = {}
         merge_steps = {}
         merge_flow = {}
+        merge_state = {}
         if composite:
             merge_processes.update(composite['processes'])
             merge_topology.update(composite['topology'])
             merge_steps.update(composite['steps'])
             merge_flow.update(composite['flow'])
+            merge_state.update(composite['state'])
 
         deep_merge(merge_processes, processes)
         deep_merge(merge_topology, topology)
         deep_merge(merge_steps, steps)
         deep_merge(merge_flow, flow)
+        deep_merge(merge_state, state)
         merge_processes = assoc_in({}, path, merge_processes)
         merge_topology = assoc_in({}, path, merge_topology)
         merge_steps = assoc_in({}, path, merge_steps)
         merge_flow = assoc_in({}, path, merge_flow)
+        merge_state = assoc_in({}, path, merge_state)
 
         # merge with instance processes and topology
         deep_merge(self.processes, merge_processes)
         deep_merge(self.topology, merge_topology)
         deep_merge(self.steps, merge_steps)
         deep_merge(self.flow, merge_flow)
+        deep_merge(self.state, merge_state)
         self._schema.update(schema_override)
 
         processes_and_steps = deep_copy_internal(self.processes)

--- a/vivarium/core/composition.py
+++ b/vivarium/core/composition.py
@@ -45,84 +45,6 @@ EXPERIMENT_OUT_DIR = os.path.join(BASE_OUT_DIR, 'experiments')
 
 COMPOSER_KEY = '_composer'
 
-
-# loading functions for compartment_hierarchy_experiment
-
-def add_processes_to_hierarchy(
-        processes: Dict[str, Process],
-        topology: Topology,
-        composer_type: Callable,
-        composer_config: Optional[Dict[str, Any]] = None,
-        composer_topology: Optional[Dict[str, Any]] = None
-) -> Composite:
-    """Use a composer to add processes and topology"""
-    composer_config = composer_config or {}
-    composer_topology = composer_topology or {}
-
-    # generate
-    composer = composer_type(composer_config)
-    composite = composer.generate()
-    new_processes = composite['processes']
-    new_topology = composite['topology']
-
-    # replace process names that already exist
-    replace_name = []
-    for name in new_processes.keys():
-        if name in processes:
-            replace_name.append(name)
-    for name in replace_name:
-        new_name = name + '_' + str(uuid.uuid1())
-        new_processes[new_name] = new_processes[name]
-        new_topology[new_name] = new_topology[name]
-        del new_processes[name]
-        del new_topology[name]
-
-    # extend processes and topology list
-    new_topology = deep_merge(new_topology, composer_topology)
-    deep_merge(topology, new_topology)
-    deep_merge_check(processes, new_processes)
-
-    return Composite({
-        'processes': processes,
-        'topology': topology})
-
-
-def initialize_hierarchy(
-        hierarchy: Dict[str, Any]
-) -> Composite:
-    """Make a hierarchy with initialized processes"""
-    processes: Dict[str, Process] = {}
-    topology: Topology = {}
-    for key, level in hierarchy.items():
-        if key == COMPOSER_KEY:
-            if isinstance(level, list):
-                for composer_def in level:
-                    add_processes_to_hierarchy(
-                        processes=processes,
-                        topology=topology,
-                        composer_type=composer_def['type'],
-                        composer_config=composer_def.get(
-                            'config', {}),
-                        composer_topology=composer_def.get(
-                            'topology', {}))
-
-            elif isinstance(level, dict):
-                add_processes_to_hierarchy(
-                    processes=processes,
-                    topology=topology,
-                    composer_type=level['type'],
-                    composer_config=level.get('config', {}),
-                    composer_topology=level.get('topology', {}))
-        else:
-            composite = initialize_hierarchy(level)
-            deep_merge_check(processes, {key: composite['processes']})
-            deep_merge(topology, {key: composite['topology']})
-
-    return Composite({
-        'processes': processes,
-        'topology': topology})
-
-
 # list of keys expected in experiment settings
 experiment_config_keys = [
         'experiment_id',
@@ -135,44 +57,6 @@ experiment_config_keys = [
         'progress_bar',
         'invoke',
     ]
-
-
-def compose_experiment(
-        hierarchy: Dict[str, Any],
-        settings: Optional[Dict[str, Any]] = None,
-        initial_state: Optional[Dict[str, Any]] = None,
-) -> Engine:
-    """Make an experiment with arbitrarily embedded compartments.
-
-    Args:
-        hierarchy: an embedded dictionary mapping the desired topology
-          of nodes, with composers declared under a global COMPOSER_KEY
-          that maps to a dictionary with 'type', 'config', and
-          'topology' for the processes in the Composer. Composers
-          include lone processes.
-        settings: experiment configuration settings.
-        initial_state: is the initial_state.
-
-    Returns:
-        The experiment.
-    """
-    settings = settings or {}
-    initial_state = initial_state or {}
-
-    # make the hierarchy
-    composite = initialize_hierarchy(hierarchy)
-    processes = composite['processes']
-    topology = composite['topology']
-
-    experiment_config = {
-        'processes': processes,
-        'topology': topology,
-        'initial_state': initial_state}
-
-    for key, setting in settings.items():
-        if key in experiment_config_keys:
-            experiment_config[key] = setting
-    return Engine(**experiment_config)
 
 
 # experiment loading functions
@@ -480,44 +364,6 @@ def test_composite_in_experiment() -> None:
 
     output = simulate_composite(composite, settings)
     assert output['aaa']['x'][-1] == -90
-
-
-def test_compose_experiment() -> None:
-    hierarchy = {
-        COMPOSER_KEY:
-            {
-                'type': ExchangeA,
-                'config': {},
-            }}
-    experiment = compose_experiment(
-        hierarchy=hierarchy,
-        settings={'experiment_name': 'test'})
-    experiment.update(10)
-
-
-def test_replace_names() -> None:
-    """if processes on the same level have the same name, add uuid string"""
-    # declare the hierarchy
-    hierarchy = {
-        COMPOSER_KEY: [
-            {
-                'type': ExchangeA,
-                'config': {},
-            },
-            {
-                'type': ExchangeA,
-                'config': {},
-            }
-        ]}
-
-    # configure experiment
-    experiment = compose_experiment(
-        hierarchy=hierarchy)
-    process_names = list(experiment.processes.keys())
-
-    assert len(process_names) == 2
-    # process_names[1] has added string
-    assert process_names[0] in process_names[1]
 
 
 def test_process_deletion() -> None:

--- a/vivarium/processes/alternator.py
+++ b/vivarium/processes/alternator.py
@@ -8,15 +8,13 @@ import os
 
 from typing import Any, Dict
 
-from vivarium.core.engine import pp
+from vivarium.core.engine import pp, Engine
 from vivarium.core.process import (
     Process,
     Deriver
 )
 from vivarium.core.composer import Composer
 from vivarium.core.composition import (
-    compose_experiment,
-    COMPOSER_KEY,
     PROCESS_OUT_DIR,
 )
 from vivarium.composites.toys import ExchangeA
@@ -203,18 +201,10 @@ def test_alternator():
     }
 
     # declare the hierarchy
-    hierarchy = {
-        COMPOSER_KEY: {
-                'type': ExchangeAlternator,
-        }
-    }
-
-    # configure experiment
-    settings = {}
-    experiment = compose_experiment(
-        hierarchy=hierarchy,
-        initial_state=initial_state,
-        settings=settings)
+    experiment = Engine(
+        composite=ExchangeAlternator().generate(),
+        initial_state=initial_state
+    )
 
     pp(experiment.topology)
     pp(experiment.state.get_value())


### PR DESCRIPTION
the `compose_experiment` method was replaced with the much cleaner `Composite.merge` a long time ago.

I would like to eventually phase out all `composition.py` functions, since working directly with `Engine` has become so much easier and is the recommended method.

-----------------------------------------------------------------------

By creating this pull request, I agree to the Contributor License
Agreement, which is available in `CLA.md` at the top level of this
repository.
