### PR TITLE
Create Mongo index for simulation time

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ scipy==1.7.3
 orjson==3.8.0
 
 # Direct Development Dependencies
-mypy==0.931
+mypy==0.981
 mypy-extensions==0.4.3
 pylint==2.12.2
 pytest==6.2.5


### PR DESCRIPTION
<!-- Here you should describe what this PR does and why. -->
Our default collection indices are out of date. This PR removes unused indices and implements the correct index for simulation time, which should improve performance for queries targeting specific time points or ranges.
<!-- DO NOT MODIFY ANYTHING BELOW THIS LINE -->
-----------------------------------------------------------------------

By creating this pull request, I agree to the Contributor License
Agreement, which is available in `CLA.md` at the top level of this
repository.
