### PR TITLE
Optimize dictionary key removal

### DIFF
--- a/vivarium/__init__.py
+++ b/vivarium/__init__.py
@@ -2,9 +2,6 @@
 Register processes, updaters, dividers, serializers upon import
 """
 
-# import matplotlib to help fix bug with import order
-import matplotlib.pyplot as plt
-
 # import registries
 from vivarium.core.registry import (
     process_registry,
@@ -54,8 +51,6 @@ from vivarium.core.serialize import (
 from vivarium.core.emitter import (
     Emitter, NullEmitter, RAMEmitter, SharedRamEmitter, DatabaseEmitter
 )
-
-_ = plt  # suppress PyCharm's unused-import warning
 
 
 # register processes

--- a/vivarium/core/emitter.py
+++ b/vivarium/core/emitter.py
@@ -24,7 +24,6 @@ from vivarium.library.topology import (
     assoc_path,
     get_in,
     paths_to_dict,
-    without_multi,
 )
 from vivarium.core.registry import emitter_registry
 from vivarium.core.serialize import (
@@ -358,7 +357,8 @@ class DatabaseEmitter(Emitter):
         # time key.
         if time is not None:
             data['data']['time'] = time
-        emit_data = without_multi(data, ['table'])
+        emit_data = data.copy()
+        emit_data.pop('table', None)
         emit_data['experiment_id'] = self.experiment_id
         self.write_emit(table, emit_data)
 
@@ -524,9 +524,12 @@ def get_history_data_db(
     data: Dict[float, Any] = {}
     for datum in assembly.values():
         time = datum['time']
+        datum = datum.copy()
+        datum.pop('_id', None)
+        datum.pop('time', None)
         deep_merge_check(
             data,
-            {time: without_multi(datum, ['_id', 'time'])},
+            {time: datum},
             check_equality=True,
         )
 

--- a/vivarium/core/store.py
+++ b/vivarium/core/store.py
@@ -586,11 +586,9 @@ class Store:
         config.pop('_output', None)
 
         if '*' in config:
-            config = config.copy()
             self._apply_subschema_config(config.pop('*'))
 
         if '_subschema' in config:
-            config = config.copy()
             subschema = config.pop('_subschema')
             if source:
                 self.sources[source] = subschema
@@ -599,24 +597,20 @@ class Store:
             
 
         if '_subtopology' in config:
-            config = config.copy()
             self._merge_subtopology(config.pop('_subtopology'))
 
         if source:
             self.sources[source] = config
 
         if '_topology' in config:
-            config = config.copy()
             self.topology = config.pop('_topology')
 
         if '_flow' in config:
-            config = config.copy()
             flow = config.pop('_flow')
             if flow != {}:
                 self.flow = flow
 
         if '_divider' in config:
-            config = config.copy()
             new_divider = config.pop('_divider')
             self.divider = self._check_schema_support_defaults(
                 'divider', new_divider, divider_registry)
@@ -624,7 +618,6 @@ class Store:
         # If emit is set on a branch node, set the entire branch to the
         # emit value.
         if '_emit' in config and self.inner:
-            config = config.copy()
             emit_value = config.pop('_emit')
             self.set_emit_value(emit=emit_value)
 

--- a/vivarium/core/store.py
+++ b/vivarium/core/store.py
@@ -19,7 +19,7 @@ from typing import Optional
 from vivarium import divider_registry, serializer_registry, updater_registry
 from vivarium.core.process import ParallelProcess, Process
 from vivarium.library.dict_utils import deep_merge, deep_merge_check, MULTI_UPDATE_KEY
-from vivarium.library.topology import without, dict_to_paths
+from vivarium.library.topology import dict_to_paths
 from vivarium.core.types import Processes, Topology, State, Steps, Flow
 
 _EMPTY_UPDATES = None, None, None, None, None, None
@@ -582,47 +582,51 @@ class Store:
             config = {}  # config needs to be a dict
 
         # remove _output special key. This is used only by schema_topology.
-        config = without(config, '_output')
+        config = config.copy()
+        config.pop('_output', None)
 
         if '*' in config:
-            self._apply_subschema_config(config['*'])
-            config = without(config, '*')
+            config = config.copy()
+            self._apply_subschema_config(config.pop('*'))
 
         if '_subschema' in config:
+            config = config.copy()
+            subschema = config.pop('_subschema')
             if source:
-                self.sources[source] = config['_subschema']
-            self._apply_subschema_config(config['_subschema'])
-            config = without(config, '_subschema')
+                self.sources[source] = subschema
+            self._apply_subschema_config(subschema)
+            
+            
 
         if '_subtopology' in config:
-            self._merge_subtopology(config['_subtopology'])
-            config = without(config, '_subtopology')
+            config = config.copy()
+            self._merge_subtopology(config.pop('_subtopology'))
 
         if source:
             self.sources[source] = config
 
         if '_topology' in config:
-            self.topology = config['_topology']
-            config = without(config, '_topology')
+            config = config.copy()
+            self.topology = config.pop('_topology')
 
         if '_flow' in config:
-            flow = config['_flow']
-            config = without(config, '_flow')
+            config = config.copy()
+            flow = config.pop('_flow')
             if flow != {}:
                 self.flow = flow
 
         if '_divider' in config:
-            new_divider = config['_divider']
+            config = config.copy()
+            new_divider = config.pop('_divider')
             self.divider = self._check_schema_support_defaults(
                 'divider', new_divider, divider_registry)
-            config = without(config, '_divider')
 
         # If emit is set on a branch node, set the entire branch to the
         # emit value.
         if '_emit' in config and self.inner:
-            emit_value = config['_emit']
+            config = config.copy()
+            emit_value = config.pop('_emit')
             self.set_emit_value(emit=emit_value)
-            config = without(config, '_emit')
 
         if self.schema_keys & set(config.keys()):
             # We are at a leaf node, so apply its config.
@@ -1761,11 +1765,11 @@ class Store:
 
         node = self
         if '_path' in path:
+            path = path.copy()
             node = self._establish_path(
-                path['_path'],
+                path.pop('_path'),
                 {},
                 source=source)
-            path = without(path, '_path')
 
         return node, path
 

--- a/vivarium/library/topology.py
+++ b/vivarium/library/topology.py
@@ -72,20 +72,6 @@ def assoc_path(d, path, value):
     return d
 
 
-def without(d, removing):
-    '''Get a copy of ``d`` without the key specified by ``removing``.'''
-    return without_multi(d, [removing])
-
-
-def without_multi(d, to_remove):
-    '''Get a copy of ``d`` without any of the keys in ``to_remove``.'''
-    return {
-        key: value
-        for key, value in d.items()
-        if key not in to_remove
-    }
-
-
 def update_in(d, path, f):
     '''Update every value in a dictionary based on ``f``.
 
@@ -173,8 +159,8 @@ def inverse_topology(outer, update, topology, inverse=None, multi_updates=True):
             if isinstance(path, dict):
                 node = inverse
                 if '_path' in path:
-                    inner = normalize_path(outer + path['_path'])
-                    path = without(path, '_path')
+                    path = path.copy()
+                    inner = normalize_path(outer + path.pop('_path'))
                 else:
                     inner = outer
 
@@ -201,8 +187,8 @@ def inverse_topology(outer, update, topology, inverse=None, multi_updates=True):
             value = update[key]
             if isinstance(path, dict):
                 if '_path' in path:
-                    inner = normalize_path(outer + path['_path'])
-                    path = without(path, '_path')
+                    path = path.copy()
+                    inner = normalize_path(outer + path.pop('_path'))
 
                     for update_key in update[key].keys():
                         if update_key not in path and '*' not in path:


### PR DESCRIPTION
<!-- Here you should describe what this PR does and why. -->
The `without` and `without_multi` functions are surprisingly slow. Creating a shallow copy of the dictionary and popping the desired keys is functionally equivalent but much faster.

I also removed a `pyplot` import that no longer seems to be necessary.
<!-- DO NOT MODIFY ANYTHING BELOW THIS LINE -->
-----------------------------------------------------------------------

By creating this pull request, I agree to the Contributor License
Agreement, which is available in `CLA.md` at the top level of this
repository.
