### PR TITLE
track composite updates in engine

### DIFF
--- a/vivarium/core/composition.py
+++ b/vivarium/core/composition.py
@@ -183,8 +183,7 @@ def composite_in_experiment(
 
     # initialize the experiment
     experiment_config = {
-        'processes': processes,
-        'topology': topology,
+        'composite': composite,
         'initial_state': initial_state}
     for key, setting in settings.items():
         if key in experiment_config_keys:

--- a/vivarium/core/composition.py
+++ b/vivarium/core/composition.py
@@ -46,7 +46,6 @@ experiment_config_keys = [
         'experiment_id',
         'experiment_name',
         'description',
-        'initial_state',
         'emitter',
         'emit_step',
         'display_info',
@@ -182,13 +181,14 @@ def composite_in_experiment(
         add_environment(processes, topology, environment)
 
     # initialize the experiment
-    experiment_config = {
-        'composite': composite,
-        'initial_state': initial_state}
+    experiment_config = {}
     for key, setting in settings.items():
         if key in experiment_config_keys:
             experiment_config[key] = setting
-    return Engine(**experiment_config)
+    return Engine(
+        composite=composite,
+        initial_state=initial_state,
+        **experiment_config)
 
 
 def composer_in_experiment(

--- a/vivarium/core/engine.py
+++ b/vivarium/core/engine.py
@@ -551,8 +551,8 @@ class Engine:
         store. These are interchangeable.
         """
         if not store:
-            if processes and topology:
-                self.processes = processes
+            if (processes and topology) or (steps and topology):
+                self.processes = processes or {}
                 self.steps = steps or {}
                 self.flow = flow or {}
                 self.topology = topology

--- a/vivarium/core/engine.py
+++ b/vivarium/core/engine.py
@@ -557,11 +557,11 @@ class Engine:
                 self.flow = flow or {}
                 self.topology = topology
             elif composite:
-                self.processes = composite.processes
-                self.steps = composite.steps
-                self.flow = composite.flow
-                self.topology = composite.topology
-                self.initial_state = composite.state or self.initial_state
+                self.processes = composite['processes']
+                self.steps = composite['steps']
+                self.flow = composite['flow']
+                self.topology = composite['topology']
+                self.initial_state = composite['state'] or self.initial_state
             else:
                 raise Exception(
                     'load either composite, store, or '
@@ -863,6 +863,7 @@ class Engine:
             deletion: Path to store to delete.
         """
         delete_in(self.processes, deletion)
+        delete_in(self.steps, deletion)
         delete_in(self.topology, deletion)
 
         for path in list(self.process_paths.keys()):

--- a/vivarium/plots/topology.py
+++ b/vivarium/plots/topology.py
@@ -60,8 +60,12 @@ def get_bigraph(composite):
     """ Get a graph with Processes, Stores, and edges from a Vivarium topology """
     topology = composite['topology']
     processes = composite['processes']
+    steps = composite['steps']
     hierarchy_object = generate_state(
-        processes=processes, topology=topology, initial_state={})
+        processes=processes,
+        topology=topology,
+        initial_state={},
+        steps=steps)
 
     # get path to processes and stores, name them by their paths
     # leaf_paths = hierarchy_object.depth(filter_function=lambda x: x.inner == {})

--- a/vivarium/processes/tree_mass.py
+++ b/vivarium/processes/tree_mass.py
@@ -8,11 +8,10 @@ import os
 
 from scipy import constants
 
-from vivarium.core.engine import pp
+from vivarium.core.engine import pp, Engine
 from vivarium.core.process import Deriver
 from vivarium.library.units import units
 from vivarium.core.composition import (
-    process_in_experiment,
     PROCESS_OUT_DIR,
 )
 
@@ -152,8 +151,12 @@ def test_tree_mass():
     }
 
     # make the experiment with initial state
-    settings = {'initial_state': state}
-    experiment = process_in_experiment(mass_process, settings)
+    composite = mass_process.generate()
+    experiment = Engine(
+        processes=composite['processes'],
+        steps=composite['steps'],
+        topology=composite['topology'],
+        initial_state=state)
 
     # run experiment and get output
     experiment.update(1)


### PR DESCRIPTION
This fixes some bugs I found when working on topology plots for a Composite both before and after division. I noticed that after division, some Steps were missing from the topology plot. I tracked this down to incomplete passing of a composite's hierarchical updates to its steps -- while the engine was tracking the steps in `Engine.steps`, it wasn't being applied to the `composite['steps']` that had been passed into engine with `Engine(composite=composite)`. 

-----------------------------------------------------------------------

By creating this pull request, I agree to the Contributor License
Agreement, which is available in `CLA.md` at the top level of this
repository.
