### PR TITLE
timestep instead of time_step

### DIFF
--- a/vivarium/composites/toys.py
+++ b/vivarium/composites/toys.py
@@ -263,7 +263,7 @@ class ToyLinearGrowthDeathProcess(Process):
 class Proton(Process):
     name = 'proton'
     defaults = {
-        'time_step': 1.0,
+        'timestep': 1.0,
         'radius': 0.0}
 
     def ports_schema(self):
@@ -314,7 +314,7 @@ class Proton(Process):
 class Electron(Process):
     name = 'electron'
     defaults = {
-        'time_step': 1.0,
+        'timestep': 1.0,
         'spin': electron_spins[0]}
 
     def ports_schema(self):
@@ -667,10 +667,10 @@ def test_composite_parameters() -> None:
     composer_parameters = bb_composer.get_parameters()
     composite_parameters = bb_composite.get_parameters()
     expected_parameters = {
-        'a1': {'time_step': 1.0},
-        'a2': {'time_step': 1.0},
+        'a1': {'timestep': 1.0},
+        'a2': {'timestep': 1.0},
         'a3_store': {
-            'a3': {'time_step': 1.0}}}
+            'a3': {'timestep': 1.0}}}
     assert composite_parameters == composer_parameters
     assert composite_parameters == expected_parameters
 

--- a/vivarium/core/process.py
+++ b/vivarium/core/process.py
@@ -82,43 +82,44 @@ def _get_parameters(
 
 
 class Process(metaclass=abc.ABCMeta):
+    """Process parent class.
+
+      All :term:`process` classes must inherit from this class. Each
+      class can provide a ``defaults`` class variable to specify the
+      process defaults as a dictionary.
+
+      Note that subclasses should call the superclass init function
+      first. This allows the superclass to correctly save the initial
+      parameters before they are mutated by subclass constructor code.
+      We need access to the original parameters for serialization to
+      work properly.
+
+      Args:
+          parameters: Override the class defaults. This dictionary may
+              also contain the following special keys:
+
+              * ``name``: Saved to ``self.name``.
+              * ``_original_parameters``: Returned by
+                ``__getstate__()`` for serialization.
+              * ``_no_original_parameters``: If specified with a value
+                of ``True``, original parameters will not be copied
+                during initialization, and ``__getstate__()`` will
+                instead return ``self.parameters``. This puts the
+                responsibility on the user to not mutate process
+                parameters.
+              * ``_schema``: Overrides the schema.
+              * ``_parallel``: Indicates that the process should be
+                parallelized. ``self.parallel`` will be set to True.
+              * ``_condition``: Path to a variable whose value will be
+                returned by
+                :py:meth:`vivarium.core.process.Process.update_condition`.
+              * ``time_step``: Returned by
+                :py:meth:`vivarium.core.process.Process.calculate_timestep`.
+      """
+
     defaults: Dict[str, Any] = {}
 
     def __init__(self, parameters: Optional[dict] = None) -> None:
-        """Process parent class.
-
-        All :term:`process` classes must inherit from this class. Each
-        class can provide a ``defaults`` class variable to specify the
-        process defaults as a dictionary.
-
-        Note that subclasses should call the superclass init function
-        first. This allows the superclass to correctly save the initial
-        parameters before they are mutated by subclass constructor code.
-        We need access to the original parameters for serialization to
-        work properly.
-
-        Args:
-            parameters: Override the class defaults. This dictionary may
-                also contain the following special keys:
-
-                * ``name``: Saved to ``self.name``.
-                * ``_original_parameters``: Returned by
-                  ``__getstate__()`` for serialization.
-                * ``_no_original_parameters``: If specified with a value
-                  of ``True``, original parameters will not be copied
-                  during initialization, and ``__getstate__()`` will
-                  instead return ``self.parameters``. This puts the
-                  responsibility on the user to not mutate process
-                  parameters.
-                * ``_schema``: Overrides the schema.
-                * ``_parallel``: Indicates that the process should be
-                  parallelized. ``self.parallel`` will be set to True.
-                * ``_condition``: Path to a variable whose value will be
-                  returned by
-                  :py:meth:`vivarium.core.process.Process.update_condition`.
-                * ``time_step``: Returned by
-                  :py:meth:`vivarium.core.process.Process.calculate_timestep`.
-        """
         parameters = parameters or {}
         if '_original_parameters' in parameters:
             original_parameters = parameters.pop('_original_parameters')
@@ -155,8 +156,14 @@ class Process(metaclass=abc.ABCMeta):
                 '_emit': True,
                 '_updater': 'set'}))
 
-        self.parameters.setdefault('time_step', DEFAULT_TIME_STEP)
+        self._set_timestep()
+
         self.schema: Optional[dict] = None
+
+    def _set_timestep(self) -> None:
+        self.parameters.setdefault('timestep', DEFAULT_TIME_STEP)
+        if self.parameters.get('time_step'):
+            self.parameters['timestep'] = self.parameters['time_step']
 
     def __getstate__(self) -> dict:
         """Return parameters
@@ -275,10 +282,10 @@ class Process(metaclass=abc.ABCMeta):
         """Return the next process time step
 
         A process subclass may override this method to implement
-        adaptive timesteps. By default it returns self.parameters['time_step'].
+        adaptive timesteps. By default it returns self.parameters['timestep'].
         """
         _ = states
-        return self.parameters['time_step']
+        return self.parameters['timestep']
 
     def default_state(self) -> State:
         """Get the default values of the variables in each port.

--- a/vivarium/core/serialize_test.py
+++ b/vivarium/core/serialize_test.py
@@ -117,7 +117,7 @@ def test_serialization_full() -> None:
         serialized.pop('function'))
     expected_serialized = {
         'process': (
-            "!ProcessSerializer[{'time_step': 1.0, '_name': "
+            "!ProcessSerializer[{'timestep': 1.0, '_name': "
             "'SerializeProcess'}]"
         ),
         '1': True,
@@ -170,3 +170,7 @@ def test_serialization_full() -> None:
         },
     }
     assert deserialized == expected_deserialized
+
+
+if __name__ == '__main__':
+    test_serialization_full()


### PR DESCRIPTION
This change the process parameter to `timestep` from `time_step`. This change is to keep consistent with other parts of the codebase, such as `engine.py`. `time_step` as a process input parameter remains compatible, but is internal changed to `timestep`.

-----------------------------------------------------------------------

By creating this pull request, I agree to the Contributor License
Agreement, which is available in `CLA.md` at the top level of this
repository.
