### PR TITLE
Prevent multi-updates in initial_state

### DIFF
--- a/vivarium/core/composer.py
+++ b/vivarium/core/composer.py
@@ -62,7 +62,7 @@ def _get_composite_state_recur(
             # Prevent multiupdates from forming when a single process has
             # multiple ports to the same stores holding a dictionary
             sub_state = inverse_topology(
-                path, process_state, sub_topology, initial=True)
+                path, process_state, sub_topology, multi_updates=False)
         else:
             Exception(f'invalid processes {sub_processes} or steps {sub_steps}')
         state = deep_merge(state, sub_state)

--- a/vivarium/core/composer.py
+++ b/vivarium/core/composer.py
@@ -59,7 +59,9 @@ def _get_composite_state_recur(
                 process_state = node.initial_state(config.get(node.name))
             elif state_type == 'default':
                 process_state = node.default_state()
-            sub_state = inverse_topology(path, process_state, sub_topology)
+            # Pass initial flag to prevent multiupdates from forming when a single process
+            # has multiple ports to the same, dictionary-based stores
+            sub_state = inverse_topology(path, process_state, sub_topology, initial=False)
         else:
             Exception(f'invalid processes {sub_processes} or steps {sub_steps}')
         state = deep_merge(state, sub_state)

--- a/vivarium/core/composer.py
+++ b/vivarium/core/composer.py
@@ -59,9 +59,10 @@ def _get_composite_state_recur(
                 process_state = node.initial_state(config.get(node.name))
             elif state_type == 'default':
                 process_state = node.default_state()
-            # Pass initial flag to prevent multiupdates from forming when a single process
-            # has multiple ports to the same, dictionary-based stores
-            sub_state = inverse_topology(path, process_state, sub_topology, initial=False)
+            # Prevent multiupdates from forming when a single process has
+            # multiple ports to the same stores holding a dictionary
+            sub_state = inverse_topology(
+                path, process_state, sub_topology, initial=True)
         else:
             Exception(f'invalid processes {sub_processes} or steps {sub_steps}')
         state = deep_merge(state, sub_state)

--- a/vivarium/library/topology.py
+++ b/vivarium/library/topology.py
@@ -149,7 +149,7 @@ def dict_to_paths(root, d):
         return [(root, d)]
 
 
-def inverse_topology(outer, update, topology, inverse=None, initial=False):
+def inverse_topology(outer, update, topology, inverse=None, multi_updates=True):
     '''
     Transform an update from the form its process produced into
     one aligned to the given topology.
@@ -178,7 +178,7 @@ def inverse_topology(outer, update, topology, inverse=None, initial=False):
                         update[child],
                         path,
                         inverse,
-                        initial)
+                        multi_updates)
             else:
                 for child, child_update in update.items():
                     inner = normalize_path(outer + path + (child,))
@@ -209,21 +209,21 @@ def inverse_topology(outer, update, topology, inverse=None, initial=False):
                     value,
                     path,
                     inverse,
-                    initial)
+                    multi_updates)
             else:
                 inner = normalize_path(outer + path)
                 if isinstance(value, dict):
-                    # Do not allow multiupdates when forming initial state
-                    if initial:
-                        inverse = update_in(
-                            inverse,
-                            inner,
-                            lambda current: deep_merge(current, value))
-                    else:
+                    if multi_updates:
                         inverse = update_in(
                             inverse,
                             inner,
                             lambda current: deep_merge_multi_update(current, value))
+                    # Do not allow multiupdates when forming initial state
+                    else:
+                        inverse = update_in(
+                            inverse,
+                            inner,
+                            lambda current: deep_merge(current, value))
                 else:
                     assoc_path(inverse, inner, value)
     return inverse

--- a/vivarium/library/topology.py
+++ b/vivarium/library/topology.py
@@ -149,7 +149,7 @@ def dict_to_paths(root, d):
         return [(root, d)]
 
 
-def inverse_topology(outer, update, topology, inverse=None):
+def inverse_topology(outer, update, topology, inverse=None, initial=False):
     '''
     Transform an update from the form its process produced into
     one aligned to the given topology.
@@ -177,7 +177,8 @@ def inverse_topology(outer, update, topology, inverse=None):
                         inner + (child,),
                         update[child],
                         path,
-                        inverse)
+                        inverse,
+                        initial)
             else:
                 for child, child_update in update.items():
                     inner = normalize_path(outer + path + (child,))
@@ -207,14 +208,22 @@ def inverse_topology(outer, update, topology, inverse=None):
                     inner,
                     value,
                     path,
-                    inverse)
+                    inverse,
+                    initial)
             else:
                 inner = normalize_path(outer + path)
                 if isinstance(value, dict):
-                    inverse = update_in(
-                        inverse,
-                        inner,
-                        lambda current: deep_merge_multi_update(current, value))
+                    # Do not allow multiupdates when forming initial state
+                    if initial:
+                        inverse = update_in(
+                            inverse,
+                            inner,
+                            lambda current: deep_merge(current, value))
+                    else:
+                        inverse = update_in(
+                            inverse,
+                            inner,
+                            lambda current: deep_merge_multi_update(current, value))
                 else:
                     assoc_path(inverse, inner, value)
     return inverse


### PR DESCRIPTION
<!-- Here you should describe what this PR does and why. -->
When a single process has multiple ports into a store holding a dictionary, running the `initial_state` method of the `Composite` yields a multi-update for the initial value of that store. This PR adds a flag to instead populate the store with the correct initial dictionary.
<!-- DO NOT MODIFY ANYTHING BELOW THIS LINE -->
-----------------------------------------------------------------------

By creating this pull request, I agree to the Contributor License
Agreement, which is available in `CLA.md` at the top level of this
repository.
