### PR TITLE
Add initial_state to composition.py Engine keys

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,12 +29,9 @@ jobs:
         if [ -f doc/requirements.txt ]; then pip install -r doc/requirements.txt; fi
         wget https://github.com/errata-ai/vale/releases/download/v2.15.4/vale_2.15.4_Linux_64-bit.tar.gz
         mkdir ~/bin && tar -xvzf vale_2.15.4_Linux_64-bit.tar.gz -C ~/bin
-        brew install vale
     - name: Test Building Documentation
       run: |
         doc/test.sh ci
     - name: Lint the Documentation
       run: |
-        doc/lint.sh ci
-      env:
-        PATH: "~/bin:$PATH"
+        PATH="~/bin:$PATH" doc/lint.sh ci

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,6 +27,8 @@ jobs:
         pip install pytest
         pip install numpy
         if [ -f doc/requirements.txt ]; then pip install -r doc/requirements.txt; fi
+        wget https://github.com/errata-ai/vale/releases/download/v2.15.4/vale_2.15.4_Linux_64-bit.tar.gz
+        mkdir ~/bin && tar -xvzf vale_2.15.4_Linux_64-bit.tar.gz -C ~/bin
         brew install vale
     - name: Test Building Documentation
       run: |
@@ -34,3 +36,5 @@ jobs:
     - name: Lint the Documentation
       run: |
         doc/lint.sh ci
+      env:
+        PATH: "~/bin:$PATH"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v1.3.1
+
+* (#200) Inside Engine, store the Step execution layers as lists instead
+  of sets to ensure deterministic execution order.
+* (#201) Restore ability to pass `initial_state` keys in `settings`
+  dictionaries to `composition.py` functions.
+
 ## v1.3.0
 
 * (#198) Introduce process commands to support more interactions with

--- a/vivarium/core/composition.py
+++ b/vivarium/core/composition.py
@@ -190,7 +190,7 @@ def composite_in_experiment(
     for key, setting in settings.items():
         if key in experiment_config_keys:
             experiment_config[key] = setting
-    return Engine(**experiment_config)
+    return Engine(**experiment_config)  # type: ignore
 
 
 def composer_in_experiment(

--- a/vivarium/core/composition.py
+++ b/vivarium/core/composition.py
@@ -47,6 +47,7 @@ experiment_config_keys = [
         'experiment_id',
         'experiment_name',
         'description',
+        'initial_state',
         'emitter',
         'emit_step',
         'display_info',
@@ -182,14 +183,14 @@ def composite_in_experiment(
         add_environment(processes, topology, environment)
 
     # initialize the experiment
-    experiment_config = {}
+    experiment_config = {
+        'composite': composite,
+        'initial_state': initial_state,
+    }
     for key, setting in settings.items():
         if key in experiment_config_keys:
             experiment_config[key] = setting
-    return Engine(
-        composite=composite,
-        initial_state=initial_state,
-        **experiment_config)
+    return Engine(**experiment_config)
 
 
 def composer_in_experiment(


### PR DESCRIPTION
In c5ce1b4, `initial_state` was removed from the list of allowed
experiment config keys to pass to `Engine`. This change was probably
made to avoid a clash between `initial_state` in the config dictionary
and the keyword argument, but the consequence is that initial states can
no longer be passed to many `composition.py` functions.

This commit restores `initial_state` to the list of allowed config keys
and avoids the clash by putting the keyword-arg `initial_state` into the
config dictionary.

<!-- DO NOT MODIFY ANYTHING BELOW THIS LINE -->
-----------------------------------------------------------------------

By creating this pull request, I agree to the Contributor License
Agreement, which is available in `CLA.md` at the top level of this
repository.
