### PR TITLE
Allow breakdown document to lack data key

### DIFF
--- a/vivarium/core/emitter.py
+++ b/vivarium/core/emitter.py
@@ -382,6 +382,7 @@ class DatabaseEmitter(Emitter):
                 assoc_path(d, path, datum)
                 d['assembly_id'] = assembly_id
                 if time:
+                    d.setdefault('data', {})
                     d['data']['time'] = time
                 table.insert_one(d)
 


### PR DESCRIPTION
<!-- Here you should describe what this PR does and why. -->
This PR fixes crashes that occur when breaking down a large document results in a document that lacks the `data` key altogether.
<!-- DO NOT MODIFY ANYTHING BELOW THIS LINE -->
-----------------------------------------------------------------------

By creating this pull request, I agree to the Contributor License
Agreement, which is available in `CLA.md` at the top level of this
repository.
