### PR TITLE
floating-point timestep precision

### DIFF
--- a/vivarium/core/engine.py
+++ b/vivarium/core/engine.py
@@ -931,14 +931,19 @@ class Engine:
 
     def update(
             self,
-            interval: float
+            interval: float,
+            global_time_precision: int = 5
     ) -> None:
         """
         Run each process for the given interval and force them to complete
         at the end of the interval.
         """
         clock_start = clock.time()
-        self.run_for(interval=interval, force_complete=True)
+        self.run_for(
+            interval=interval,
+            force_complete=True,
+            global_time_precision=global_time_precision
+        )
         self._check_complete()
         runtime = clock.time() - clock_start
         if self.display_info:
@@ -962,6 +967,7 @@ class Engine:
             self,
             interval: float,
             force_complete: bool = False,
+            global_time_precision: int = 5,
     ) -> None:
         """Run each process within the given interval and update their states.
 
@@ -1013,13 +1019,9 @@ class Engine:
                         future = min(process_time + process_timestep, end_time)
                     else:
                         future = process_time + process_timestep
-
-                    print(f'FUTURE {future}')
-                    if future % 0.1 != 0:
-                        print(f'process_time {process_time}')
-                        print(f'process_timestep {process_timestep}')
-                        print(f'process_time + process_timestep {process_time + process_timestep}')
-                        import ipdb; ipdb.set_trace()
+                    if global_time_precision:
+                        # set future time based on global_time_precision
+                        future = round(future, global_time_precision)
 
                     if future <= end_time:
                         # calculate the update for this process
@@ -1039,10 +1041,6 @@ class Engine:
                     # absolute timestep
                     timestep = future - self.global_time
                     if timestep < full_step:
-
-                        print(f'full_step {full_step}')
-                        print(f'timestep {timestep}')
-
                         full_step = timestep
                 else:
                     # don't shoot past processes that didn't run this time

--- a/vivarium/core/engine.py
+++ b/vivarium/core/engine.py
@@ -1022,7 +1022,7 @@ class Engine:
                         future = min(process_time + process_timestep, end_time)
                     else:
                         future = process_time + process_timestep
-                    if global_time_precision:
+                    if global_time_precision is not None:
                         # set future time based on global_time_precision
                         future = round(future, global_time_precision)
 

--- a/vivarium/core/engine.py
+++ b/vivarium/core/engine.py
@@ -975,9 +975,9 @@ class Engine:
             interval: the amount of time to simulate the composite.
             force_complete: a bool indicating whether to force processes
                 to complete at the end of the interval.
-            global_time_precision: an optional int that sets the decimal precision
-                of global_time. This is useful for remove floating-point rounding
-                errors for the time keys of saved states.
+            global_time_precision: an optional int that sets the decimal
+                precision of global_time. This is useful for remove floating-
+                point rounding errors for the time keys of saved states.
         """
         end_time = self.global_time + interval
         emit_time = self.global_time + self.emit_step

--- a/vivarium/core/engine.py
+++ b/vivarium/core/engine.py
@@ -932,11 +932,11 @@ class Engine:
     def update(
             self,
             interval: float,
-            global_time_precision: int = 5
+            global_time_precision: Optional[int] = None
     ) -> None:
         """
         Run each process for the given interval and force them to complete
-        at the end of the interval.
+        at the end of the interval. See ``run_for`` for the keyword args.
         """
         clock_start = clock.time()
         self.run_for(
@@ -967,7 +967,7 @@ class Engine:
             self,
             interval: float,
             force_complete: bool = False,
-            global_time_precision: int = 5,
+            global_time_precision: Optional[int] = None
     ) -> None:
         """Run each process within the given interval and update their states.
 
@@ -975,6 +975,9 @@ class Engine:
             interval: the amount of time to simulate the composite.
             force_complete: a bool indicating whether to force processes
                 to complete at the end of the interval.
+            global_time_precision: an optional int that sets the decimal precision
+                of global_time. This is useful for remove floating-point rounding
+                errors for the time keys of saved states.
         """
         end_time = self.global_time + interval
         emit_time = self.global_time + self.emit_step

--- a/vivarium/core/engine.py
+++ b/vivarium/core/engine.py
@@ -1014,6 +1014,13 @@ class Engine:
                     else:
                         future = process_time + process_timestep
 
+                    print(f'FUTURE {future}')
+                    if future % 0.1 != 0:
+                        print(f'process_time {process_time}')
+                        print(f'process_timestep {process_timestep}')
+                        print(f'process_time + process_timestep {process_time + process_timestep}')
+                        import ipdb; ipdb.set_trace()
+
                     if future <= end_time:
                         # calculate the update for this process
                         if process.update_condition(process_timestep, states):
@@ -1032,6 +1039,10 @@ class Engine:
                     # absolute timestep
                     timestep = future - self.global_time
                     if timestep < full_step:
+
+                        print(f'full_step {full_step}')
+                        print(f'timestep {timestep}')
+
                         full_step = timestep
                 else:
                     # don't shoot past processes that didn't run this time

--- a/vivarium/experiments/engine_tests.py
+++ b/vivarium/experiments/engine_tests.py
@@ -1201,9 +1201,11 @@ def test_floating_point_timesteps():
     )
     sim.update(1)
     data = sim.emitter.get_data()
-    # print(pf(data))
+    print(pf(data))
     for t in data.keys():
-        assert t % transport_timestep == 0, f'bad timestep {t}'
+        ntimes = round(t / transport_timestep, 5)
+        expected_t = round(ntimes * transport_timestep, 5)
+        assert t == expected_t, f'bad timestep {t}'
 
 
 engine_tests = {

--- a/vivarium/experiments/engine_tests.py
+++ b/vivarium/experiments/engine_tests.py
@@ -1188,7 +1188,7 @@ def test_add_new_state() -> None:
     assert len(timeseries['agents'][agent_id]['extra']) == total_time + 1
 
 
-def test_floating_point_timesteps():
+def test_floating_point_timesteps() -> None:
     agent_id = '1'
     transport_timestep = 0.1
     composite = get_toy_transport_in_env_composite(

--- a/vivarium/experiments/engine_tests.py
+++ b/vivarium/experiments/engine_tests.py
@@ -1199,7 +1199,7 @@ def test_floating_point_timesteps() -> None:
         processes=composite.processes,
         topology=composite.topology,
     )
-    sim.update(1)
+    sim.update(1, global_time_precision=5)
     data = sim.emitter.get_data()
     print(pf(data))
     for t in data.keys():


### PR DESCRIPTION
Floating-point errors were causing small timesteps to be incorrectly added to `Engine.global_time`, leading to ugly output with base save times. The following example had one process with `timestep=0.1`:

```
 0.0: {'agents': {'1': {'external': {'GLC': 0.0}, 'internal': {'GLC': 0.0}}}},
  0.1: {'agents': {'1': {'external': {'GLC': 0.0}, 'internal': {'GLC': 0.0}}}},
  0.2: {'agents': {'1': {'external': {'GLC': 0.0}, 'internal': {'GLC': 0.0}}}},
  0.30000000000000004: { 'agents': { '1': { 'external': {'GLC': 0.0},
                                            'internal': {'GLC': 0.0}}}},
  0.4: {'agents': {'1': {'external': {'GLC': 0.0}, 'internal': {'GLC': 0.0}}}},
  0.5: {'agents': {'1': {'external': {'GLC': 0.0}, 'internal': {'GLC': 0.0}}}},
  0.6: {'agents': {'1': {'external': {'GLC': 0.0}, 'internal': {'GLC': 0.0}}}},
  0.7: {'agents': {'1': {'external': {'GLC': 0.0}, 'internal': {'GLC': 0.0}}}},
  0.7999999999999999: { 'agents': { '1': { 'external': {'GLC': 0.0},
                                           'internal': {'GLC': 0.0}}}},
  0.8999999999999999: { 'agents': { '1': { 'external': {'GLC': 0.0},
                                           'internal': {'GLC': 0.0}}}},
  0.9999999999999999: { 'agents': { '1': { 'external': {'GLC': 0.0},
                                           'internal': {'GLC': 0.0}}}},
  1.0: {'agents': {'1': {'external': {'GLC': 1.0}, 'internal': {'GLC': 0.0}}}}}
```

To solve this, I added a `global_time_precision` keyword arg to `Engine.run_for` and `Engine.update`, which rounds the global time to a set decimal precision. This is not done by default.

Now the test calls `Engine` like this:
```
sim.update(1, global_time_precision=5)
```

and returns output:
```
{ 0.0: {'agents': {'1': {'external': {'GLC': 0.0}, 'internal': {'GLC': 0.0}}}},
  0.1: {'agents': {'1': {'external': {'GLC': 0.0}, 'internal': {'GLC': 0.0}}}},
  0.2: {'agents': {'1': {'external': {'GLC': 0.0}, 'internal': {'GLC': 0.0}}}},
  0.3: {'agents': {'1': {'external': {'GLC': 0.0}, 'internal': {'GLC': 0.0}}}},
  0.4: {'agents': {'1': {'external': {'GLC': 0.0}, 'internal': {'GLC': 0.0}}}},
  0.5: {'agents': {'1': {'external': {'GLC': 0.0}, 'internal': {'GLC': 0.0}}}},
  0.6: {'agents': {'1': {'external': {'GLC': 0.0}, 'internal': {'GLC': 0.0}}}},
  0.7: {'agents': {'1': {'external': {'GLC': 0.0}, 'internal': {'GLC': 0.0}}}},
  0.8: {'agents': {'1': {'external': {'GLC': 0.0}, 'internal': {'GLC': 0.0}}}},
  0.9: {'agents': {'1': {'external': {'GLC': 0.0}, 'internal': {'GLC': 0.0}}}},
  1.0: {'agents': {'1': {'external': {'GLC': 1.0}, 'internal': {'GLC': 0.0}}}}}
```


-----------------------------------------------------------------------

By creating this pull request, I agree to the Contributor License
Agreement, which is available in `CLA.md` at the top level of this
repository.
