### PR TITLE
Serialization fixes

### DIFF
--- a/doc/reference/api/vivarium.core.serialize.rst
+++ b/doc/reference/api/vivarium.core.serialize.rst
@@ -2,4 +2,4 @@
    :members:
    :undoc-members:
    :show-inheritance:
-   :exclude-members: transform_python, python_type
+   :exclude-members: python_type

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -19,6 +19,7 @@ more-itertools==8.5.0
 nbsphinx==0.8.7
 networkx==2.5
 numpy==1.19.1
+orjson==3.8.0
 packaging==20.4
 Pillow==7.2.0
 Pint==0.15

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ numpy==1.22.1
 Pint==0.18
 pymongo==4.0.1
 scipy==1.7.3
+orjson==3.8.0
 
 # Direct Development Dependencies
 mypy==0.931

--- a/vivarium/__init__.py
+++ b/vivarium/__init__.py
@@ -41,10 +41,9 @@ from vivarium.core.registry import (
     divide_null, divide_binomial, divide_set_value,
 )
 from vivarium.core.serialize import (
-    ProcessSerializer, NumpySerializer, SequenceDeserializer,
-    NumpyBoolSerializer, UnitsSerializer, DictDeserializer,
-    FunctionSerializer, NumpyInt64Serializer, NumpyInt32Serializer,
-    NumpyFloat32Serializer, SetSerializer
+    NumpyFallbackSerializer, UnitsSerializer, QuantitySerializer,
+    SetSerializer, ProcessSerializer, FunctionSerializer,
+    SequenceDeserializer, DictDeserializer
 )
 
 # import emitters
@@ -92,10 +91,10 @@ divider_registry.register('null', divide_null)
 
 # register serializers
 for SerializerClass in (
-        ProcessSerializer, NumpySerializer, SequenceDeserializer,
-        NumpyBoolSerializer, UnitsSerializer, DictDeserializer,
-        FunctionSerializer, NumpyInt64Serializer, NumpyInt32Serializer,
-        NumpyFloat32Serializer, SetSerializer):
+    NumpyFallbackSerializer, UnitsSerializer, QuantitySerializer,
+    SetSerializer, ProcessSerializer, FunctionSerializer,
+    SequenceDeserializer, DictDeserializer
+    ):
     serializer = SerializerClass()
     serializer_registry.register(
         serializer.name, serializer)

--- a/vivarium/core/emitter.py
+++ b/vivarium/core/emitter.py
@@ -311,7 +311,6 @@ class DatabaseEmitter(Emitter):
     >>> # The line below works only if you have to have 27017 open locally
     >>> # emitter = DatabaseEmitter(config)
     """
-    client = None
     default_host = 'localhost:27017'
 
     @classmethod
@@ -327,10 +326,9 @@ class DatabaseEmitter(Emitter):
         self.emit_limit = config.get('emit_limit', MONGO_DOCUMENT_LIMIT)
         self.embed_path = config.get('embed_path', tuple())
 
-        # create singleton instance of mongo client
-        if DatabaseEmitter.client is None:
-            DatabaseEmitter.client = MongoClient(
-                config.get('host', self.default_host))
+        # create object instance of mongo client to prevent forking issues
+        self.client = MongoClient(
+            config.get('host', self.default_host))
 
         self.db = getattr(self.client, config.get('database', 'simulations'))
         self.history = getattr(self.db, 'history')

--- a/vivarium/core/emitter.py
+++ b/vivarium/core/emitter.py
@@ -27,7 +27,7 @@ from vivarium.library.topology import (
 )
 from vivarium.core.registry import emitter_registry
 from vivarium.core.serialize import (
-    get_codec_options,
+    make_default,
     serialize_value,
     deserialize_value)
 
@@ -49,24 +49,20 @@ CONFIGURATION_INDEXES = [
 SECRETS_PATH = 'secrets.json'
 
 
-def size_of(emit_data: Any) -> int:
-    return len(str(emit_data))
-
-
 def breakdown_data(
         limit: float,
         data: Any,
         path: Tuple = (),
         size: float = None,
 ) -> list:
-    size = size or size_of(data)
+    size = size or len(str(data))
     if size > limit:
         if isinstance(data, dict):
             output = []
             subsizes = {}
             total = 0
             for key, subdata in data.items():
-                subsizes[key] = size_of(subdata)
+                subsizes[key] = len(str(subdata))
                 total += subsizes[key]
 
             order = sorted(
@@ -249,7 +245,7 @@ class RAMEmitter(Emitter):
     def __init__(self, config: Dict[str, Any]) -> None:
         super().__init__(config)
         self.saved_data: Dict[float, Dict[str, Any]] = {}
-        self.codec_options = get_codec_options()
+        self.default = make_default()
         self.embed_path = config.get('embed_path', tuple())
 
     def emit(self, data: Dict[str, Any]) -> None:
@@ -266,7 +262,7 @@ class RAMEmitter(Emitter):
                 if key not in ['time']}
             data_at_time = assoc_path({}, self.embed_path, data_at_time)
             self.saved_data.setdefault(time, {})
-            data_at_time = serialize_value(data_at_time, self.codec_options)
+            data_at_time = serialize_value(data_at_time, self.default)
             deep_merge_check(
                 self.saved_data[time], data_at_time, check_equality=True)
 
@@ -298,7 +294,7 @@ class SharedRamEmitter(RAMEmitter):
         # We intentionally don't call the superclass constructor because
         # we don't want to create a per-instance ``saved_data``
         # attribute.
-        self.codec_options = get_codec_options()
+        self.default = make_default()
         self.embed_path = config.get('embed_path', tuple())
 
 
@@ -344,12 +340,11 @@ class DatabaseEmitter(Emitter):
         self.create_indexes(self.configuration, CONFIGURATION_INDEXES)
         self.create_indexes(self.phylogeny, CONFIGURATION_INDEXES)
 
-        self.codec_options = get_codec_options()
+        self.default = make_default()
 
     def emit(self, data: Dict[str, Any]) -> None:
         table_id = data['table']
-        table = self.db.get_collection(
-            table_id, codec_options=self.codec_options)
+        table = self.db.get_collection(table_id)
         time = data['data'].pop('time', None)
         data['data'] = assoc_path({}, self.embed_path, data['data'])
         # Analysis scripts expect the time to be at the top level of the
@@ -368,6 +363,7 @@ class DatabaseEmitter(Emitter):
         Break up large emits into smaller pieces and emit them individually
         """
         assembly_id = str(uuid.uuid4())
+        emit_data = serialize_value(emit_data, self.default)
         try:
             emit_data['assembly_id'] = assembly_id
             table.insert_one(emit_data)
@@ -376,7 +372,6 @@ class DatabaseEmitter(Emitter):
         # getting string representation of Numpy arrays
         except DocumentTooLarge:
             emit_data.pop('assembly_id')
-            emit_data = serialize_value(emit_data, self.codec_options)
             broken_down_data = breakdown_data(self.emit_limit, emit_data)
             for (path, datum) in broken_down_data:
                 d: Dict[str, Any] = {}

--- a/vivarium/core/engine.py
+++ b/vivarium/core/engine.py
@@ -12,6 +12,7 @@ import os
 import logging as log
 import pprint
 import re
+import gc
 from typing import (
     Any, Dict, Optional, Union, Tuple, Callable, Iterable, List,
     cast, Sequence)
@@ -1083,6 +1084,8 @@ class Engine:
 
             if force_complete and self.global_time == end_time:
                 force_complete = False
+
+            # gc.collect()
 
     @staticmethod
     def _end_process_if_parallel(process: Process) -> None:

--- a/vivarium/core/engine.py
+++ b/vivarium/core/engine.py
@@ -12,7 +12,6 @@ import os
 import logging as log
 import pprint
 import re
-import gc
 from typing import (
     Any, Dict, Optional, Union, Tuple, Callable, Iterable, List,
     cast, Sequence)
@@ -1084,8 +1083,6 @@ class Engine:
 
             if force_complete and self.global_time == end_time:
                 force_complete = False
-
-            # gc.collect()
 
     @staticmethod
     def _end_process_if_parallel(process: Process) -> None:

--- a/vivarium/core/process.py
+++ b/vivarium/core/process.py
@@ -759,6 +759,10 @@ class ParallelProcess(Process):
         self._ended = False
         self._pending_command: Optional[
             Tuple[str, Optional[tuple], Optional[dict]]] = None
+        
+        # Uncomment if using spawn or forkserver
+        del self.process
+        del self.child
 
     def send_command(
             self, command: str, args: Optional[tuple] = None,

--- a/vivarium/core/process.py
+++ b/vivarium/core/process.py
@@ -759,8 +759,7 @@ class ParallelProcess(Process):
         self._ended = False
         self._pending_command: Optional[
             Tuple[str, Optional[tuple], Optional[dict]]] = None
-        
-        # Uncomment if using spawn or forkserver
+
         del self.process
         del self.child
 

--- a/vivarium/core/process.py
+++ b/vivarium/core/process.py
@@ -103,14 +103,6 @@ class Process(metaclass=abc.ABCMeta):
               also contain the following special keys:
 
               * ``name``: Saved to ``self.name``.
-              * ``_original_parameters``: Returned by
-                ``__getstate__()`` for serialization.
-              * ``_no_original_parameters``: If specified with a value
-                of ``True``, original parameters will not be copied
-                during initialization, and ``__getstate__()`` will
-                instead return ``self.parameters``. This puts the
-                responsibility on the user to not mutate process
-                parameters.
               * ``_schema``: Overrides the schema.
               * ``_parallel``: Indicates that the process should be
                 parallelized. ``self.parallel`` will be set to True.
@@ -133,20 +125,6 @@ class Process(metaclass=abc.ABCMeta):
 
     def __init__(self, parameters: Optional[dict] = None) -> None:
         parameters = parameters or {}
-        if '_original_parameters' in parameters:
-            original_parameters = parameters.pop('_original_parameters')
-        else:
-            original_parameters = parameters
-        if parameters.get('_no_original_parameters', False):
-            self._original_parameters: Optional[dict] = None
-        else:
-            try:
-                self._original_parameters = copy.deepcopy(
-                    original_parameters)
-            except TypeError:
-                # Copying the parameters failed because some parameters do
-                # not support being copied.
-                self._original_parameters = None
 
         if 'name' in parameters:
             self.name = parameters['name']
@@ -357,28 +335,6 @@ class Process(metaclass=abc.ABCMeta):
         if self._parameters.get('time_step'):
             self._parameters['timestep'] = self._parameters['time_step']
 
-    def __getstate__(self) -> dict:
-        """Return parameters
-
-        This is sufficient to reproduce the Process if there are no
-        hidden states. Processes with hidden states may need to write
-        their own __getstate__.
-
-        The original parameters saved by the constructor are used here,
-        so any later changes to the parameters will be lost during
-        serialization.
-        """
-        if self.parameters.get('_no_original_parameters', False):
-            return self.parameters
-        if self._original_parameters is None:
-            raise TypeError(
-                'Parameters could not be copied, so serialization is '
-                'not supported.')
-        return self._original_parameters
-
-    def __setstate__(self, parameters: dict) -> None:
-        """Initialize process with parameters"""
-        self.__init__(parameters)  # type: ignore
 
     def initial_state(self, config: Optional[dict] = None) -> State:
         """Get initial state in embedded path dictionary.
@@ -743,25 +699,20 @@ class ParallelProcess(Process):
                 is deleted. Only used if ``profile`` is true.
         """
         super().__init__({
-            '_no_original_parameters': True,
             'name': process.name,
             '_parallel': True,
         })
-        self.process = process
         self.profile = profile
         self._stats_objs = stats_objs
         assert not self.profile or self._stats_objs is not None
-        self.parent, self.child = Pipe()
+        self.parent, child = Pipe()
         self.multiprocess = Multiprocess(
             target=_handle_parallel_process,
-            args=(self.child, self.process, self.profile))
+            args=(child, process, self.profile))
         self.multiprocess.start()
         self._ended = False
         self._pending_command: Optional[
             Tuple[str, Optional[tuple], Optional[dict]]] = None
-
-        del self.process
-        del self.child
 
     def send_command(
             self, command: str, args: Optional[tuple] = None,
@@ -905,7 +856,6 @@ class ToySerializedProcessInheritance(Process):
         parameters = parameters or {}
         super().__init__({
             '2': parameters['1'],
-            '_original_parameters': parameters,
         })
 
     def ports_schema(self) -> Schema:
@@ -945,8 +895,6 @@ def test_serialize_process() -> None:
     proc_pickle = pickle.loads(pickle.dumps(proc))
 
     assert proc.parameters['list'] == [1]
-    # If we pickled using `self.parameters` instead of
-    # `self._original_parameters`, this list would be [1, 1].
     assert proc_pickle.parameters['list'] == [1]
 
 

--- a/vivarium/core/registry.py
+++ b/vivarium/core/registry.py
@@ -79,9 +79,12 @@ Serializer API
 Serializers MUST define the following:
 
 1. The ``python_type`` class attributes that determines what types are
-    handled by the serializer
-2. The :py:meth:`vivarium.core.registry.Serializer.serializer()` method
-    which is called on all objects of type ``python_type``
+   handled by the serializer
+2. The :py:meth:`vivarium.core.registry.Serializer.serialize()` method
+   which is called on all objects of type ``python_type``
+
+Avoid defining custom serializers for built-in or Numpy types as these are
+automatically handled by ``orjson``, the package used to serialize data.
 
 If it is necessary to redefine the how objects are serialized by orjson,
 assign custom serializers to the stores containing objects of the affected
@@ -91,8 +94,9 @@ objects serialized this way are deserialized correctly, you SHOULD consider
 implementing the following as well:
 
 1. :py:meth:`vivarium.core.registry.Serializer.can_deserialize()` to determine
-    whether to call ``deserialize`` on data
+   whether to call ``deserialize`` on data
 2. :py:meth:`vivarium.core.registry.Serializer.deserialize()` to deserialize
+   data
 
 If it is necessary to deserialize objects of the same BSON type differently,
 the corresponding serializer(s) MUST implement these 2 methods.
@@ -377,7 +381,7 @@ class Serializer:
     recover the original object.
 
     Serialization of Python's built-in datatypes and most Numpy types is
-    handled directly by the :py:meth:`orjson.dumps()` method.
+    handled directly by the ``orjson.dumps()`` method.
     
     The serialization routines in Serializers are compiled into a fallback
     function that is called on objects not handled by ``orjson``.

--- a/vivarium/core/registry.py
+++ b/vivarium/core/registry.py
@@ -86,6 +86,9 @@ Serializers MUST define the following:
 Avoid defining custom serializers for built-in or Numpy types as these are
 automatically handled by ``orjson``, the package used to serialize data.
 
+.. note:: All dictionary keys MUST be Python strings for ``orjson`` to work.
+    Numpy strings (``np.str_``) are not allowed.
+
 If it is necessary to redefine the how objects are serialized by orjson,
 assign custom serializers to the stores containing objects of the affected
 type(s) using the ``_serializer`` ports schema key. This can also be used

--- a/vivarium/core/registry.py
+++ b/vivarium/core/registry.py
@@ -69,7 +69,9 @@ Each :term:`serializer` is defined as a class that follows the API we
 describe below. Vivarium uses these serializers to convert emitted data
 into a BSON-compatible format for database storage. Serializer names are
 registered in :py:data:`serializer_registry`, which maps these names to
-serializer subclasses.
+serializer subclasses. For maximum performance, register serializers
+using a key equal to the string representation of its designated type
+(e.g. ``str(Serializer.python_type)``).
 
 Serializer API
 ==============
@@ -97,6 +99,7 @@ the corresponding serializer(s) MUST implement these 2 methods.
 """
 import copy
 import random
+from typing import Any
 
 import numpy as np
 
@@ -391,10 +394,11 @@ class Serializer:
     Args:
         name: Name of the serializer. Defaults to the class name.
     """
-    python_type = None #: Type matching is NOT exact (subclasses included)
+    python_type: Any = None #: Type matching is NOT exact (subclasses included)
     
-    def __init__(self, name=''):
-        self.name = name or self.__class__.__name__
+    def __init__(self):
+        # Register serializer under its exclusive type
+        self.name = str(self.python_type) or self.__class__.__name__
     
     def serialize(self, data):
         """Controls what happens to data of the type ``python_type``

--- a/vivarium/core/serialize.py
+++ b/vivarium/core/serialize.py
@@ -106,7 +106,7 @@ class NumpyFallbackSerializer(Serializer):
     """
     python_type = np.ndarray
 
-    def serialize(self, data: np.ndarray) -> list:
+    def serialize(self, data: Any) -> list:
         return data.tolist()
 
 

--- a/vivarium/core/serialize_test.py
+++ b/vivarium/core/serialize_test.py
@@ -180,5 +180,41 @@ def test_serialization_full() -> None:
     assert deserialized == expected_deserialized
 
 
+def test_non_string_keys() -> None:
+    to_serialize = {
+        np.str_(1): [1, 2, 3],
+        1: [1, 2, 3],
+        'string': {
+            'string2': {
+                'string3': {
+                    np.str_(1): 3
+                }
+            }
+        }
+    }
+    try:
+        serialize_value(to_serialize)
+    except TypeError as e:
+        expected_error = (
+            "These paths end in incompatible non-string or Numpy string " +
+            "keys: [('1',), (1,), ('string', 'string2', 'string3', '1')]")
+        assert str(e) == expected_error
+
+
+def test_unsupported_types() -> None:
+    to_serialize = {
+        'serializer': Serializer,
+        np.str_('bad string'): 1
+    }
+    try:
+        serialize_value(to_serialize)
+    except TypeError as e:
+        expected_error = (
+            "These paths end in incompatible non-string or Numpy string " +
+            "keys: [('bad string',)]")
+        assert str(e) == expected_error
+        assert str(e.__cause__) == 'Type is not JSON serializable: type'
+
+
 if __name__ == '__main__':
     test_serialization_full()

--- a/vivarium/core/serialize_test.py
+++ b/vivarium/core/serialize_test.py
@@ -1,13 +1,12 @@
 import math
 import re
-from typing import Any, List
+from typing import Any
 
 import numpy as np
-from bson.codec_options import TypeEncoder
 
 from vivarium.core.process import Process
 from vivarium.core.serialize import serialize_value, deserialize_value
-from vivarium.core.registry import serializer_registry, Serializer
+from vivarium.core.registry import Serializer
 from vivarium.library.units import units
 
 
@@ -18,16 +17,6 @@ class SerializeProcess(Process):
 
     def next_update(self, timestep: float, states: dict) -> dict:
         return {}
-
-class SerializeProcessSerializer(Serializer):
-        
-    python_type = SerializeProcess
-    def serialize(self, value: SerializeProcess) -> str:
-        return ("!ProcessSerializer[" +
-            str(dict(value.parameters, _name=value.name)) + "]")
-
-serializer_registry.register(
-    "SerializeProcessSerializer", SerializeProcessSerializer())
 
 def serialize_function() -> None:
     pass

--- a/vivarium/core/serialize_test.py
+++ b/vivarium/core/serialize_test.py
@@ -20,14 +20,11 @@ class SerializeProcess(Process):
         return {}
 
 class SerializeProcessSerializer(Serializer):
-    class Codec(TypeEncoder):
-        python_type = type(SerializeProcess())
-        def transform_python(self, value: SerializeProcess) -> str:
-            return ("!ProcessSerializer[" +
-                str(dict(value.parameters, _name=value.name)) + "]")
-
-    def get_codecs(self) -> List:
-        return [self.Codec()]
+        
+    python_type = SerializeProcess
+    def serialize(self, value: SerializeProcess) -> str:
+        return ("!ProcessSerializer[" +
+            str(dict(value.parameters, _name=value.name)) + "]")
 
 serializer_registry.register(
     "SerializeProcessSerializer", SerializeProcessSerializer())

--- a/vivarium/core/store.py
+++ b/vivarium/core/store.py
@@ -632,7 +632,7 @@ class Store:
             if '_units' in config:
                 self.units = self._check_schema(
                     'units', config.get('_units'))
-                self.serializer = serializer_registry.access('units')
+                self.serializer = serializer_registry.access('QuantitySerializer')
 
             if '_serializer' in config:
                 serializer = config['_serializer']
@@ -647,13 +647,13 @@ class Store:
                 if isinstance(self.default, Quantity):
                     self.units = self.units or self.default.units
                     self.serializer = (self.serializer or
-                                       serializer_registry.access('units'))
+                                       serializer_registry.access('QuantitySerializer'))
                 elif isinstance(self.default, list) and \
                         len(self.default) > 0 and \
                         isinstance(self.default[0], Quantity):
                     self.units = self.units or self.default[0].units
                     self.serializer = (self.serializer or
-                                       serializer_registry.access('units'))
+                                       serializer_registry.access('QuantitySerializer'))
 
             if '_value' in config:
                 self.value = self._check_schema(

--- a/vivarium/core/store.py
+++ b/vivarium/core/store.py
@@ -21,6 +21,7 @@ from vivarium.core.process import ParallelProcess, Process
 from vivarium.library.dict_utils import deep_merge, deep_merge_check, MULTI_UPDATE_KEY
 from vivarium.library.topology import dict_to_paths
 from vivarium.core.types import Processes, Topology, State, Steps, Flow
+from vivarium.core.serialize import QuantitySerializer
 
 _EMPTY_UPDATES = None, None, None, None, None, None
 DEFAULT_SCHEMA = '_default'
@@ -632,7 +633,8 @@ class Store:
             if '_units' in config:
                 self.units = self._check_schema(
                     'units', config.get('_units'))
-                self.serializer = serializer_registry.access('QuantitySerializer')
+                self.serializer = serializer_registry.access(
+                    str(QuantitySerializer.python_type))
 
             if '_serializer' in config:
                 serializer = config['_serializer']
@@ -647,13 +649,15 @@ class Store:
                 if isinstance(self.default, Quantity):
                     self.units = self.units or self.default.units
                     self.serializer = (self.serializer or
-                                       serializer_registry.access('QuantitySerializer'))
+                                       serializer_registry.access(
+                                        str(QuantitySerializer.python_type)))
                 elif isinstance(self.default, list) and \
                         len(self.default) > 0 and \
                         isinstance(self.default[0], Quantity):
                     self.units = self.units or self.default[0].units
                     self.serializer = (self.serializer or
-                                       serializer_registry.access('QuantitySerializer'))
+                                       serializer_registry.access(
+                                        str(QuantitySerializer.python_type)))
 
             if '_value' in config:
                 self.value = self._check_schema(

--- a/vivarium/core/store.py
+++ b/vivarium/core/store.py
@@ -1982,8 +1982,6 @@ class Store:
     def build_topology_views(self):
         if self.leaf:
             if isinstance(self.value, Process):
-                if not self.value.schema:
-                    self.value.schema = self.value.get_schema()
                 self.topology_view = self.outer.schema_topology(
                     self.value.schema,
                     self.topology)

--- a/vivarium/core/store.py
+++ b/vivarium/core/store.py
@@ -1978,6 +1978,8 @@ class Store:
     def build_topology_views(self):
         if self.leaf:
             if isinstance(self.value, Process):
+                if not self.value.schema:
+                    self.value.schema = self.value.get_schema()
                 self.topology_view = self.outer.schema_topology(
                     self.value.schema,
                     self.topology)

--- a/vivarium/experiments/engine_tests.py
+++ b/vivarium/experiments/engine_tests.py
@@ -1,15 +1,13 @@
 import random
 import logging as log
 from typing import Optional, Union, Dict, Any, cast, List
-from bson.codec_options import TypeEncoder
 
 from vivarium.composites.toys import (
-    Po, Qo, PoQo, Sine, ToyDivider, ToyTransport, ToyEnvironment,
+    PoQo, Sine, ToyDivider, ToyTransport, ToyEnvironment,
     Proton, Electron)
 from vivarium.core.composer import Composer, Composite
 from vivarium.core.engine import Engine, pf, pp, _StepGraph
 from vivarium.core.process import Process, Step, Deriver
-from vivarium.core.registry import serializer_registry, Serializer
 from vivarium.core.store import Store, hierarchy_depth
 from vivarium.core.types import (
     Schema, State, Update, Topology, Steps, Processes)
@@ -1138,27 +1136,6 @@ def test_engine_run_for() -> None:
         assert advance['time'] == sim.global_time, \
             f"process at path {path} did not complete"
 
-# Demonstrates how each process to be emitted
-# must have its own codec
-class PoQoSerializer(Serializer):
-    def __init__(self) -> None:
-        super().__init__()
-
-    class PoCodec(TypeEncoder):
-        python_type = type(Po())
-        def transform_python(self, value: Po) -> str:
-            return ("!ProcessSerializer[" +
-                str(dict(value.parameters, _name=value.name)) + "]")
-    class QoCodec(TypeEncoder):
-        python_type = type(Qo())
-        def transform_python(self, value: Qo) -> str:
-            return ("!ProcessSerializer[" +
-                str(dict(value.parameters, _name=value.name)) + "]")
-
-    def get_codecs(self) -> List:
-        return [self.PoCodec(), self.QoCodec()]
-
-serializer_registry.register('PoQoSerializer', PoQoSerializer())
 
 def test_set_branch_emit() -> None:
     run_time = 5


### PR DESCRIPTION
<!-- Here you should describe what this PR does and why. -->
BSON has a hidden maximum serialized size of 2GB (refer to [this](https://github.com/mongodb/mongo-python-driver/blob/179efda31200b495beab6c2e94f365f5713aadc4/bson/buffer.c#L106)). In this PR, we switch to using the `orjson` package, which has no size limits and is generally faster than BSON anyways. Orjson also has the benefit of natively supporting Numpy arrays and types. 

An important caveat is `np.str_`. Orjson will complain if dictionary keys are of the type `np.str_` or if the data to serialize contains arrays with `np.str_` values. The latter case is handled by a fallback [Numpy array serializer](https://github.com/vivarium-collective/vivarium-core/blob/a8749ce3fd202b9d79c9a82f810e617ee3e6746a/vivarium/core/serialize.py#L104), but users must manually ensure that all dictionary keys are Python strings and not Numpy strings.

Additionally, this PR makes some tweaks to multiprocessing:
- `ParallelProcesses` no longer keep a reference to the original `Process` instance after initializing a separate OS process. This reduces RAM usage.
- When parallelization is enabled, process schemas may be lost in transit. If this happens, the process schema is now retrieved anew when rebuilding the topology view.


<!-- DO NOT MODIFY ANYTHING BELOW THIS LINE -->
-----------------------------------------------------------------------

By creating this pull request, I agree to the Contributor License
Agreement, which is available in `CLA.md` at the top level of this
repository.
