### PR TITLE
don't use timestep for quiet paths

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -118,3 +118,4 @@ variable-rgx=^[a-z][a-z0-9]*((_[a-z0-9]+)*)?$
 argument-rgx=^[a-z][a-z0-9]*((_[a-z0-9]+)*)?$
 include-naming-hint=yes
 max-statements=65
+max-nested-blocks=6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
 
+## v1.2.7
+
+* (#190) makes `global_time_precision` an `Engine` parameter rather than `Engine.run_for()` keyword -- this changes the method introduced in 1.2.5. Technically a breaking API, but only from 2 versions ago.
+* (#191) don't use timestep for quiet paths. This allows Engine to skip over processes that don't meet their update condition.
+
 ## v1.2.6
 
 * (#189) track composite updates in engine so that the composite topology can be plotted after being updated.

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import re
 from setuptools import setup
 
 
-VERSION = '1.2.6'
+VERSION = '1.2.7'
 
 
 if __name__ == '__main__':

--- a/vivarium/core/engine.py
+++ b/vivarium/core/engine.py
@@ -1028,6 +1028,7 @@ class Engine:
                         future = round(future, global_time_precision)
 
                     if future <= end_time:
+
                         # calculate the update for this process
                         if process.update_condition(process_timestep, states):
                             update = self._process_update(
@@ -1037,15 +1038,20 @@ class Engine:
                             self.front[path]['time'] = future
                             self.front[path]['update'] = update
 
+                            # absolute timestep
+                            timestep = future - self.global_time
+                            if timestep < full_step:
+                                full_step = timestep
                         else:
                             # mark this path "quiet" so its time can be advanced
                             self.front[path]['update'] = (EmptyDefer(), store)
                             quiet_paths.append(path)
+                    else:
+                        # absolute timestep
+                        timestep = future - self.global_time
+                        if timestep < full_step:
+                            full_step = timestep
 
-                    # absolute timestep
-                    timestep = future - self.global_time
-                    if timestep < full_step:
-                        full_step = timestep
                 else:
                     # don't shoot past processes that didn't run this time
                     process_delay = process_time - self.global_time


### PR DESCRIPTION
A previous PR pulled the calculation of which timestep to advance to the top level of the update loop, which meant the timesteps for quiet paths were being expressed even though they weren't being calculated or making updates. This was causing problems with combining processes with small time steps with processes with large time steps. 

The fix is to avoid updating the timestep if the process is not updating due to not meeting it's update condition in the current state. 

-----------------------------------------------------------------------

By creating this pull request, I agree to the Contributor License
Agreement, which is available in `CLA.md` at the top level of this
repository.
