### PR TITLE
add pytest to setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,8 @@ if __name__ == '__main__':
             'numpy>=1.22.1',
             'Pint>=0.18',
             'pymongo>=4.0.1',
-            'scipy>=1.7.3'
+            'scipy>=1.7.3',
+            'pytest>=6.2.5'
         ],
         classifiers=[
             'Development Status :: 4 - Beta',


### PR DESCRIPTION
There are a couple uses of pytest documented in #181, which make pytest a requirement. Currently users have to install it themselves to run Vivarium. This PR adds it to setup.py. 
-----------------------------------------------------------------------

By creating this pull request, I agree to the Contributor License
Agreement, which is available in `CLA.md` at the top level of this
repository.
