### PR TITLE
Recursively compare schemas during validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
 ## v1.6.1
-* (#233) Fix some bugs in `emitter.py` and allow Numpy arrays in Store schemas
+* (#234) Allow Numpy arrays to be deeply nested in Store schemas
+* (#233) Fix some bugs in `emitter.py`
 
 ## v1.6.0
 * (#231) Update `networkx` error message for already deleted Step.


### PR DESCRIPTION
<!-- Here you should describe what this PR does and why. -->
This PR properly closes #228 by allowing Numpy arrays to be buried deep within ports schemas ([example for `_divider`](https://github.com/vivarium-collective/vivarium-core/blob/ab6346d369d9224e2df6945db74c143007246300/vivarium/core/engine.py#L1341-L1346)). Additionally, this fixes a bug I introduced in #233 which caused things like 0 and `np.zeros(10)` to be considered equivalent in ports schemas when they should not be.

To ensure that everything works as intended, I added [`test_numpy_schema_validation`](https://github.com/vivarium-collective/vivarium-core/blob/a0945835681e63d58bdbfc9d0b666e44dce0f4a4/vivarium/core/engine.py#L1242) to `engine.py`.
<!-- DO NOT MODIFY ANYTHING BELOW THIS LINE -->
-----------------------------------------------------------------------

By creating this pull request, I agree to the Contributor License
Agreement, which is available in `CLA.md` at the top level of this
repository.
