### PR TITLE
make global_time_precision an Engine parameter

### DIFF
--- a/vivarium/experiments/engine_tests.py
+++ b/vivarium/experiments/engine_tests.py
@@ -1198,8 +1198,9 @@ def test_floating_point_timesteps() -> None:
     sim = Engine(
         processes=composite.processes,
         topology=composite.topology,
+        global_time_precision=5
     )
-    sim.update(1, global_time_precision=5)
+    sim.update(1)
     data = sim.emitter.get_data()
     print(pf(data))
     for t in data.keys():


### PR DESCRIPTION
make `global_time_precision` an `Engine` parameter instead of an `Engine.run_for()` keyword. This is more reproducible if we want to rerun a simulation.

-----------------------------------------------------------------------

By creating this pull request, I agree to the Contributor License
Agreement, which is available in `CLA.md` at the top level of this
repository.
