### PR TITLE
Allow passing additional filters to data_from_database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v1.4.1
+
+* (#202) Add the `filters` argument to `data_from_database()` to allow
+  further filtering of MongoDB query results.
+
 ## v1.3.1
 
 * (#200) Inside Engine, store the Step execution layers as lists instead

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import re
 from setuptools import setup
 
 
-VERSION = '1.3.1'
+VERSION = '1.4.1'
 
 
 if __name__ == '__main__':

--- a/vivarium/core/emitter.py
+++ b/vivarium/core/emitter.py
@@ -417,6 +417,7 @@ def get_history_data_db(
         query: list = None,
         func_dict: dict = None,
         f: Callable[..., Any] = None,
+        filters: Optional[dict] = None,
 ) -> Dict[float, dict]:
     """Query MongoDB for history data.
 
@@ -431,11 +432,15 @@ def get_history_data_db(
             In the format: {('path', 'to', 'field1'): function}
         f: a function that applies equally to all fields in query. func_dict
             is the recommended approach and takes priority over f.
+        filters: MongoDB query arguments to further filter results
+            beyond matching the experiment ID.
     Returns:
         data (dict)
     """
 
     experiment_query = {'experiment_id': experiment_id}
+    if filters:
+        experiment_query.update(filters)
 
     projection = None
     if query:
@@ -496,6 +501,7 @@ def data_from_database(
         query: list = None,
         func_dict: dict = None,
         f: Callable[..., Any] = None,
+        filters: Optional[dict] = None,
 ) -> Tuple[dict, Any]:
     """Fetch something from a MongoDB."""
 
@@ -513,7 +519,7 @@ def data_from_database(
     # Retrieve timepoint data
     history = client.history
     data = get_history_data_db(
-        history, experiment_id, query, func_dict, f)
+        history, experiment_id, query, func_dict, f, filters)
 
     return data, experiment_config
 


### PR DESCRIPTION
It's sometimes useful to pass additional filters when retrieving simulation data from the database, for example to retrieve only every 10th timepoint from long simulations. This PR adds a `filters` argument to `data_from_database()` to allow this.

<!-- DO NOT MODIFY ANYTHING BELOW THIS LINE -->
-----------------------------------------------------------------------

By creating this pull request, I agree to the Contributor License
Agreement, which is available in `CLA.md` at the top level of this
repository.
