### PR TITLE
Parallel queries

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ if __name__ == '__main__':
             'Pint>=0.18',
             'pymongo>=4.0.1',
             'scipy>=1.7.3',
-            'pytest>=6.2.5'
+            'pytest>=6.2.5',
             'orjson>=3.8.0'
         ],
         classifiers=[

--- a/vivarium/core/emitter.py
+++ b/vivarium/core/emitter.py
@@ -12,6 +12,7 @@ import uuid
 from typing import Any, Dict, List, Optional, Tuple, Callable
 from urllib.parse import quote_plus
 
+from pymongo import ASCENDING
 from pymongo.errors import DocumentTooLarge
 from pymongo.mongo_client import MongoClient
 
@@ -36,7 +37,9 @@ MONGO_DOCUMENT_LIMIT = 1e7
 
 HISTORY_INDEXES = [
     'data.time',
-    'experiment_id',
+    [('experiment_id', ASCENDING),
+     ('data.time', ASCENDING),
+     ('_id', ASCENDING)],
 ]
 
 CONFIGURATION_INDEXES = [


### PR DESCRIPTION
<!-- Here you should describe what this PR does and why. -->
A single MongoDB query is unable to fully saturate I/O throughput on Google Compute Engine. This PR creates helper methods to intelligently split large queries into smaller, approximately equal chunks that can be run in parallel on separate OS processes. The number of chunks can be manually tuned to reach I/O saturation for maximum performance.

This was made possible by a new compound index: `{experiment_id: 1, 'data.time': 1, _id: 1}`. This index fully covers the aggregation step in `get_data_chunks` and represents a marked improvement over using any single-key index for queries that specify ranges or values for `experiment_id` or `data.time`. Best of all, compound indices maintain the ability to [cover queries on prefixes](https://www.mongodb.com/docs/manual/core/index-compound/#prefixes).

As a single data point, an aggregation that previously took about 2 hours on GCE finishes in **just 3 minutes** when properly parallelized.

I also fixed a careless typo in `setup.py`. After this PR is taken care of, I think we are ready for a release.
<!-- DO NOT MODIFY ANYTHING BELOW THIS LINE -->
-----------------------------------------------------------------------

By creating this pull request, I agree to the Contributor License
Agreement, which is available in `CLA.md` at the top level of this
repository.
