### PR TITLE
RAMEmitter only returns query if data exists

### DIFF
--- a/vivarium/core/emitter.py
+++ b/vivarium/core/emitter.py
@@ -262,8 +262,10 @@ class RAMEmitter(Emitter):
             for t, data in self.saved_data.items():
                 paths_data = []
                 for path in query:
-                    path_data = (path, get_in(data, path))
-                    paths_data.append(path_data)
+                    datum = get_in(data, path)
+                    if datum:
+                        path_data = (path, datum)
+                        paths_data.append(path_data)
                 returned_data[t] = paths_to_dict(paths_data)
             return returned_data
         return self.saved_data


### PR DESCRIPTION
Fixing a bug found while working on vivarium-ecoli. The `RAMEmitter.get_data(query)` was returning empty dicts for queries that did not exist. With this PR nothing is returned if the data does not exist. 

-----------------------------------------------------------------------

By creating this pull request, I agree to the Contributor License
Agreement, which is available in `CLA.md` at the top level of this
repository.
