### PR TITLE
Deterministic step execution order within layers

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,10 +27,11 @@ jobs:
         pip install pytest
         pip install numpy
         if [ -f doc/requirements.txt ]; then pip install -r doc/requirements.txt; fi
-        brew install vale
+        wget https://github.com/errata-ai/vale/releases/download/v2.15.4/vale_2.15.4_Linux_64-bit.tar.gz
+        mkdir ~/bin && tar -xvzf vale_2.15.4_Linux_64-bit.tar.gz -C ~/bin
     - name: Test Building Documentation
       run: |
         doc/test.sh ci
     - name: Lint the Documentation
       run: |
-        doc/lint.sh ci
+        PATH="~/bin:$PATH" doc/lint.sh ci

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import re
 from setuptools import setup
 
 
-VERSION = '1.3.0'
+VERSION = '1.3.1'
 
 
 if __name__ == '__main__':

--- a/vivarium/core/engine.py
+++ b/vivarium/core/engine.py
@@ -256,10 +256,10 @@ class _StepGraph:
         self._sequential_steps.append(path)
         self._validate()
 
-    def get_execution_layers(self) -> List[Set[HierarchyPath]]:
+    def get_execution_layers(self) -> List[List[HierarchyPath]]:
         """Get step execution layers, with steps represnted by paths.
 
-        An execution layer is a set of steps that can be executed in
+        An execution layer is a list of steps that can be executed in
         parallel. The graph's execution layers are an ordered list of
         these layers such that:
 
@@ -276,8 +276,8 @@ class _StepGraph:
             represented by its path.
         """
         layers = nx.topological_generations(self._graph)
-        to_return = [set([step]) for step in self._sequential_steps]
-        to_return += [set(layer) for layer in layers]
+        to_return = [[step] for step in self._sequential_steps]
+        to_return += [sorted(layer) for layer in layers]
         return to_return
 
     def remove(self, path: HierarchyPath) -> None:

--- a/vivarium/core/engine.py
+++ b/vivarium/core/engine.py
@@ -711,14 +711,13 @@ class Engine:
             Tuple of the deferred update (in absolute terms) and
             ``store``.
         """
-
-        update = self._invoke_process(
+        process = self._invoke_process(
             process,
             interval,
             states)
 
         absolute = Defer(
-            update,
+            process,
             invert_topology,
             (path, store.topology))
 

--- a/vivarium/core/engine.py
+++ b/vivarium/core/engine.py
@@ -13,7 +13,7 @@ import logging as log
 import pprint
 import re
 from typing import (
-    Any, Dict, Optional, Union, Tuple, Callable, Iterable, List, Set,
+    Any, Dict, Optional, Union, Tuple, Callable, Iterable, List,
     cast, Sequence)
 import math
 import datetime

--- a/vivarium/experiments/engine_tests.py
+++ b/vivarium/experiments/engine_tests.py
@@ -590,9 +590,9 @@ class TestStepGraph:
 
         layers = list(tg.get_execution_layers())
         expected_layers = [
-            {('a',), ('b',)},
-            {('c',)},
-            {('d',)},
+            [('a',), ('b',)],
+            [('c',)],
+            [('d',)],
         ]
         assert layers == expected_layers
 
@@ -605,8 +605,8 @@ class TestStepGraph:
 
         layers = list(tg.get_execution_layers())
         expected_layers = [
-            {('c',)},
-            {('a',), ('b',)},
+            [('c',)],
+            [('a',), ('b',)],
         ]
         assert layers == expected_layers
 


### PR DESCRIPTION
Make step execution order deterministic, even within execution layers.

<!-- DO NOT MODIFY ANYTHING BELOW THIS LINE -->
-----------------------------------------------------------------------

By creating this pull request, I agree to the Contributor License
Agreement, which is available in `CLA.md` at the top level of this
repository.
