### PR TITLE
Add data key to breakdown documents if missing

### DIFF
--- a/vivarium/core/emitter.py
+++ b/vivarium/core/emitter.py
@@ -388,8 +388,8 @@ class DatabaseEmitter(Emitter):
                 assoc_path(d, path, datum)
                 d['assembly_id'] = assembly_id
                 d['experiment_id'] = experiment_id
+                d.setdefault('data', {})
                 if time:
-                    d.setdefault('data', {})
                     d['data']['time'] = time
                 table.insert_one(d)
 


### PR DESCRIPTION
<!-- Here you should describe what this PR does and why. -->
When retrieving data from MongoDB, the `assemble_data` function expects each document to have a `data` key. When a document is too large, the `breakdown_data` method splits the large nested dictionary into smaller sub-dictionaries, some of which may not have a `data` key after the split. This PR ensures that all documents have a `data` key, not just those that also have a corresponding `time` key. This fixes an issue where a very large configuration document (no `time` key) is broken down into sub-dictionaries, one of which lacks the `data` key and breaks `assemble_data`.
<!-- DO NOT MODIFY ANYTHING BELOW THIS LINE -->
-----------------------------------------------------------------------

By creating this pull request, I agree to the Contributor License
Agreement, which is available in `CLA.md` at the top level of this
repository.
