### PR TITLE
update pint imports for 0.20.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## v1.5.4
+* (#223) Update pint imports to support newest version
+* (#222) More breakdown fixes
+* (#220) Recalculate hashes for comparison of Units
+* (#219) Parallel queries. Ccreates helper methods to intelligently split large queries into smaller, approximately 
+  equal chunks that can be run in parallel on separate OS processes.  
+* (#218) MongoClient optimizations
+* (#217) Create Mongo index for simulation time. 
+* (#215) Serialization fixes for BSON.
+* (#214) Optimize dictionary key removal.
+* (#213) Clean up documentation for Serializer API.
+
 ## v1.5.3
 * (#211) Fix a memory leak when removing parallel processes.
 * (#204) Implement a new serialization API based on PyMongo's 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -27,7 +27,7 @@ from setup import VERSION
 # -- Project information -----------------------------------------------------
 
 project = 'Vivarium Core'
-copyright = '2018-{}, The Vivarium Core Authors'.format(
+copyright = '2020-{}, The Vivarium Core Authors'.format(
     datetime.now().year)
 author = 'The Vivarium Core Authors'
 

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -22,7 +22,7 @@ numpy==1.19.1
 orjson==3.8.0
 packaging==20.4
 Pillow==7.2.0
-Pint==0.15
+Pint==0.20.1
 pluggy==0.13.1
 py==1.9.0
 Pygments==2.6.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 matplotlib==3.5.1
 networkx==2.6.3
 numpy==1.22.1
-Pint==0.18
+Pint==0.20.1
 pymongo==4.0.1
 scipy==1.7.3
 orjson==3.8.0

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import re
 from setuptools import setup
 
 
-VERSION = '1.5.3'
+VERSION = '1.5.4'
 
 
 if __name__ == '__main__':

--- a/vivarium/core/serialize.py
+++ b/vivarium/core/serialize.py
@@ -18,7 +18,7 @@ import numpy as np
 from pint import Unit
 try:
     from pint.quantity import Quantity
-except:
+except ImportError:
     from pint import Quantity
 from vivarium.core.process import Process
 from vivarium.library.units import units

--- a/vivarium/core/serialize.py
+++ b/vivarium/core/serialize.py
@@ -24,6 +24,7 @@ from vivarium.core.process import Process
 from vivarium.library.units import units
 from vivarium.core.registry import serializer_registry, Serializer
 
+
 def find_numpy_and_non_strings(
     d: dict,
     curr_path: tuple=tuple(),
@@ -42,6 +43,7 @@ def find_numpy_and_non_strings(
             saved_paths = find_numpy_and_non_strings(
                 d[key], curr_path+(key,), saved_paths)
     return saved_paths
+
 
 def serialize_value(
     value: Any,
@@ -70,6 +72,7 @@ def serialize_value(
         bad_keys = find_numpy_and_non_strings(value)
         raise TypeError('These paths end in incompatible non-string or Numpy '
             f'string keys: {bad_keys}').with_traceback(e.__traceback__) from e
+
 
 def deserialize_value(value: Any) -> Any:
     """Find and apply the correct serializer for a value
@@ -129,6 +132,7 @@ class DictDeserializer(Serializer):
             for key, value in data.items()
         }
 
+
 class NumpyFallbackSerializer(Serializer):
     """Orjson does not handle Numpy arrays with strings
     """
@@ -148,6 +152,7 @@ class UnitsSerializer(Serializer):
         self.regex_for_serialized = re.compile('!units\\[(.*)\\]')
 
     python_type = type(units.fg)
+
     def serialize(self, data: Any) -> Union[List[str], str]:
         try:
             return_value = []
@@ -206,8 +211,9 @@ class UnitsSerializer(Serializer):
             else:
                 unit_data = units(data)
             if unit is not None:
-                unit_data.to(unit)
+                unit_data.to(unit)  # type: ignore
         return unit_data
+
 
 class QuantitySerializer(Serializer):
     """Serializes data with units into strings of the form ``!units[...]``,
@@ -224,12 +230,14 @@ class QuantitySerializer(Serializer):
         except TypeError:
             return f"!units[{str(data)}]"
 
+
 class SetSerializer(Serializer):
     """Serializer for set objects."""
     python_type = set
 
     def serialize(self, data: set) -> List:
         return list(data)
+
 
 class FunctionSerializer(Serializer):
     """Serializer for function objects."""

--- a/vivarium/core/serialize.py
+++ b/vivarium/core/serialize.py
@@ -16,7 +16,10 @@ from collections.abc import Callable
 import orjson
 import numpy as np
 from pint import Unit
-from pint.quantity import Quantity
+try:
+    from pint.quantity import Quantity
+except:
+    from pint import Quantity
 from vivarium.core.process import Process
 from vivarium.library.units import units
 from vivarium.core.registry import serializer_registry, Serializer

--- a/vivarium/library/units.py
+++ b/vivarium/library/units.py
@@ -23,9 +23,13 @@ False
 from typing import Any
 
 import pint
+
 # noinspection PyProtectedMember
-from pint.quantity import _Quantity as Quantity
-from pint.unit import Unit
+try:
+    from pint.quantity import _Quantity as Quantity
+    from pint.unit import Unit
+except:
+    from pint import Quantity, Unit
 
 #: Units registry that stores the units used throughout Vivarium
 units = pint.UnitRegistry()

--- a/vivarium/library/units.py
+++ b/vivarium/library/units.py
@@ -25,12 +25,11 @@ from typing import Any
 import pint
 
 # noinspection PyProtectedMember
+from pint import Unit
 try:
     from pint.quantity import _Quantity as Quantity
-    from pint.unit import Unit
 except ImportError:
     from pint import Quantity
-    from pint import Unit
 
 #: Units registry that stores the units used throughout Vivarium
 units = pint.UnitRegistry()

--- a/vivarium/library/units.py
+++ b/vivarium/library/units.py
@@ -25,11 +25,12 @@ from typing import Any
 import pint
 
 # noinspection PyProtectedMember
-from pint import Unit
 try:
     from pint.quantity import _Quantity as Quantity
+    from pint.unit import Unit
 except ImportError:
-    from pint import Quantity, Unit
+    from pint import Quantity
+    from pint import Unit
 
 #: Units registry that stores the units used throughout Vivarium
 units = pint.UnitRegistry()

--- a/vivarium/library/units.py
+++ b/vivarium/library/units.py
@@ -25,10 +25,10 @@ from typing import Any
 import pint
 
 # noinspection PyProtectedMember
+from pint import Unit
 try:
     from pint.quantity import _Quantity as Quantity
-    from pint.unit import Unit
-except:
+except ImportError:
     from pint import Quantity, Unit
 
 #: Units registry that stores the units used throughout Vivarium


### PR DESCRIPTION
pint version 0.20.1 changed the location of `Quantity` and `Unit`, which led to import errors for some vivarium users. This PR adds try/except statements where these are imported to make the imports come from the correct modules.

-----------------------------------------------------------------------

By creating this pull request, I agree to the Contributor License
Agreement, which is available in `CLA.md` at the top level of this
repository.
