### PR TITLE
import registries from registry module to fix bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v1.5.6
+* (#225) Update registry imports to `store.py`.
+
 ## v1.5.5
 * (#224) Keep processes and steps in composite spec that is passed to `Engine`. Add `test_hierarchy_update` to keep
   this working.

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import re
 from setuptools import setup
 
 
-VERSION = '1.5.5'
+VERSION = '1.5.6'
 
 
 if __name__ == '__main__':

--- a/vivarium/core/serialize.py
+++ b/vivarium/core/serialize.py
@@ -16,10 +16,10 @@ from collections.abc import Callable
 import orjson
 import numpy as np
 # from pint import Unit
-try:
-    from pint.quantity import Quantity
-except ImportError:
-    from pint import Quantity
+# try:
+#     from pint.quantity import Quantity
+# except ImportError:
+#     from pint import Quantity
 from vivarium.core.process import Process
 from vivarium.library.units import units
 from vivarium.core.registry import serializer_registry, Serializer
@@ -169,8 +169,7 @@ class UnitsSerializer(Serializer):
 
     # Here the differing argument is `unit`, which is optional, so we
     # can ignore the pylint warning.
-    def deserialize(  # pylint: disable=arguments-differ
-            self, data: str, unit=None):
+    def deserialize(self, data: str, unit=None):  # type: ignore  # pylint: disable=arguments-differ
         """Deserialize data with units from a human-readable string.
 
         Args:

--- a/vivarium/core/serialize.py
+++ b/vivarium/core/serialize.py
@@ -15,7 +15,7 @@ from collections.abc import Callable
 
 import orjson
 import numpy as np
-from pint import Unit
+# from pint import Unit
 try:
     from pint.quantity import Quantity
 except ImportError:
@@ -170,7 +170,7 @@ class UnitsSerializer(Serializer):
     # Here the differing argument is `unit`, which is optional, so we
     # can ignore the pylint warning.
     def deserialize(  # pylint: disable=arguments-differ
-            self, data: str, unit: Unit = None) -> Quantity:
+            self, data: str, unit=None):
         """Deserialize data with units from a human-readable string.
 
         Args:

--- a/vivarium/core/store.py
+++ b/vivarium/core/store.py
@@ -16,7 +16,7 @@ import numpy as np
 from pint import Unit, Quantity
 from typing import Optional
 
-from vivarium import divider_registry, serializer_registry, updater_registry
+from vivarium.core.registry import divider_registry, serializer_registry, updater_registry
 from vivarium.core.process import ParallelProcess, Process
 from vivarium.library.dict_utils import deep_merge, deep_merge_check, MULTI_UPDATE_KEY
 from vivarium.library.topology import dict_to_paths


### PR DESCRIPTION
I was informed of an import error some users were experiencing by having the registries imported from the top-level vivarium module. Fixed by changing the `store.py` imports.

-----------------------------------------------------------------------

By creating this pull request, I agree to the Contributor License
Agreement, which is available in `CLA.md` at the top level of this
repository.
