### PR TITLE
Optimize Serialization Using BSON C Extensions

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -93,6 +93,7 @@ intersphinx_mapping = {
     'python': ('https://docs.python.org/3', None),
     'shapely': ('https://shapely.readthedocs.io/en/latest/', None),
     'pint': ('https://pint.readthedocs.io/en/stable/', None),
+    'pymongo': ('https://pymongo.readthedocs.io/en/stable/', None)
 }
 
 # -- sphinx.ext.napoleon options --

--- a/vivarium/__init__.py
+++ b/vivarium/__init__.py
@@ -44,7 +44,7 @@ from vivarium.core.registry import (
     divide_null, divide_binomial, divide_set_value,
 )
 from vivarium.core.serialize import (
-    NumpySerializer, SequenceDeserializer,
+    ProcessSerializer, NumpySerializer, SequenceDeserializer,
     NumpyBoolSerializer, UnitsSerializer, DictDeserializer,
     FunctionSerializer, NumpyInt64Serializer, NumpyInt32Serializer,
     NumpyFloat32Serializer, SetSerializer
@@ -97,7 +97,7 @@ divider_registry.register('null', divide_null)
 
 # register serializers
 for SerializerClass in (
-        NumpySerializer, SequenceDeserializer,
+        ProcessSerializer, NumpySerializer, SequenceDeserializer,
         NumpyBoolSerializer, UnitsSerializer, DictDeserializer,
         FunctionSerializer, NumpyInt64Serializer, NumpyInt32Serializer,
         NumpyFloat32Serializer, SetSerializer):

--- a/vivarium/__init__.py
+++ b/vivarium/__init__.py
@@ -44,7 +44,7 @@ from vivarium.core.registry import (
     divide_null, divide_binomial, divide_set_value,
 )
 from vivarium.core.serialize import (
-    IdentityDeserializer, NumpySerializer, SequenceDeserializer,
+    NumpySerializer, SequenceDeserializer,
     NumpyBoolSerializer, UnitsSerializer, DictDeserializer,
     FunctionSerializer, NumpyInt64Serializer, NumpyInt32Serializer,
     NumpyFloat32Serializer, SetSerializer
@@ -97,7 +97,7 @@ divider_registry.register('null', divide_null)
 
 # register serializers
 for SerializerClass in (
-        IdentityDeserializer, NumpySerializer, SequenceDeserializer,
+        NumpySerializer, SequenceDeserializer,
         NumpyBoolSerializer, UnitsSerializer, DictDeserializer,
         FunctionSerializer, NumpyInt64Serializer, NumpyInt32Serializer,
         NumpyFloat32Serializer, SetSerializer):

--- a/vivarium/__init__.py
+++ b/vivarium/__init__.py
@@ -47,7 +47,7 @@ from vivarium.core.serialize import (
     IdentitySerializer, NumpySerializer, SequenceSerializer,
     NumpyBoolSerializer, UnitsSerializer, DictSerializer,
     FunctionSerializer, NumpyInt64Serializer, NumpyInt32Serializer,
-    NumpyFloat32Serializer
+    NumpyFloat32Serializer, SetSerializer
 )
 
 # import emitters
@@ -100,7 +100,7 @@ for SerializerClass in (
         IdentitySerializer, NumpySerializer, SequenceSerializer,
         NumpyBoolSerializer, UnitsSerializer, DictSerializer,
         FunctionSerializer, NumpyInt64Serializer, NumpyInt32Serializer,
-        NumpyFloat32Serializer):
+        NumpyFloat32Serializer, SetSerializer):
     serializer = SerializerClass()
     serializer_registry.register(
         serializer.name, serializer)

--- a/vivarium/__init__.py
+++ b/vivarium/__init__.py
@@ -45,9 +45,8 @@ from vivarium.core.registry import (
 )
 from vivarium.core.serialize import (
     IdentitySerializer, NumpySerializer, SequenceSerializer,
-    NumpyScalarSerializer, UnitsSerializer, ProcessSerializer,
-    ComposerSerializer, FunctionSerializer, ObjectIdSerializer,
-    DictSerializer,
+    NumpyBoolSerializer, UnitsSerializer, DictSerializer, 
+    FunctionSerializer
 )
 
 # import emitters
@@ -98,12 +97,11 @@ divider_registry.register('null', divide_null)
 # register serializers
 for SerializerClass in (
         IdentitySerializer, NumpySerializer, SequenceSerializer,
-        NumpyScalarSerializer, UnitsSerializer, ProcessSerializer,
-        ComposerSerializer, FunctionSerializer, ObjectIdSerializer,
-        DictSerializer):
+        NumpyBoolSerializer, UnitsSerializer, DictSerializer,
+        FunctionSerializer):
     serializer = SerializerClass()
     serializer_registry.register(
-        serializer.name, serializer, serializer.alternate_keys)
+        serializer.name, serializer)
 
 # register emitters
 emitter_registry.register('print', Emitter)

--- a/vivarium/__init__.py
+++ b/vivarium/__init__.py
@@ -45,8 +45,9 @@ from vivarium.core.registry import (
 )
 from vivarium.core.serialize import (
     IdentitySerializer, NumpySerializer, SequenceSerializer,
-    NumpyBoolSerializer, UnitsSerializer, DictSerializer, 
-    FunctionSerializer
+    NumpyBoolSerializer, UnitsSerializer, DictSerializer,
+    FunctionSerializer, NumpyInt64Serializer, NumpyInt32Serializer,
+    NumpyFloat32Serializer
 )
 
 # import emitters
@@ -98,7 +99,8 @@ divider_registry.register('null', divide_null)
 for SerializerClass in (
         IdentitySerializer, NumpySerializer, SequenceSerializer,
         NumpyBoolSerializer, UnitsSerializer, DictSerializer,
-        FunctionSerializer):
+        FunctionSerializer, NumpyInt64Serializer, NumpyInt32Serializer,
+        NumpyFloat32Serializer):
     serializer = SerializerClass()
     serializer_registry.register(
         serializer.name, serializer)

--- a/vivarium/__init__.py
+++ b/vivarium/__init__.py
@@ -44,8 +44,8 @@ from vivarium.core.registry import (
     divide_null, divide_binomial, divide_set_value,
 )
 from vivarium.core.serialize import (
-    IdentitySerializer, NumpySerializer, SequenceSerializer,
-    NumpyBoolSerializer, UnitsSerializer, DictSerializer,
+    IdentityDeserializer, NumpySerializer, SequenceDeserializer,
+    NumpyBoolSerializer, UnitsSerializer, DictDeserializer,
     FunctionSerializer, NumpyInt64Serializer, NumpyInt32Serializer,
     NumpyFloat32Serializer, SetSerializer
 )
@@ -97,8 +97,8 @@ divider_registry.register('null', divide_null)
 
 # register serializers
 for SerializerClass in (
-        IdentitySerializer, NumpySerializer, SequenceSerializer,
-        NumpyBoolSerializer, UnitsSerializer, DictSerializer,
+        IdentityDeserializer, NumpySerializer, SequenceDeserializer,
+        NumpyBoolSerializer, UnitsSerializer, DictDeserializer,
         FunctionSerializer, NumpyInt64Serializer, NumpyInt32Serializer,
         NumpyFloat32Serializer, SetSerializer):
     serializer = SerializerClass()

--- a/vivarium/core/emitter.py
+++ b/vivarium/core/emitter.py
@@ -298,6 +298,7 @@ class SharedRamEmitter(RAMEmitter):
         # We intentionally don't call the superclass constructor because
         # we don't want to create a per-instance ``saved_data``
         # attribute.
+        self.codec_options = get_codec_options()
         self.embed_path = config.get('embed_path', tuple())
 
 

--- a/vivarium/core/emitter.py
+++ b/vivarium/core/emitter.py
@@ -347,7 +347,7 @@ class DatabaseEmitter(Emitter):
             data = _bson_to_dict(data, self.codec_options)
             broken_down_data = breakdown_data(self.emit_limit, data)
             for (path, datum) in broken_down_data:
-                d = {}
+                d: Dict[str, Any] = {}
                 assoc_path(d, path, datum)
                 d['assembly_id'] = assembly_id
                 table.insert_one(d)

--- a/vivarium/core/emitter.py
+++ b/vivarium/core/emitter.py
@@ -13,6 +13,7 @@ from urllib.parse import quote_plus
 
 from bson import _dict_to_bson, _bson_to_dict
 from bson.errors import BSONError
+from bson.raw_bson import RawBSONDocument
 from pymongo import MongoClient
 
 from vivarium.library.units import remove_units
@@ -335,23 +336,20 @@ class DatabaseEmitter(Emitter):
         Break up large emits into smaller pieces and emit them individually
         """
         assembly_id = str(uuid.uuid4())
-        try:
-            emit_data['assembly_id'] = assembly_id
-            table.insert_one(emit_data)
-        # If document is too large, serialize and deserialize using
-        # BSON C extension before splitting to avoid heavy cost of
-        # getting string representation of Numpy arrays
-        except BSONError:
-            emit_data.pop('assembly_id')
-            data = emit_data.pop('data')
-            data = _dict_to_bson(data, False, self.codec_options)
+        emit_data['assembly_id'] = assembly_id
+        data = _dict_to_bson(emit_data, False, self.codec_options)
+        if len(data) > self.emit_limit:
             data = _bson_to_dict(data, self.codec_options)
+            data.pop('assembly_id')
             broken_down_data = breakdown_data(self.emit_limit, data)
             for (path, datum) in broken_down_data:
-                d = dict(emit_data)
-                assoc_path(d, ('data',) + path, datum)
+                d = {}
+                assoc_path(d, path, datum)
                 d['assembly_id'] = assembly_id
                 table.insert_one(d)
+        else:
+            d = RawBSONDocument(data)
+            table.insert_one(d)
 
     def get_data(self, query: list = None) -> dict:
         return get_history_data_db(self.history, self.experiment_id, query)

--- a/vivarium/core/emitter.py
+++ b/vivarium/core/emitter.py
@@ -265,6 +265,8 @@ class RAMEmitter(Emitter):
                 if key not in ['time']}
             data_at_time = assoc_path({}, self.embed_path, data_at_time)
             self.saved_data.setdefault(time, {})
+            data_at_time = _dict_to_bson(data_at_time, False, self.codec_options)
+            data_at_time = _bson_to_dict(data_at_time, self.codec_options)
             deep_merge_check(
                 self.saved_data[time], data_at_time, check_equality=True)
 

--- a/vivarium/core/emitter.py
+++ b/vivarium/core/emitter.py
@@ -11,6 +11,8 @@ import uuid
 from typing import Any, Dict, List, Optional, Tuple, Callable
 from urllib.parse import quote_plus
 
+from bson import _dict_to_bson, _bson_to_dict
+from bson.errors import BSONError
 from pymongo import MongoClient
 
 from vivarium.library.units import remove_units
@@ -20,7 +22,7 @@ from vivarium.library.dict_utils import (
     deep_merge,
 )
 from vivarium.library.topology import assoc_path, get_in, paths_to_dict
-from vivarium.core.serialize import deserialize_value
+from vivarium.core.serialize import get_codec_options, deserialize_value
 from vivarium.core.registry import emitter_registry
 
 MONGO_DOCUMENT_LIMIT = 1e7
@@ -241,6 +243,7 @@ class RAMEmitter(Emitter):
     def __init__(self, config: Dict[str, str]) -> None:
         super().__init__(config)
         self.saved_data: Dict[float, Dict[str, Any]] = {}
+        self.codec_options = get_codec_options()
 
     def emit(self, data: Dict[str, Any]) -> None:
         """
@@ -251,6 +254,8 @@ class RAMEmitter(Emitter):
         if data['table'] == 'history':
             emit_data = data['data']
             time = emit_data['time']
+            emit_data = _dict_to_bson(emit_data, False, self.codec_options)
+            emit_data = _bson_to_dict(emit_data, self.codec_options)
             self.saved_data[time] = {
                 key: value for key, value in emit_data.items()
                 if key not in ['time']}
@@ -312,9 +317,12 @@ class DatabaseEmitter(Emitter):
         self.create_indexes(self.configuration, CONFIGURATION_INDEXES)
         self.create_indexes(self.phylogeny, CONFIGURATION_INDEXES)
 
+        self.codec_options = get_codec_options()
+
     def emit(self, data: Dict[str, Any]) -> None:
         table_id = data['table']
-        table = getattr(self.db, table_id)
+        table = self.db.get_collection(
+            table_id, codec_options=self.codec_options)
         emit_data = {
             key: value for key, value in data.items()
             if key not in ['table']}
@@ -326,14 +334,24 @@ class DatabaseEmitter(Emitter):
 
         Break up large emits into smaller pieces and emit them individually
         """
-        data = emit_data.pop('data')
-        broken_down_data = breakdown_data(self.emit_limit, data)
         assembly_id = str(uuid.uuid4())
-        for (path, datum) in broken_down_data:
-            d = dict(emit_data)
-            assoc_path(d, ('data',) + path, datum)
-            d['assembly_id'] = assembly_id
-            table.insert_one(d)
+        try:
+            emit_data['assembly_id'] = assembly_id
+            table.insert_one(emit_data)
+        # If document is too large, serialize and deserialize using
+        # BSON C extension before splitting to avoid heavy cost of
+        # getting string representation of Numpy arrays
+        except BSONError:
+            emit_data.pop('assembly_id')
+            data = emit_data.pop('data')
+            data = _dict_to_bson(data, False, self.codec_options)
+            data = _bson_to_dict(data, self.codec_options)
+            broken_down_data = breakdown_data(self.emit_limit, data)
+            for (path, datum) in broken_down_data:
+                d = dict(emit_data)
+                assoc_path(d, ('data',) + path, datum)
+                d['assembly_id'] = assembly_id
+                table.insert_one(d)
 
     def get_data(self, query: list = None) -> dict:
         return get_history_data_db(self.history, self.experiment_id, query)

--- a/vivarium/core/engine.py
+++ b/vivarium/core/engine.py
@@ -32,7 +32,6 @@ from vivarium.core.process import (
     Step,
 )
 from vivarium.core.composer import Composite
-from vivarium.core.serialize import serialize_value
 from vivarium.library.topology import (
     get_in,
     delete_in,
@@ -642,7 +641,7 @@ class Engine:
         }
         emit_config: Dict[str, Any] = {
             'table': 'configuration',
-            'data': serialize_value(data)
+            'data': data
         }
         self.emitter.emit(emit_config)
 
@@ -655,7 +654,7 @@ class Engine:
             'time': self.global_time})
         emit_config = {
             'table': 'history',
-            'data': serialize_value(data)}
+            'data': data}
         self.emitter.emit(emit_config)
 
     def _invoke_process(

--- a/vivarium/core/registry.py
+++ b/vivarium/core/registry.py
@@ -426,10 +426,8 @@ class Serializer:
         return string_serialization
 
     def can_deserialize(self, data):
-        """Serializer will deserialize a string if it has the form::
-        
-            f'!{self.name or self.__class__.__name__}[serialized_data]'
-
+        """Serializer will deserialize a string if it has the form:
+        ``f'!{self.name or self.__class__.__name__}[serialized_data]'``
         """
         if not isinstance(data, str):
             return False

--- a/vivarium/core/registry.py
+++ b/vivarium/core/registry.py
@@ -60,13 +60,35 @@ function MUST return either:
 .. note:: Dividers MAY not be deterministic and MAY not be symmetric.
     For example, a divider splitting an odd, integer-valued value may
     randomly decide which daughter cell receives the remainder.
+    
+-----------
+Serializers
+-----------
+
+Each :term:`serializer` is defined as a class that follows the API we
+describe below. Vivarium uses these serializers to convert emitted data
+into a BSON-compatible format for database storage. Serializer names are
+registered in :py:data:`serializer_registry`, which maps these names to
+serializer subclasses.
+
+Serializer API
+==============
+
+Each serializer SHOULD implement the following methods and attributes:
+
+1. One or more codecs in of the type :py:class:`bson.codec_options.TypeCodec`
+   or one of its subclasses
+2. The :py:meth:`vivarium.core.registry.Serializer.get_codecs()` method
+3. The :py:meth:`vivarium.core.registry.Serializer.deserialize_from_string()`
+   method OR the :py:meth:`vivarium.core.registry.Serializer.deserialize()`
+   and :py:meth:`vivarium.core.registry.Serializer.can_deserialize()` methods
 """
 import copy
 import random
 import re
 
 import numpy as np
-from bson.codec_options import TypeEncoder
+from bson.codec_options import TypeCodec
 
 from vivarium.library.dict_utils import deep_merge
 from vivarium.library.units import Quantity
@@ -89,12 +111,7 @@ class Registry(object):
                 returned by ``Registry.list()``.
 
                 This may be useful if you want to be able to look up an
-                item in the registry under multiple keys. For example,
-                in a registry of serializers, you could register a
-                serializer with its name as ``key`` and the types it can
-                serialize under ``alternate_keys``. Then, when presented
-                with an object to serialize, you could use the object's
-                type to look up the appropriate serializer.
+                item in the registry under multiple keys.
         """
         keys = [key]
         keys.extend(alternate_keys)
@@ -335,36 +352,41 @@ def divide_null(state):
     """
     return None
 
-class Dummy():
-    dummy = ''
 
+class Dummy():
+    """Dummy class used to define example codec.
+    """
+    dummy = ''
 
 # Serializers
 class Serializer:
     """Base serializer class.
 
     Serializers work together to convert Python objects, which may be
-    collections of many different kinds of objects, into JSON-compatible
+    collections of many different kinds of objects, into BSON-compatible
     representations. Those representations can then be deserialized to
     recover the original object.
-
-    Most serializers convert an object to a string. To implement a
-    serializer of this type, you only need to implement the
-    :py:meth:`vivarium.core.registry.Serializer.serialize_to_string` and
-    :py:meth:`vivarium.core.registry.Serializer.deserialize()` methods.
+    
+    Serialization is mostly handled via the 
+    :py:class:`bson.codec_options.TypeCodec` interface of PyMongo.
+    If a store is assigned a custom serializer using the
+    ``_serializer`` key, serialization occurs instead via the
+    :py:meth:`vivarium.core.registry.Serializer.serialize()` method and
+    may be slower.
+    
+    Deserialization is typically handled by either the
+    :py:meth:`vivarium.core.registry.Serializer.deserialize()` or
+    :py:meth:`vivarium.core.registry.Serializer.deserialize_from_string()`
+    method depending on whether the subclass has a one-to-one mapping
+    between BSON and Python types (no codecs in the subclass or any other
+    subclass share the same input or output types as the codecs in the
+    subclass). Alternatively, if the defined codecs define ``bson_type``
+    and the ``transform_bson()`` method, deserialization is handled by
+    PyMongo, and :py:meth:`vivarium.core.registry.Serializer.deserialize()`
+    can be safely overriden to simply ``pass``.
 
     Args:
         name: Name of the serializer. Defaults to the class name.
-        exclusive_types: Types that are exclusively handled by this
-            serializer. These can be used to quickly lookup which
-            serializer handles a particular type. If an object does not
-            match any of these exclusive types, the `can_serialize`
-            method will be used as a fallback.
-
-            Note that exclusive type matching is exact--inheritance is
-            not accounted for. This means that if your serializer has an
-            exclusive type of A and B inherits from A, an instance of B
-            will not match to your serializer's exclusive types.
     """
     REGEX_FOR_NAME = re.compile('[A-Za-z0-9-_]+')
     REGEX_FOR_SERIALIZED_ANY_TYPE = re.compile(
@@ -373,27 +395,70 @@ class Serializer:
     def __init__(self, name=''):
         self.name = name or self.__class__.__name__
         self.regex_for_serialized = re.compile(f'!{self.name}\\[(.*)\\]')
-        self.codec = self.Codec()
+        self.codecs = self.get_codecs()
 
-    class Codec(TypeEncoder):
-        python_type = type(Dummy())
+    class Codec(TypeCodec):
+        """Example TypeCodec.
+        
+        All subclasses must have one or more codecs. Note that type checking
+        is exact, meaning subclasses of defined types require their own codecs.
+        """
+        python_type = type(Dummy()) #: Python type to serialize
         def transform_python(self, value):
+            """Converts ``value`` with type ``python_type`` into a
+            BSON-compatible type.
+            """
+            return None
+        bson_type = type(Dummy()) #: BSON type to deserialize
+        def transform_bson(self, value):
+            """Converts ``value`` with type ``bson_type`` into a
+            Python type."""
             return None
     
     def get_codecs(self):
-        return [self.codec]
+        """Get list of codecs in serializer.
+        
+        All subclasses should override this method.
+        """
+        return [self.Codec()]
     
     def serialize(self, data):
-        return self.codec.transform_python(data)
+        """Serialize data using correct codec.
+        
+        This is typically only called in the case that individual stores
+        are assigned custom serializers. For maximum efficiency, serialization
+        should be left to ``pymongo`` instead of calling this function.
+        
+        Do not override this function without good reason.
+        
+        Args:
+            data: Data to serialize
+            
+        Returns:
+            Serialized data
+        """
+        for codec in self.codecs:
+            if isinstance(data, codec.python_type):
+                return codec.transform_python(data)
 
     def deserialize_from_string(self, data):
         """Deserialize data from a string.
 
-        This function is the inverse of
-        :py:meth:`vivarium.core.registry.Serializer.serialize_to_string`.
-        It need only be overridden in a subclass if that subclass does
-        not override
-        :py:meth:`vivarium.core.registry.Serializer.deserialize`.
+        This function should only be overwritten if a codec does not form
+        a one-to-one mapping between BSON and Python types and instead
+        serializes data to strings of the form::
+
+            f'!{self.name or self.__class__.__name__}[serialized_data]'
+
+        It should turn ``serialized_data`` into the correct Python type.
+        
+        Args:
+            data: Serialized data without the 
+                ``!{self.name or self.__class__.__name__}``
+                prefix or the brackets
+                
+        Returns:
+            The deserialized data
         """
         raise NotImplementedError(
             f'{self} has not implemented deserialize_from_string().')
@@ -401,16 +466,16 @@ class Serializer:
     def deserialize(self, data):
         """Deserialize some data.
 
-        Subclasses relying on
-        :py:meth:`vivarium.core.registry.Serializer.serialize_to_string`
-        should not override this function and instead override
+        This function should typically only be overwritten if all codecs in
+        the subclass form one-to-one mappings between BSON and Python types.
+        Otherwise, leave this function alone and only override
         :py:meth:`vivarium.core.registry.Serializer.deserialize_from_string`.
 
         Args:
-            data: Serialized data to deserialize.
+            data: Serialized data to deserialize
 
         Returns:
-            The deserialized data.
+            The deserialized data
         """
         string_serialization = self.regex_for_serialized.fullmatch(
             data).group(1)
@@ -420,9 +485,11 @@ class Serializer:
         """Check whether the serializer can deserialize an object.
 
         By default, this function checks that ``data`` is a string of the
-        form produced by the default implementation of
-        :py:meth:`vivarium.core.registry.Serializer.serialize`. If a
-        subclass overrides this ``serialize()`` method, it should also
+        form::
+        
+            f'!{self.name or self.__class__.__name__}[serialized_data]'
+        
+        If a subclass does not serialize to this format, it should also
         override ``can_deserialize()``.
         """
         if not isinstance(data, str):

--- a/vivarium/core/registry.py
+++ b/vivarium/core/registry.py
@@ -401,7 +401,9 @@ class Serializer:
                 self.can_deserialize = lambda _: False
     
     def get_codecs(self):
-        """Get list of codecs in serializer.
+        """Get list of codecs in serializer. Codecs are class attributes of type
+        :py:class:`bson.codec_options.TypeCodec` that are used by PyMongo to
+        serialize and (optionally) deserialize data.
         """
         return []
     

--- a/vivarium/core/serialize.py
+++ b/vivarium/core/serialize.py
@@ -227,6 +227,20 @@ class NumpyFloat32Serializer(Serializer):
         raise NotImplementedError(
             f'{self} cannot be deserialized.')
 
+class SetSerializer(Serializer):
+
+    def __init__(self) -> None:
+        super().__init__()
+
+    class Codec(TypeEncoder):
+        python_type = set
+        def transform_python(self, value: set) -> List:
+            return list(value)
+
+    def deserialize_from_string(self, data: str) -> None:
+        raise NotImplementedError(
+            f'{self} cannot be deserialized.')
+
 class FunctionSerializer(Serializer):
     def __init__(self) -> None:
         super().__init__()

--- a/vivarium/core/serialize.py
+++ b/vivarium/core/serialize.py
@@ -137,12 +137,12 @@ class UnitsSerializer(Serializer):
                 unit_data = [d.to(unit) for d in data]
         else:
             # The superclass deserialize() extracts ... from !units[...].
-            data = super().deserialize(data)
-            if data.startswith('nan'):
-                unit = data[len('nan'):].strip()
-                unit_data = math.nan * units(unit)
+            str_data = super().deserialize(data)
+            if str_data.startswith('nan'):
+                unit_str = str_data[len('nan'):].strip()
+                unit_data = math.nan * units(unit_str)
             else:
-                unit_data = units(data)
+                unit_data = units(str_data)
             if unit is not None:
                 unit_data.to(unit)
         return unit_data

--- a/vivarium/core/serialize.py
+++ b/vivarium/core/serialize.py
@@ -1,6 +1,7 @@
 import math
 import warnings
-from typing import Any, List
+from typing import Any, List, Union
+from collections.abc import Callable
 
 import numpy as np
 from pint import Unit
@@ -89,7 +90,7 @@ class UnitsSerializer(Serializer):
 
     class Codec(TypeEncoder):
         python_type = type(units.fg)
-        def transform_python(self, value):
+        def transform_python(self, value: Any) -> Union[List[str], str]:
             try:
                 data = []
                 for subvalue in value:
@@ -101,7 +102,7 @@ class UnitsSerializer(Serializer):
     class Codec2(Codec):
         python_type = type(1*units.fg)
 
-    def get_codecs(self):
+    def get_codecs(self) -> List:
         return [self.Codec(), self.Codec2()]
 
     def deserialize_from_string(self, data: str) -> Quantity:
@@ -163,10 +164,10 @@ class NumpySerializer(Serializer):
 
     class Codec(TypeEncoder):
         python_type = np.ndarray
-        def transform_python(self, value):
+        def transform_python(self, value: np.ndarray) -> List:
             return value.tolist()
 
-    def deserialize_from_string(self, data):
+    def deserialize_from_string(self, data: str) -> None:
         raise NotImplementedError(
             f'{self} cannot be deserialized.')
 
@@ -177,24 +178,65 @@ class NumpyBoolSerializer(Serializer):
 
     class Codec(TypeEncoder):
         python_type = np.bool_
-        def transform_python(self, value):
+        def transform_python(self, value: np.bool_) -> bool:
             return bool(value)
 
-    def deserialize_from_string(self, data):
+    def deserialize_from_string(self, data: str) -> None:
         raise NotImplementedError(
             f'{self} cannot be deserialized.')
 
+class NumpyInt64Serializer(Serializer):
+
+    def __init__(self) -> None:
+        super().__init__()
+
+    class Codec(TypeEncoder):
+        python_type = np.int64
+        def transform_python(self, value: np.int64) -> int:
+            return int(value)
+
+    def deserialize_from_string(self, data: str) -> None:
+        raise NotImplementedError(
+            f'{self} cannot be deserialized.')
+
+class NumpyInt32Serializer(Serializer):
+
+    def __init__(self) -> None:
+        super().__init__()
+
+    class Codec(TypeEncoder):
+        python_type = np.int32
+        def transform_python(self, value: np.int32) -> int:
+            return int(value)
+
+    def deserialize_from_string(self, data: str) -> None:
+        raise NotImplementedError(
+            f'{self} cannot be deserialized.')
+
+class NumpyFloat32Serializer(Serializer):
+
+    def __init__(self) -> None:
+        super().__init__()
+
+    class Codec(TypeEncoder):
+        python_type = np.float32
+        def transform_python(self, value: np.float32) -> float:
+            return float(value)
+
+    def deserialize_from_string(self, data: str) -> None:
+        raise NotImplementedError(
+            f'{self} cannot be deserialized.')
 
 class FunctionSerializer(Serializer):
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
 
     class Codec(TypeEncoder):
         python_type = type(deserialize_value)
-        def transform_python(self, value):
+        def transform_python(self, value: Callable) -> str:
             return f"!FunctionSerializer[{str(value)}]"
 
-    def deserialize_from_string(self, data):
+    def deserialize_from_string(self, data: str) -> None:
         raise NotImplementedError(
             f'{self} cannot be deserialized.')
 
@@ -202,7 +244,7 @@ class FunctionSerializer(Serializer):
 # Subclasses of data types handled by custom
 # TypeEncoders require their own TypeEncoders.
 # This includes Process, Composites, etc.
-def get_codec_options():
+def get_codec_options() -> CodecOptions:
     codecs = []
     for serializer in serializer_registry.registry.values():
         codecs += serializer.get_codecs()

--- a/vivarium/core/serialize.py
+++ b/vivarium/core/serialize.py
@@ -9,6 +9,7 @@ from pint import Unit
 from pint.quantity import Quantity
 from bson.codec_options import TypeEncoder, TypeRegistry, CodecOptions
 from bson import _dict_to_bson, _bson_to_dict
+from vivarium.core.process import Process
 
 from vivarium.library.units import units
 from vivarium.core.registry import serializer_registry, Serializer
@@ -214,6 +215,15 @@ class FunctionSerializer(Serializer):
     def get_codecs(self) -> List:
         return [self.Codec()]
 
+class ProcessSerializer(Serializer):
+    """Serializer for processes if ``emit_process`` is enabled."""
+
+    def __init__(self) -> None:
+        super().__init__(name='processes')
+
+    def serialize(self, data: Process) -> str:
+        proc_str = str(dict(data.parameters, _name=data.name))
+        return f"!ProcessSerializer[{proc_str}]"
 
 # Subclasses of data types handled by custom
 # TypeEncoders require their own TypeEncoders.

--- a/vivarium/core/serialize_test.py
+++ b/vivarium/core/serialize_test.py
@@ -22,16 +22,16 @@ class SerializeProcess(Process):
 
 class SerializeProcessSerializer(Serializer):
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
 
     class Codec(TypeEncoder):
         python_type = type(SerializeProcess())
-        def transform_python(self, value):
+        def transform_python(self, value: SerializeProcess) -> str:
             return ("!ProcessSerializer[" +
                 str(dict(value.parameters, _name=value.name)) + "]")
 
-    def deserialize_from_string(self, data):
+    def deserialize_from_string(self, data: str) -> None:
         raise NotImplementedError(
             f'{self} cannot be deserialized.')
 

--- a/vivarium/core/serialize_test.py
+++ b/vivarium/core/serialize_test.py
@@ -59,8 +59,9 @@ class ToySerializer(Serializer):
         return bool(self.regex_for_serialized.fullmatch(data))
 
     def deserialize(self, data: str) -> str:
-        data = self.regex_for_serialized.fullmatch(
-            data).group(1)
+        matched_regex = self.regex_for_serialized.fullmatch(data)
+        if matched_regex:
+            data = matched_regex.group(1)
         if self.suffix:
             return data[len(self.prefix):-len(self.suffix)]
         return data[len(self.prefix):]

--- a/vivarium/core/serialize_test.py
+++ b/vivarium/core/serialize_test.py
@@ -3,11 +3,10 @@ import re
 from typing import Any
 
 import numpy as np
-from bson import _dict_to_bson, _bson_to_dict
 from bson.codec_options import TypeEncoder
 
 from vivarium.core.process import Process
-from vivarium.core.serialize import get_codec_options, deserialize_value
+from vivarium.core.serialize import serialize_value, deserialize_value
 from vivarium.core.registry import serializer_registry, Serializer
 from vivarium.library.units import units
 
@@ -21,19 +20,14 @@ class SerializeProcess(Process):
         return {}
 
 class SerializeProcessSerializer(Serializer):
-
-    def __init__(self) -> None:
-        super().__init__()
-
     class Codec(TypeEncoder):
         python_type = type(SerializeProcess())
         def transform_python(self, value: SerializeProcess) -> str:
             return ("!ProcessSerializer[" +
                 str(dict(value.parameters, _name=value.name)) + "]")
-
-    def deserialize_from_string(self, data: str) -> None:
-        raise NotImplementedError(
-            f'{self} cannot be deserialized.')
+    
+    def get_codecs(self):
+        return [self.Codec()]
 
 serializer_registry.register(
     "SerializeProcessSerializer", SerializeProcessSerializer())
@@ -64,7 +58,8 @@ class ToySerializer(Serializer):
 
         return f'!{self.name}[{string_serialization}]'
 
-    def deserialize_from_string(self, data: str) -> str:
+    def deserialize(self, data: str) -> str:
+        data = super().deserialize(data)
         if self.suffix:
             return data[len(self.prefix):-len(self.suffix)]
         return data[len(self.prefix):]
@@ -122,8 +117,6 @@ def test_exclamation_point_suffixing_serializer_string() -> None:
 def test_serialization_full() -> None:
     to_serialize = {
         'process': SerializeProcess(),
-        # Cannot handle non-string keys
-        # 1: True,
         'numpy_int': np.array([1, 2, 3]),
         'numpy_float': np.array([1.1, 2.2, 3.3]),
         'numpy_str': np.array(['a', 'b', 'c']),
@@ -140,8 +133,7 @@ def test_serialization_full() -> None:
         },
         'function': serialize_function,
     }
-    serialized = _dict_to_bson(to_serialize, False, get_codec_options())
-    serialized = _bson_to_dict(serialized, get_codec_options())
+    serialized = serialize_value(to_serialize)
     assert re.fullmatch(
         '!FunctionSerializer\\[<function serialize_function at 0x[0-9a-f]+>\\]',
         serialized.pop('function'))
@@ -150,7 +142,6 @@ def test_serialization_full() -> None:
             "!ProcessSerializer[{'timestep': 1.0, '_name': "
             "'SerializeProcess'}]"
         ),
-        # '1': True,
         'numpy_int': [1, 2, 3],
         'numpy_float': [1.1, 2.2, 3.3],
         'numpy_str': ['a', 'b', 'c'],
@@ -184,7 +175,6 @@ def test_serialization_full() -> None:
     deserialized.pop('nan_unit')
 
     expected_deserialized = {
-        # '1': True,
         'numpy_int': [1, 2, 3],
         'numpy_float': [1.1, 2.2, 3.3],
         'numpy_str': ['a', 'b', 'c'],

--- a/vivarium/core/serialize_test.py
+++ b/vivarium/core/serialize_test.py
@@ -25,7 +25,7 @@ class SerializeProcessSerializer(Serializer):
         def transform_python(self, value: SerializeProcess) -> str:
             return ("!ProcessSerializer[" +
                 str(dict(value.parameters, _name=value.name)) + "]")
-    
+
     def get_codecs(self) -> List:
         return [self.Codec()]
 

--- a/vivarium/core/store.py
+++ b/vivarium/core/store.py
@@ -191,6 +191,12 @@ class Store:
       dictionary by default.
     * **_emit** (:py:class:`bool`): Whether to emit the variable to the
       :term:`emitter`. This is ``False`` by default.
+    * **_serializer** (:py:class:`vivarium.core.registry.Serializer` or
+      :py:class:`str`): Serializer (or name of serializer) whose ``serialize``
+      method should be called on data in this store before emitting and whose
+      ``deserialize`` method should be called when repopulating this store
+      from serialized data. Only define if it is necessary to serialize and
+      deserialize data in this store differently from other data of the same type.
     """
     schema_keys = {
         '_default',
@@ -651,9 +657,6 @@ class Store:
                     self.units = self.units or self.default[0].units
                     self.serializer = (self.serializer or
                                        serializer_registry.access('units'))
-                elif isinstance(self.default, np.ndarray):
-                    self.serializer = (self.serializer or
-                                       serializer_registry.access('numpy'))
 
             if '_value' in config:
                 self.value = self._check_schema(
@@ -1026,8 +1029,6 @@ class Store:
                 if self.units:
                     return self.serializer.serialize(
                         self.value.to(self.units))
-                if isinstance(self.value, list):
-                    return self.value
                 return self.serializer.serialize(self.value)
             if self.units:
                 return self.value.to(self.units).magnitude

--- a/vivarium/core/store.py
+++ b/vivarium/core/store.py
@@ -1021,8 +1021,8 @@ class Store:
         if self.emit:
             if self.serializer:
                 if isinstance(self.value, list) and self.units:
-                    return self.serializer.serialize(
-                        [v.to(self.units) for v in self.value])
+                    return [self.serializer.serialize(v.to(self.units))
+                            for v in self.value]
                 if self.units:
                     return self.serializer.serialize(
                         self.value.to(self.units))

--- a/vivarium/experiments/engine_tests.py
+++ b/vivarium/experiments/engine_tests.py
@@ -1141,19 +1141,19 @@ class PoQoSerializer(Serializer):
 
     class Codec(TypeEncoder):
         python_type = type(Po())
-        def transform_python(self, value):
+        def transform_python(self, value: Po) -> str:
             return ("!ProcessSerializer[" +
                 str(dict(value.parameters, _name=value.name)) + "]")
     class Codec2(TypeEncoder):
         python_type = type(Qo())
-        def transform_python(self, value):
+        def transform_python(self, value: Qo) -> str:
             return ("!ProcessSerializer[" +
                 str(dict(value.parameters, _name=value.name)) + "]")
 
-    def get_codecs(self):
+    def get_codecs(self) -> List:
         return [self.Codec(), self.Codec2()]
 
-    def deserialize_from_string(self, data):
+    def deserialize_from_string(self, data: str) -> None:
         raise NotImplementedError(
             f'{self} cannot be deserialized.')
 

--- a/vivarium/experiments/engine_tests.py
+++ b/vivarium/experiments/engine_tests.py
@@ -1158,10 +1158,6 @@ class PoQoSerializer(Serializer):
     def get_codecs(self) -> List:
         return [self.Codec(), self.Codec2()]
 
-    def deserialize_from_string(self, data: str) -> None:
-        raise NotImplementedError(
-            f'{self} cannot be deserialized.')
-
 serializer_registry.register('PoQoSerializer', PoQoSerializer())
 
 def test_set_branch_emit() -> None:

--- a/vivarium/experiments/engine_tests.py
+++ b/vivarium/experiments/engine_tests.py
@@ -1,13 +1,15 @@
 import random
 import logging as log
 from typing import Optional, Union, Dict, Any, cast, List
+from bson.codec_options import TypeEncoder
 
 from vivarium.composites.toys import (
-    PoQo, Sine, ToyDivider, ToyTransport, ToyEnvironment,
+    Po, Qo, PoQo, Sine, ToyDivider, ToyTransport, ToyEnvironment,
     Proton, Electron)
 from vivarium.core.composer import Composer, Composite
 from vivarium.core.engine import Engine, pf, pp, _StepGraph
 from vivarium.core.process import Process, Step, Deriver
+from vivarium.core.registry import serializer_registry, Serializer
 from vivarium.core.store import Store, hierarchy_depth
 from vivarium.core.types import (
     Schema, State, Update, Topology, Steps, Processes)
@@ -1131,6 +1133,31 @@ def test_engine_run_for() -> None:
         assert advance['time'] == sim.global_time, \
             f"process at path {path} did not complete"
 
+# Demonstrates how each process to be emitted
+# must have its own codec
+class PoQoSerializer(Serializer):
+    def __init__(self) -> None:
+        super().__init__()
+
+    class Codec(TypeEncoder):
+        python_type = type(Po())
+        def transform_python(self, value):
+            return ("!ProcessSerializer[" +
+                str(dict(value.parameters, _name=value.name)) + "]")
+    class Codec2(TypeEncoder):
+        python_type = type(Qo())
+        def transform_python(self, value):
+            return ("!ProcessSerializer[" +
+                str(dict(value.parameters, _name=value.name)) + "]")
+
+    def get_codecs(self):
+        return [self.Codec(), self.Codec2()]
+
+    def deserialize_from_string(self, data):
+        raise NotImplementedError(
+            f'{self} cannot be deserialized.')
+
+serializer_registry.register('PoQoSerializer', PoQoSerializer())
 
 def test_set_branch_emit() -> None:
     run_time = 5


### PR DESCRIPTION
<!-- Here you should describe what this PR does and why. -->
## Rationale
Serialization of emitter data can make up a large portion of simulation runtimes, according to profiling data. 
## Proposal
PyMongo implements its serialization logic in C and has the ability to accept custom encoders via the [`TypeCodec` interface](https://pymongo.readthedocs.io/en/stable/examples/custom_type.html). Here, I modify the `Serializer` class to instantiate and return `TypeCodec` instances for serialization. 
## Results
When no document splitting is required, this PR nearly halves simulation time (running a simulation with a relatively large and complex emit). When document splitting is required at every timestep, the performance improvement drops to about 20%.
## Drawbacks
- Our [document-splitting algorithm](https://github.com/vivarium-collective/vivarium-core/blob/02b6bb51717e9d760cf425f851ff1b9064eb7590/vivarium/core/emitter.py#L50) is very slow on unserialized data due to the costliness of converting Numpy arrays to strings (used to determine size of dictionary). In my simulations, splitting the emit before serialization is still marginally faster than what we currently have. However, I can see this resulting in performance regressions for simulations that emit more/larger Numpy arrays.
  - **Solution 1:** Use PyMongo's C extensions to convert the data as follows before splitting: `dict` --> `BSON` --> `dict`. The final dictionary will contain only BSON-supported types (e.g. built-ins), making the cost of our document splitting algorithm negligible. Interestingly, this round-trip scheme still yields a 40% improvement.
  - **Solution 2:** Try to serialize and insert each document without splitting. Default to the round-trip solution when splitting is necessary. This is implemented in 973de3a and yields the aforementioned 50% improvement. If every document requires splitting (worst case scenario), this is just Solution 1 with the added cost of serializing the entire emit at each timestep.
  - **Solution 3:** Serialize the emit to BSON, then check whether the BSON is over MongoDB's size limit. If so, deserialize it back to dict, split as needed, and send the split data to PyMongo for re-serialization and insertion. If not, instantiate a [`RawBSONDocument`](https://pymongo.readthedocs.io/en/stable/api/bson/raw_bson.html) instance (which avoids PyMongo's internal serialization logic) and insert. This was implemented in b6b46f6 and ended up being significantly slower than Solution 2 even in the case where documents are split at every timestep.
  - **Note:** All relative performance numbers come from running my particular simulation. These margins of improvement may increase, decrease, or even become negative when running other simulations.
- PyMongo's serializer requires that all dictionary keys be strings (or subclasses of strings, like `np.str_`). This is in line with the official JSON specifications, but it does break [this test](https://github.com/vivarium-collective/vivarium-core/blob/02b6bb51717e9d760cf425f851ff1b9064eb7590/vivarium/core/serialize_test.py#L125).
- PyMongo does not automatically serialize objects that are subclasses of a class defined in a `TypeCodec`. This means that each `Process`, `Composer`, etc. requires its own `TypeCodec` as [demonstrated here](https://github.com/vivarium-collective/vivarium-core/blob/02b6bb51717e9d760cf425f851ff1b9064eb7590/vivarium/experiments/engine_tests.py#L1138).
- `TypeCodec` does not support custom de/serializers for Python's built-in types.
- All Python objects of a given type must be serialized the same way (e.g. cannot treat float-filled and string-filled Numpy arrays differently).
- Performance can be bottlenecked by document splitting for very large emits (e.g. simulation after multiple generations).
<!-- DO NOT MODIFY ANYTHING BELOW THIS LINE -->
-----------------------------------------------------------------------

By creating this pull request, I agree to the Contributor License
Agreement, which is available in `CLA.md` at the top level of this
repository.
