### PR TITLE
Create new MongoClient per OS process

### DIFF
--- a/vivarium/core/emitter.py
+++ b/vivarium/core/emitter.py
@@ -13,7 +13,7 @@ from typing import Any, Dict, List, Optional, Tuple, Callable
 from urllib.parse import quote_plus
 
 from pymongo.errors import DocumentTooLarge
-from pymongo import MongoClient
+from pymongo.mongo_client import MongoClient
 
 from vivarium.library.units import remove_units
 from vivarium.library.dict_utils import (

--- a/vivarium/core/emitter.py
+++ b/vivarium/core/emitter.py
@@ -324,10 +324,10 @@ class DatabaseEmitter(Emitter):
 
         # create new MongoClient per OS process
         curr_pid = os.getpid()
-        if curr_pid not in self.client_dict:
-            self.client_dict[curr_pid] = MongoClient(
+        if curr_pid not in DatabaseEmitter.client_dict:
+            DatabaseEmitter.client_dict[curr_pid] = MongoClient(
                 config.get('host', self.default_host))
-        self.client = self.client_dict[curr_pid]
+        self.client = DatabaseEmitter.client_dict[curr_pid]
 
         self.db = getattr(self.client, config.get('database', 'simulations'))
         self.history = getattr(self.db, 'history')


### PR DESCRIPTION
<!-- Here you should describe what this PR does and why. -->
The MongoDB documentation recommends that only a single `MongoClient` be created per application, taking advantage of connection pooling to reduce latency and the number of new connections ([refer to docs](https://www.mongodb.com/docs/manual/administration/connection-pool-overview/)). At the same time, PyMongo is not fork-safe and [strongly recommends](https://pymongo.readthedocs.io/en/stable/faq.html#using-pymongo-with-multiprocessing) that a new `MongoClient` be created for each child process. This PR strikes a balance between these guidelines by caching `MongoClient` instances by PID, only spawning a new instance if running under a new PID. 
<!-- DO NOT MODIFY ANYTHING BELOW THIS LINE -->
-----------------------------------------------------------------------

By creating this pull request, I agree to the Contributor License
Agreement, which is available in `CLA.md` at the top level of this
repository.
