### PR TITLE
Support multiple emits for the same timestep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
-# v1.4.2
+## v1.5.1
+
+* (#206) Support multiple emits for the same timestep.
+
+## v1.4.2
 
 * (#203) Make `Store.soures` more comprehensive, in particular by
   including dividers and flows.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
 # Changelog
 
-## v1.5.1
+## v1.5.0
 
-* (#206) Support multiple emits for the same timestep.
+* (#206) Support multiple emits for the same timestep and remove
+  `Engine.complete()`. Instead, callers of `Engine.run_for()` must pass
+  `force_complete=True` at the end of their caller-managed simulation
+  loops.
 
 ## v1.4.2
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import re
 from setuptools import setup
 
 
-VERSION = '1.4.2'
+VERSION = '1.5.1'
 
 
 if __name__ == '__main__':

--- a/vivarium/__init__.py
+++ b/vivarium/__init__.py
@@ -52,7 +52,7 @@ from vivarium.core.serialize import (
 
 # import emitters
 from vivarium.core.emitter import (
-    Emitter, NullEmitter, RAMEmitter, DatabaseEmitter
+    Emitter, NullEmitter, RAMEmitter, SharedRamEmitter, DatabaseEmitter
 )
 
 _ = plt  # suppress PyCharm's unused-import warning
@@ -110,4 +110,5 @@ emitter_registry.register('print', Emitter)
 emitter_registry.register('null', NullEmitter)
 emitter_registry.register('timeseries', RAMEmitter)
 emitter_registry.register('ram', RAMEmitter)
+emitter_registry.register('shared_ram', SharedRamEmitter)
 emitter_registry.register('database', DatabaseEmitter)

--- a/vivarium/core/emitter.py
+++ b/vivarium/core/emitter.py
@@ -257,13 +257,13 @@ class RAMEmitter(Emitter):
         if data['table'] == 'history':
             emit_data = data['data']
             time = emit_data['time']
-            time_data = {
+            data_at_time = {
                 key: value for key, value in emit_data.items()
                 if key not in ['time']}
-            time_data = assoc_path({}, self.embed_path, time_data)
+            data_at_time = assoc_path({}, self.embed_path, data_at_time)
             self.saved_data.setdefault(time, {})
             deep_merge_check(
-                self.saved_data[time], time_data, check_equality=True)
+                self.saved_data[time], data_at_time, check_equality=True)
 
     def get_data(self, query: list = None) -> dict:
         """ Return the accumulated timeseries history of "emitted" data. """

--- a/vivarium/core/emitter.py
+++ b/vivarium/core/emitter.py
@@ -280,6 +280,21 @@ class RAMEmitter(Emitter):
         return self.saved_data
 
 
+class SharedRamEmitter(RAMEmitter):
+    """
+    Accumulate the timeseries history portion of the "emitted" data to a table
+    in RAM that is shared across all instances of the emitter.
+    """
+
+    saved_data: Dict[float, Dict[str, Any]] = {}
+
+    def __init__(self, config: Dict[str, Any]) -> None:  # pylint: disable=super-init-not-called
+        # We intentionally don't call the superclass constructor because
+        # we don't want to create a per-instance ``saved_data``
+        # attribute.
+        self.embed_path = config.get('embed_path', tuple())
+
+
 class DatabaseEmitter(Emitter):
     """
     Emit data to a mongoDB database

--- a/vivarium/core/emitter.py
+++ b/vivarium/core/emitter.py
@@ -257,13 +257,13 @@ class RAMEmitter(Emitter):
         if data['table'] == 'history':
             emit_data = data['data']
             time = emit_data['time']
-            timepoint = {
+            time_data = {
                 key: value for key, value in emit_data.items()
                 if key not in ['time']}
-            timepoint = assoc_path({}, self.embed_path, timepoint)
+            time_data = assoc_path({}, self.embed_path, time_data)
             self.saved_data.setdefault(time, {})
             deep_merge_check(
-                self.saved_data[time], timepoint, check_equality=True)
+                self.saved_data[time], time_data, check_equality=True)
 
     def get_data(self, query: list = None) -> dict:
         """ Return the accumulated timeseries history of "emitted" data. """

--- a/vivarium/core/emitter.py
+++ b/vivarium/core/emitter.py
@@ -262,7 +262,8 @@ class RAMEmitter(Emitter):
                 if key not in ['time']}
             timepoint = assoc_path({}, self.embed_path, timepoint)
             self.saved_data.setdefault(time, {})
-            deep_merge_check(self.saved_data[time], timepoint)
+            deep_merge_check(
+                self.saved_data[time], timepoint, check_equality=True)
 
     def get_data(self, query: list = None) -> dict:
         """ Return the accumulated timeseries history of "emitted" data. """
@@ -414,7 +415,11 @@ def assemble_data(data: list) -> dict:
             assembly_id = datum['assembly_id']
             if assembly_id not in assembly:
                 assembly[assembly_id] = {}
-            deep_merge_check(assembly[assembly_id], datum['data'])
+            deep_merge_check(
+                assembly[assembly_id],
+                datum['data'],
+                check_equality=True,
+            )
         else:
             assembly_id = str(uuid.uuid4())
             assembly[assembly_id] = datum['data']
@@ -497,7 +502,8 @@ def get_history_data_db(
         time = datum['time']
         deep_merge_check(
             data,
-            {time: without_multi(datum, ['_id', 'time'])}
+            {time: without_multi(datum, ['_id', 'time'])},
+            check_equality=True,
         )
 
     return data

--- a/vivarium/core/emitter.py
+++ b/vivarium/core/emitter.py
@@ -341,7 +341,13 @@ class DatabaseEmitter(Emitter):
     def emit(self, data: Dict[str, Any]) -> None:
         table_id = data['table']
         table = getattr(self.db, table_id)
+        time = data['data'].pop('time', None)
         data['data'] = assoc_path({}, self.embed_path, data['data'])
+        # Analysis scripts expect the time to be at the top level of the
+        # dictionary, but some emits, like configuration emits, lack a
+        # time key.
+        if time is not None:
+            data['data']['time'] = time
         emit_data = without_multi(data, ['table'])
         emit_data['experiment_id'] = self.experiment_id
         self.write_emit(table, emit_data)

--- a/vivarium/core/engine.py
+++ b/vivarium/core/engine.py
@@ -936,11 +936,6 @@ class Engine:
         if self.display_info:
             self._print_summary(runtime)
 
-    def complete(self) -> None:
-        """Force all processes to complete at the current global time"""
-        self.run_for(interval=0, force_complete=True)
-        self._check_complete()
-
     def _check_complete(self) -> None:
         """Check that all processes completed"""
         for path, advance in self.front.items():
@@ -963,6 +958,16 @@ class Engine:
             force_complete: bool = False,
     ) -> None:
         """Run each process within the given interval and update their states.
+
+        :py:meth:`run_for` gives the caller more control over the
+        simulation loop than :py:meth:`update`. In particular, it may be
+        called repeatedly within a caller-managed simulation loop
+        without forcing processes to complete after each call (as would
+        be the case with :py:meth:`update`). It is the responsibility
+        of the caller to ensure that when :py:meth:`run_for` is called
+        for the last time in the caller-managed simulation loop,
+        `force_complete=True` so that all the processes finish at the
+        end of the simulation.
 
         Args:
             interval: the amount of time to simulate the composite.

--- a/vivarium/core/engine.py
+++ b/vivarium/core/engine.py
@@ -329,6 +329,7 @@ class Engine:
             progress_bar: bool = False,
             global_time_precision: Optional[int] = None,
             profile: bool = False,
+            initial_global_time: float = 0,
     ) -> None:
         """Defines simulations
 
@@ -397,6 +398,9 @@ class Engine:
             emit_config: If True, this will emit the serialized initial
                 state with the configuration data.
             profile: Whether to profile the simulation with cProfile.
+            initial_global_time: The initial time for the simulation.
+                Useful when this Engine is part of a larger, older
+                simulation.
         """
         self.profiler: Optional[cProfile.Profile] = None
         if profile:
@@ -450,7 +454,7 @@ class Engine:
         self.emit_config = emit_config
 
         # initialize global time
-        self.global_time = 0.0
+        self.global_time = initial_global_time
 
         # front tracks how far each process has been simulated in time,
         # and also holds the processes' updates before they are applied.
@@ -655,7 +659,8 @@ class Engine:
             'time': self.global_time})
         emit_config = {
             'table': 'history',
-            'data': serialize_value(data)}
+            'data': serialize_value(data),
+        }
         self.emitter.emit(emit_config)
 
     def _invoke_process(

--- a/vivarium/core/store.py
+++ b/vivarium/core/store.py
@@ -1613,6 +1613,8 @@ class Store:
                 raise Exception(
                     f"failed update at path {self.path_for()} "
                     f"with value {self.value} for update {pformat(update)}")
+        if self.units:
+            self.value = self.value.to(self.units)
 
         return _EMPTY_UPDATES
 

--- a/vivarium/experiments/engine_tests.py
+++ b/vivarium/experiments/engine_tests.py
@@ -1105,7 +1105,12 @@ def test_engine_run_for() -> None:
 
     time = 0.0
     while sim.global_time < total_time:
-        sim.run_for(time_interval)
+        if time + time_interval >= total_time:
+            # If this is the last iteration of the simulation loop,
+            # force processes to complete.
+            sim.run_for(time_interval, force_complete=True)
+        else:
+            sim.run_for(time_interval)
         time += time_interval
         assert sim.global_time == time
 
@@ -1113,7 +1118,9 @@ def test_engine_run_for() -> None:
         front = sim.front
         for path, advance in front.items():
             expected_time = 0.0
-            if path[0] == 'process1':
+            if time >= total_time:
+                expected_time = total_time
+            elif path[0] == 'process1':
                 expected_time = int(time / timestep1) * timestep1
             elif path[0] == 'process2':
                 expected_time = int(time / timestep2) * timestep2
@@ -1121,8 +1128,6 @@ def test_engine_run_for() -> None:
                 f"front time {advance['time']} " \
                 f"is not expected {expected_time}"
 
-    # make all the processes complete
-    sim.complete()
     final_time = time
     assert sim.global_time == final_time
 

--- a/vivarium/library/dict_utils.py
+++ b/vivarium/library/dict_utils.py
@@ -21,23 +21,43 @@ def merge_dicts(dicts):
     return merge
 
 
-def deep_merge_check(dct, merge_dct):
-    """Recursive dict merge with checks
+def deep_merge_check(dct, merge_dct, check_equality=False, path=tuple()):
+    """Recursively merge dictionaries with checks to avoid overwriting.
 
-    Throws exceptions for conflicting values.
-    This mutates dct - the contents of merge_dct are added to dct (which is also returned).
-    If you want to keep dct you could call it like deep_merge_check(copy.deepcopy(dct), merge_dct)
+    Args:
+        dct: The dictionary to merge into. This dictionary is mutated
+            and ends up being the merged dictionary.  If you want to
+            keep dct you could call it like
+            ``deep_merge_check(copy.deepcopy(dct), merge_dct)``.
+        merge_dct: The dictionary to merge into ``dct``.
+        check_equality: Whether to use ``==`` to check for conflicts
+            instead of the default ``is`` comparator. Note that ``==``
+            can cause problems when used with Numpy arrays.
+        path: If the ``dct`` is nested within a larger dictionary, the
+            path to ``dct``. This is normally an empty tuple (the
+            default) for the end user but is used for recursive calls.
+
+    Returns:
+        ``dct``
+
+    Raises:
+        ValueError: Raised when conflicting values are found between
+            ``dct`` and ``merge_dct``.
     """
-
-    for k, v in merge_dct.items():
+    for k in merge_dct:
         if (k in dct and isinstance(dct[k], dict)
                 and isinstance(merge_dct[k], collections.abc.Mapping)):
-            try:
-                deep_merge_check(dct[k], merge_dct[k])
-            except ValueError:
-                raise ValueError('dict merge mismatch: key "{}" has values {} AND {}'.format(k, dct[k], merge_dct[k]))
-        elif k in dct and (dct[k] is not merge_dct[k]):
-            raise ValueError('dict merge mismatch: key "{}" has values {} AND {}'.format(k, dct[k], merge_dct[k]))
+            deep_merge_check(dct[k], merge_dct[k], check_equality, path + (k,))
+        elif k in dct and not check_equality and (dct[k] is not merge_dct[k]):
+            raise ValueError(
+                f'Failure to deep-merge dictionaries at path {path + (k,)}: '
+                f'{dct[k]} IS NOT {merge_dct[k]}'
+            )
+        elif k in dct and check_equality and (dct[k] != merge_dct[k]):
+            raise ValueError(
+                f'Failure to deep-merge dictionaries at path {path + (k,)}: '
+                f'{dct[k]} DOES NOT EQUAL {merge_dct[k]}'
+            )
         else:
             dct[k] = merge_dct[k]
     return dct

--- a/vivarium/library/topology.py
+++ b/vivarium/library/topology.py
@@ -74,10 +74,16 @@ def assoc_path(d, path, value):
 
 def without(d, removing):
     '''Get a copy of ``d`` without the key specified by ``removing``.'''
+    return without_multi(d, [removing])
+
+
+def without_multi(d, to_remove):
+    '''Get a copy of ``d`` without any of the keys in ``to_remove``.'''
     return {
         key: value
         for key, value in d.items()
-        if key != removing}
+        if key not in to_remove
+    }
 
 
 def update_in(d, path, f):

--- a/vivarium/processes/toy_gillespie.py
+++ b/vivarium/processes/toy_gillespie.py
@@ -218,15 +218,16 @@ def test_gillespie_process(total_time=1000):
 
     # run the experiment in large increments
     increment = 10
-    for _ in range(total_time):
+    for i in range(total_time):
+        if i == total_time - 1:
+            gillespie_experiment.run_for(increment, force_complete=True)
+            # Now the process is at the global time.
+            break
         gillespie_experiment.run_for(increment)
-
         # check that process remains behind global time
         front = gillespie_experiment.front
         assert front[('process',)]['time'] < gillespie_experiment.global_time
 
-    # complete
-    gillespie_experiment.complete()
     front = gillespie_experiment.front
     assert front[('process',)]['time'] == gillespie_experiment.global_time
 


### PR DESCRIPTION
This allows e.g. multiple parallel `Engine` instances to send emits to
the same destination, e.g. the same database. So long as they use the
same experiment IDs and have synchronized times, the emits will be
merged upon retrieval.

<!-- DO NOT MODIFY ANYTHING BELOW THIS LINE -->
-----------------------------------------------------------------------

By creating this pull request, I agree to the Contributor License
Agreement, which is available in `CLA.md` at the top level of this
repository.
