### PR TITLE
Fix memory leak and parallel process division

### DIFF
--- a/vivarium/core/process.py
+++ b/vivarium/core/process.py
@@ -155,8 +155,8 @@ class Process(metaclass=abc.ABCMeta):
 
         self._parameters = copy.deepcopy(self.defaults)
         self._parameters = deep_merge(self._parameters, parameters)
-        self._schema_override: Schema = self._parameters.pop('_schema', {})
-        self._parallel = self._parameters.pop('_parallel', False)
+        self._schema_override: Schema = self._parameters.get('_schema', {})
+        self._parallel = self._parameters.get('_parallel', False)
         self._condition_path: Optional[HierarchyPath] = None
         self._command_result: Any = None
         self._pending_command: Optional[
@@ -164,7 +164,7 @@ class Process(metaclass=abc.ABCMeta):
 
         # set up the conditional state if a condition key is provided
         if '_condition' in self._parameters:
-            self._condition_path = self._parameters.pop('_condition')
+            self._condition_path = self._parameters.get('_condition')
         if self._condition_path:
             self.merge_overrides(assoc_path({}, self._condition_path, {
                 '_default': True,


### PR DESCRIPTION
<!-- Here you should describe what this PR does and why. -->
Parallel processes were not properly saving certain class attributes, including `_parallel`, causing them to be lost upon pickling during division.

Additionally, we were not properly ending parallel processes when deleting stores, causing a memory leak. 

Both of these issues are fixed in this PR.
<!-- DO NOT MODIFY ANYTHING BELOW THIS LINE -->
-----------------------------------------------------------------------

By creating this pull request, I agree to the Contributor License
Agreement, which is available in `CLA.md` at the top level of this
repository.
