### PR TITLE
Removing dtypes from serialize.py that are not available on several platforms

### DIFF
--- a/vivarium/core/serialize.py
+++ b/vivarium/core/serialize.py
@@ -188,8 +188,8 @@ class NumpyScalarSerializer(Serializer):
             np.bool_,
             np.int8, np.int16, np.int32, np.int64,
             np.uint8, np.uint16, np.uint32, np.uint64,
-            np.float16, np.float32, np.float64, np.float128,
-            np.complex64, np.complex128, np.complex256,
+            np.float16, np.float32, np.float64,
+            np.complex64, np.complex128,
         ))
 
     @staticmethod


### PR DESCRIPTION
<!-- Here you should describe what this PR does and why. -->
This PR closes #196, removing np.float128 and np.complex256 from serialize.py as they do not exist for numpy on some platforms (including Windows, ARM-based MacOS, which breaks scripts when trying to import them.
<!-- DO NOT MODIFY ANYTHING BELOW THIS LINE -->
-----------------------------------------------------------------------

By creating this pull request, I agree to the Contributor License
Agreement, which is available in `CLA.md` at the top level of this
repository.
