### PR TITLE
Schema fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v1.6.1
+* (#232) Fix some bugs in `emitter.py` and allow Numpy arrays in Store schemas
+
 ## v1.6.0
 * (#231) Update `networkx` error message for already deleted Step.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## v1.6.1
-* (#232) Fix some bugs in `emitter.py` and allow Numpy arrays in Store schemas
+* (#233) Fix some bugs in `emitter.py` and allow Numpy arrays in Store schemas
 
 ## v1.6.0
 * (#231) Update `networkx` error message for already deleted Step.

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import re
 from setuptools import setup
 
 
-VERSION = '1.6.0'
+VERSION = '1.6.1'
 
 
 if __name__ == '__main__':

--- a/vivarium/composites/toys.py
+++ b/vivarium/composites/toys.py
@@ -711,7 +711,25 @@ def test_override() -> None:
     assert default_state == expected_default_state
 
 
-def test_composer() -> Dict:
+def test_composer():
+    toy_compartment = ToyCompartment({})
+    total_time = 10
+    initial_state = {
+        'periplasm': {
+            'GLC': 20,
+            'MASS': 100,
+            'DENSITY': 10},
+        'cytoplasm': {
+            'GLC': 0,
+            'MASS': 3,
+            'DENSITY': 10}}
+
+    composite = toy_compartment.generate()
+    sim = Engine(composite=composite, initial_state=initial_state)
+    sim.update(total_time)
+
+
+def run_composer() -> Dict:
     toy_compartment = ToyCompartment({})
     total_time = 10
     initial_state = {

--- a/vivarium/core/composition.py
+++ b/vivarium/core/composition.py
@@ -381,7 +381,7 @@ def test_process_deletion() -> None:
     assert masses == expected_masses
 
 
-def test_composer() -> Dict:
+def test_composer(return_value: bool = False) -> Optional[Dict]:
     toy_compartment = ToyCompartment({})
     settings = {
         'total_time': 10,
@@ -394,7 +394,9 @@ def test_composer() -> Dict:
                 'GLC': 0,
                 'MASS': 3,
                 'DENSITY': 10}}}
-    return simulate_composer(toy_compartment, settings)
+    if return_value:
+        return simulate_composer(toy_compartment, settings)
+    return None
 
 
 if __name__ == '__main__':

--- a/vivarium/core/control.py
+++ b/vivarium/core/control.py
@@ -17,7 +17,7 @@ from vivarium.core.types import OutputDict
 
 from vivarium.core.engine import timestamp
 from vivarium.core.directories import BASE_OUT_DIR
-from vivarium.composites.toys import ToyCompartment, test_composer
+from vivarium.composites.toys import ToyCompartment, run_composer
 
 from vivarium.plots.simulation_output import plot_simulation_output
 
@@ -193,9 +193,9 @@ def toy_control(
         # put in dictionary with name
         '1': {
             'name': 'exp_1',
-            'experiment': test_composer},
+            'experiment': run_composer},
         # map to function to run as is
-        '2': test_composer,
+        '2': run_composer,
     }
     plot_library = {
         # put in dictionary with config

--- a/vivarium/core/store.py
+++ b/vivarium/core/store.py
@@ -499,7 +499,9 @@ class Store:
                 value is different from the existing one.
         """
         current_schema_value = getattr(self, schema_key)
-        if current_schema_value is not None and current_schema_value != new_schema:
+        if current_schema_value is not None and np.all(
+            current_schema_value != new_schema
+        ):
             if schema_key == "units":
                 # Different Python interpreters (inc. from multiprocessing with
                 # spawn start method) yield different hashes for the same value
@@ -527,8 +529,8 @@ class Store:
                 new_schema[schema_key])
         if (
                 current_schema_value
-                and current_schema_value != DEFAULT_SCHEMA
-                and current_schema_value != new_schema):
+                and np.all(current_schema_value != DEFAULT_SCHEMA)
+                and np.all(current_schema_value != new_schema)):
             warnings.warn(
                 f"Incompatible schema assignment at {self.path_for()}. "
                 f"Trying to assign the value {new_schema} to key {schema_key}, "

--- a/vivarium/experiments/store_api.py
+++ b/vivarium/experiments/store_api.py
@@ -1,3 +1,4 @@
+from typing import Optional, cast
 import pytest
 
 from vivarium.composites.toys import Qo, ToyProcess, ToyComposer
@@ -17,7 +18,7 @@ def get_toy_store() -> Store:
     return store2
 
 
-def test_insert_process() -> Store:
+def test_insert_process(return_value: bool = False) -> Optional[Store]:
     """Test Store.insert by adding a new process
 
     Return:
@@ -36,25 +37,27 @@ def test_insert_process() -> Store:
     assert isinstance(
         store['process3'].value, Process), \
         'process3 not inserted successfully'
-    return store
+    if return_value:
+        return store
+    return None
 
 
 def test_rewire_ports() -> None:
     """connect a process' ports to different store"""
-    store = test_insert_process()
+    store = cast(Store, test_insert_process(return_value=True))
 
     # connect process1's port1 to the store at process3's port1
-    store = test_insert_process()
+    store = cast(Store, test_insert_process(return_value=True))
     store['process1'].connect('port1', store['process3']['port1'])
     assert store['process1']['port1'] == store['process3']['port1']
 
     # connect process2's port2 to store store_A
-    store = test_insert_process()
+    store = cast(Store, test_insert_process(return_value=True))
     store['process2'].connect('port2', store['store_A'])
     assert store['process2', 'port2', 'var_a'] == store['store_A', 'var_a']
 
     # turn variable 'var_a' into 'var_b'
-    store = test_insert_process()
+    store = cast(Store, test_insert_process(return_value=True))
     store['process2'].connect(['port2', 'var_a'], store['store_A', 'var_b'])
     # store['process2', 'port2', 'var_a'] = store['store_A', 'var_b']
     assert store['process2', 'port2', 'var_a'] == store['store_A', 'var_b']

--- a/vivarium/processes/alternator.py
+++ b/vivarium/processes/alternator.py
@@ -183,7 +183,7 @@ class ExchangeAlternator(Composer):
                     'OFF': ('OFF',)}}}
 
 
-def test_alternator():
+def test_alternator(return_value=False):
     initial_on = 10.0
     initial_off = 13.0
 
@@ -215,13 +215,15 @@ def test_alternator():
     output = experiment.emitter.get_data()
     experiment.end()  # end required for parallel processes
 
-    return output
+    if return_value:
+        return output
+    return None
 
 
 def run_alternator():
     out_dir = os.path.join(PROCESS_OUT_DIR, NAME)
     os.makedirs(out_dir, exist_ok=True)
-    output = test_alternator()
+    output = test_alternator(return_value=True)
     pp(output)
 
 

--- a/vivarium/processes/burst.py
+++ b/vivarium/processes/burst.py
@@ -106,7 +106,7 @@ class ToyAgent(Composer):
             }}
 
 
-def test_burst():
+def test_burst(return_value=False):
     agent_1_id = '1'
     agent_2_id = '2'
 
@@ -175,13 +175,14 @@ def test_burst():
     assert output[0.0]['concentrations']['A'] == initial_a
     assert output[5.0]['concentrations']['A'] + output[5.0]['agents'][agent_1_id]['concentrations']['A'] == initial_a
 
-    return output
+    if return_value:
+        return output
 
 
 def run_burst():
     out_dir = os.path.join(PROCESS_OUT_DIR, NAME)
     os.makedirs(out_dir, exist_ok=True)
-    output = test_burst()
+    output = test_burst(return_value=True)
     pp(output)
 
 

--- a/vivarium/processes/ecoli_shape_deriver.py
+++ b/vivarium/processes/ecoli_shape_deriver.py
@@ -146,7 +146,7 @@ class EcoliShape(Deriver):
 
 
 
-def test_deriver(total_time=10):
+def test_deriver(total_time=10, return_value=False):
 
     growth_rate = 6e-3
 
@@ -182,9 +182,10 @@ def test_deriver(total_time=10):
         # save state
         saved_state[time] = copy.deepcopy(state)
 
-    return saved_state
+    if return_value:
+        return saved_state
 
 
 if __name__ == '__main__':
-    saved_data = test_deriver(100)
+    saved_data = test_deriver(100, return_value=True)
     print(saved_data)

--- a/vivarium/processes/engulf.py
+++ b/vivarium/processes/engulf.py
@@ -98,7 +98,7 @@ class ToyAgent(Composer):
                 'outer': config['engulf']['inner_path']}}
 
 
-def test_engulf():
+def test_engulf(return_value=False):
     num_agents = 3
     agent_ids = [
         str(agent_id + 1)
@@ -160,13 +160,14 @@ def test_engulf():
     assert [*output[10.0]['agents'].keys()] == ['1']
     assert [*output[10.0]['agents']['1']['agents'].keys()] == ['3', '2']
 
-    return output
+    if return_value:
+        return output
 
 
 def run_engulf():
     out_dir = os.path.join(PROCESS_OUT_DIR, NAME)
     os.makedirs(out_dir, exist_ok=True)
-    output = test_engulf()
+    output = test_engulf(return_value=True)
     pp(output)
 
 

--- a/vivarium/processes/growth_rate.py
+++ b/vivarium/processes/growth_rate.py
@@ -67,7 +67,7 @@ class GrowthRate(Process):
         return {'variables': variable_update}
 
 
-def test_growth_rate(total_time=1350):
+def test_growth_rate(total_time=1350, return_value=False):
     initial_mass = 100
     growth_rate = 0.0005
     config = {
@@ -91,7 +91,9 @@ def test_growth_rate(total_time=1350):
     decimal_precision = 11
     assert abs(expected_mass - final_mass) < \
            1.5 * 10 ** (-decimal_precision)
-    return output
+    if return_value:
+        return output
+    return None
 
 
 def main():
@@ -100,7 +102,7 @@ def main():
     if not os.path.exists(out_dir):
         os.makedirs(out_dir)
 
-    data = test_growth_rate()
+    data = test_growth_rate(return_value=True)
     plot_settings = {}
     plot_simulation_output(data, plot_settings, out_dir)
 

--- a/vivarium/processes/meta_division.py
+++ b/vivarium/processes/meta_division.py
@@ -175,7 +175,7 @@ def _get_toy_experiment(agent_id, time_divide, time_total, parallel):
 
 
 
-def test_division():
+def test_division(return_value=False):
     agent_id = '1'
     time_divide = 5
     time_total = 10
@@ -194,10 +194,11 @@ def test_division():
     assert len(output[time_divide]['agents']) == 1
     assert len(output[time_divide + 1]['agents']) == 2
 
-    return output
+    if return_value:
+        return output
 
 
-def test_division_parallel():
+def test_division_parallel(return_value=False):
     agent_id = '1'
     time_divide = 5
     time_total = 10
@@ -225,13 +226,14 @@ def test_division_parallel():
     assert len(output[time_divide]['agents']) == 1
     assert len(output[time_divide + 1]['agents']) == 2
 
-    return output
+    if return_value:
+        return output
 
 
 def run_division():
     out_dir = os.path.join(PROCESS_OUT_DIR, NAME)
     os.makedirs(out_dir, exist_ok=True)
-    output = test_division()
+    output = test_division(return_value=True)
     pp(output)
 
 

--- a/vivarium/processes/remove.py
+++ b/vivarium/processes/remove.py
@@ -74,7 +74,7 @@ class ToyLivingCompartment(Composer):
                 'agents': agents_path}}
 
 
-def test_remove():
+def test_remove(return_value=False):
     agent_id = '1'
 
     # timeline turns death on
@@ -114,13 +114,14 @@ def test_remove():
     assert len(output['agents']['1']['dead']) == time_dead + 1
     assert len(output['time']) == time_total + 1
 
-    return output
+    if return_value:
+        return output
 
 
 def run_remove():
     out_dir = os.path.join(PROCESS_OUT_DIR, NAME)
     os.makedirs(out_dir, exist_ok=True)
-    output = test_remove()
+    output = test_remove(return_value=True)
     pp(output)
 
 

--- a/vivarium/processes/swap_processes.py
+++ b/vivarium/processes/swap_processes.py
@@ -125,7 +125,7 @@ class ToyLivingCompartment(Composer):
                 'self': self_path}}
 
 
-def test_death():
+def test_death(return_value=False):
     agent_id = '1'
 
     # make the composite
@@ -175,13 +175,14 @@ def test_death():
     assert internal_a[time_dead] > internal_a[0]
     assert internal_a[time_total] < internal_a[time_dead]
 
-    return output
+    if return_value:
+        return output
 
 
 def run_death():
     out_dir = os.path.join(PROCESS_OUT_DIR, NAME)
     os.makedirs(out_dir, exist_ok=True)
-    output = test_death()
+    output = test_death(return_value=True)
     plot_simulation_output(output, {}, out_dir)
 
 

--- a/vivarium/processes/toy_gillespie.py
+++ b/vivarium/processes/toy_gillespie.py
@@ -204,7 +204,7 @@ class StochasticTscTrl(Composer):
 
 
 
-def test_gillespie_process(total_time=1000):
+def test_gillespie_process(total_time=1000, return_value=False):
     gillespie_process = StochasticTSC({'name': 'process'})
 
     # make the experiment
@@ -232,10 +232,12 @@ def test_gillespie_process(total_time=1000):
     assert front[('process',)]['time'] == gillespie_experiment.global_time
 
     gillespie_data = gillespie_experiment.emitter.get_timeseries()
-    return gillespie_data
+    if return_value:
+        return gillespie_data
+    return None
 
 
-def test_gillespie_composite(total_time=10000):
+def test_gillespie_composite(total_time=10000, return_value=False):
     stochastic_tsc_trl = StochasticTscTrl().generate()
 
     # make the experiment
@@ -249,7 +251,9 @@ def test_gillespie_composite(total_time=10000):
     stoch_experiment.update(total_time)
     data = stoch_experiment.emitter.get_timeseries()
 
-    return data
+    if return_value:
+        return data
+    return None
 
 
 def main():
@@ -258,8 +262,8 @@ def main():
     if not os.path.exists(out_dir):
         os.makedirs(out_dir)
 
-    process_output = test_gillespie_process()
-    composite_output = test_gillespie_composite()
+    process_output = test_gillespie_process(return_value=True)
+    composite_output = test_gillespie_composite(return_value=True)
 
     # plot the simulation output
     plot_settings = {}

--- a/vivarium/processes/tree_mass.py
+++ b/vivarium/processes/tree_mass.py
@@ -105,7 +105,7 @@ class TreeMass(Deriver):
                         'initial': initial_mass}}}}
 
 
-def test_tree_mass():
+def test_tree_mass(return_data=False):
 
     mass_1 = 1.0 * units.g / units.mol
     mass_2 = 2.0 * units.g / units.mol
@@ -164,13 +164,14 @@ def test_tree_mass():
     experiment.end()
 
     assert output[0.0]['global']['mass'] == 4 * units.g
-    return output
+    if return_data:
+        return output
 
 
 def _run_tree_mass():
     out_dir = os.path.join(PROCESS_OUT_DIR, NAME)
     os.makedirs(out_dir, exist_ok=True)
-    output = test_tree_mass()
+    output = test_tree_mass(return_data=True)
     pp(output)
 
 


### PR DESCRIPTION
<!-- Here you should describe what this PR does and why. -->
- Addresses some bugs in `emitter.py`
  - [`DatabaseEmitter.write_emit`](https://github.com/vivarium-collective/vivarium-core/blob/a927c7abf943d02c6d9a9008dacd37b15a597caf/vivarium/core/emitter.py#L381C1-L381C1): Drop the `ObjectID` added by `insert_one` before chunking large docs
  - [`get_history_data_db`](https://github.com/vivarium-collective/vivarium-core/blob/a927c7abf943d02c6d9a9008dacd37b15a597caf/vivarium/core/emitter.py#L626): `start_time` and `end_time` now work when `cpus=1`
  - [`data_from_database`](https://github.com/vivarium-collective/vivarium-core/blob/a927c7abf943d02c6d9a9008dacd37b15a597caf/vivarium/core/emitter.py#L695C10-L695C10): Clarify to accept a `Database` instance and not a `MongoClient`
- Addresses #228 in `store.py`
- Ensures all tests return `None` by default (otherwise will raise errors in a future version of `pytest`)
<!-- DO NOT MODIFY ANYTHING BELOW THIS LINE -->
-----------------------------------------------------------------------

By creating this pull request, I agree to the Contributor License
Agreement, which is available in `CLA.md` at the top level of this
repository.
