### PR TITLE
Make TimelineProcess a Step

### DIFF
--- a/vivarium/core/composition.py
+++ b/vivarium/core/composition.py
@@ -344,7 +344,7 @@ def test_composer_in_experiment() -> None:
     output = simulate_experiment(experiment, settings)
 
     # check that timeline worked
-    assert output['aaa']['a1'][6] == 10
+    assert output['aaa']['a1'][5] == 10
     assert settings['total_time'] == 15
     assert len(output['aaa']['a1']) == 16
 

--- a/vivarium/processes/remove.py
+++ b/vivarium/processes/remove.py
@@ -112,7 +112,9 @@ def test_remove():
     output = sim.emitter.get_timeseries()
 
     assert len(output['agents']['1']['dead']) == time_dead + 1
-    assert len(output['time']) == time_total + 1
+    # Simulation stops emitting when Processes (not Steps) are deleted
+    # Add 2 to account for t=0 and t=6 (when processes see the death flag)
+    assert len(output['time']) == time_dead + 2
 
     return output
 

--- a/vivarium/processes/timeline.py
+++ b/vivarium/processes/timeline.py
@@ -1,7 +1,7 @@
 import logging as log
 
 from vivarium.library.dict_utils import deep_merge_combine_lists
-from vivarium.core.process import Process
+from vivarium.core.process import Step
 
 
 def nested_set(dic, keys, value):
@@ -14,7 +14,7 @@ def nested_set(dic, keys, value):
     dic[keys[-1]] = value
 
 
-class TimelineProcess(Process):
+class TimelineProcess(Step):
 
     name = 'timeline'
 
@@ -81,7 +81,7 @@ class TimelineProcess(Process):
 
     def next_update(self, timestep, states):
         time = states['global']['time']
-        update = {'global': {'time': timestep}}
+        update = {'global': {'time': self.parameters['timestep']}}
         for (t, change_dict) in self.timeline:
             if time >= t:
                 for path_to_variable, value in change_dict.items():


### PR DESCRIPTION
<!-- Here you should describe what this PR does and why. -->
This corrects `TimelineProcess` to apply updates at the time(s) indicated in the timeline. Before, specifying an update at t=0, for example, only results in an updated simulation state after a timestep has elapsed. 
<!-- DO NOT MODIFY ANYTHING BELOW THIS LINE -->
-----------------------------------------------------------------------

By creating this pull request, I agree to the Contributor License
Agreement, which is available in `CLA.md` at the top level of this
repository.
