### PR TITLE
Handle lists of Quantities in `Store.apply_update`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v1.5.2
+
+* (#207) Fix a bug in `Store.apply_update()` that caused failures when
+  `self.value` was a list and `self.units` was set.
+
 ## v1.5.1
 
 * (#206) Support multiple emits for the same timestep and remove

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import re
 from setuptools import setup
 
 
-VERSION = '1.5.1'
+VERSION = '1.5.2'
 
 
 if __name__ == '__main__':

--- a/vivarium/core/serialize.py
+++ b/vivarium/core/serialize.py
@@ -74,8 +74,9 @@ class IdentitySerializer(Serializer):  # pylint: disable=abstract-method
     '''Serializer for base types that get serialized as themselves.'''
 
     def __init__(self) -> None:
-        super().__init__(
-            exclusive_types=(int, float, bool, str, type(None)))
+        super().__init__(exclusive_types=(
+            int, float, bool, str, type(None), np.str_
+        ))
 
     def can_serialize(self, data: Any) -> bool:
         if (

--- a/vivarium/core/store.py
+++ b/vivarium/core/store.py
@@ -1614,7 +1614,10 @@ class Store:
                     f"failed update at path {self.path_for()} "
                     f"with value {self.value} for update {pformat(update)}")
         if self.units:
-            self.value = self.value.to(self.units)
+            if isinstance(self.value, list):
+                self.value = [v.to(self.units) for v in self.value]
+            else:
+                self.value = self.value.to(self.units)
 
         return _EMPTY_UPDATES
 


### PR DESCRIPTION
Fix a bug in `Store.apply_update` to correctly handle lists of `Quantity` objects.

<!-- DO NOT MODIFY ANYTHING BELOW THIS LINE -->
-----------------------------------------------------------------------

By creating this pull request, I agree to the Contributor License
Agreement, which is available in `CLA.md` at the top level of this
repository.
