### PR TITLE
Recalculate hashes for comparison of Units

### DIFF
--- a/vivarium/core/store.py
+++ b/vivarium/core/store.py
@@ -500,6 +500,14 @@ class Store:
         """
         current_schema_value = getattr(self, schema_key)
         if current_schema_value is not None and current_schema_value != new_schema:
+            if schema_key == "units":
+                # Hashes from different Python interpreters (e.g. multiprocessing
+                # with spawn start method) are different even if the values are same
+                # Recalculate hashes in this process to double-check
+                current_hash = hash(frozenset(current_schema_value._units._d))
+                new_hash = hash(frozenset(new_schema._units._d))
+                if current_hash == new_hash:
+                    return new_schema
             raise ValueError(
                 f"Incompatible schema assignment at {self.path_for()}. "
                 f"Trying to assign the value {new_schema} to key {schema_key}, "


### PR DESCRIPTION
<!-- Here you should describe what this PR does and why. -->
The `__eq__` method for instances of `Unit` (from a `pint.UnitRegistry`) compares the cached hash values for the two objects ([source](https://github.com/hgrecco/pint/blob/37a61ede6fbd628c7dc160eb36278cf41c96484c/pint/util.py#L421)). Since Python 3.3, hash randomization has been [enabled by default](https://docs.python.org/3/reference/datamodel.html#object.__hash__), meaning different Python interpreters will almost certainly produce different hashes for the same object. This includes Python interpreters created by `multiprocessing` with the `spawn` start method (default on Mac and Windows). Thus, when division is triggered from a subprocess and passed back to the main process, a simple `==` comparison of two `Unit` instances will result in `False` even when they are actually identical.

I don't love the idea of accessing private attributes to recalculate this hash as I've done in this PR. Suggestions are welcome!
<!-- DO NOT MODIFY ANYTHING BELOW THIS LINE -->
-----------------------------------------------------------------------

By creating this pull request, I agree to the Contributor License
Agreement, which is available in `CLA.md` at the top level of this
repository.
