### PR TITLE
Add tests for MongoDB and fix bugs

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -14,6 +14,16 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.9', '3.10', '3.11']
+    services:
+      mongodb:
+        image: mongo:6.0.13
+        ports:
+          - 27017:27017
+        options: >-
+          --health-cmd mongosh
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     steps:
     - uses: actions/checkout@v2
     - name: Setup Python ${{ matrix.python-version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v1.6.3
+* (#237) Add tests for MongoDB emitter and fix related bugs
+
 ## v1.6.2
 * (#236) Add data key to breakdown documents if missing
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import re
 from setuptools import setup
 
 
-VERSION = '1.6.2'
+VERSION = '1.6.3'
 
 
 if __name__ == '__main__':

--- a/vivarium/core/emitter.py
+++ b/vivarium/core/emitter.py
@@ -469,7 +469,6 @@ def delete_experiment_from_database(
     else:
         query = {'experiment_id': experiment_id}
         db.history.delete_many(query, hint=HISTORY_INDEXES[1])
-    db.configuration.delete_many(query)
 
 
 def assemble_data(data: list) -> dict:

--- a/vivarium/core/emitter.py
+++ b/vivarium/core/emitter.py
@@ -469,6 +469,7 @@ def delete_experiment_from_database(
     else:
         query = {'experiment_id': experiment_id}
         db.history.delete_many(query, hint=HISTORY_INDEXES[1])
+    db.configuration.delete_many({'experiment_id': experiment_id})
 
 
 def assemble_data(data: list) -> dict:

--- a/vivarium/core/emitter.py
+++ b/vivarium/core/emitter.py
@@ -389,7 +389,7 @@ class DatabaseEmitter(Emitter):
                 d['assembly_id'] = assembly_id
                 d['experiment_id'] = experiment_id
                 d.setdefault('data', {})
-                if time:
+                if time is not None:
                     d['data']['time'] = time
                 table.insert_one(d)
 

--- a/vivarium/core/emitter.py
+++ b/vivarium/core/emitter.py
@@ -735,10 +735,10 @@ def data_to_database(
     
     Args:
         data: Dictionary mapping time to subdictionaries. Subdictionaries
-            must have an `experiment_id` key for compatibility with retrieval
+            must have an ``experiment_id`` key for compatibility with retrieval
             functions like :py:func:`~.data_from_database`.
-        environment_config: Dictionary that will be written to `configuration`
-            collection. Must have an `experiment_id` key.
+        environment_config: Dictionary that will be written to ``configuration``
+            collection. Must have an ``experiment_id`` key.
         db: MongoDB database (e.g. from :py:func:`~.get_experiment_database`)
     """
     history_collection = db.history

--- a/vivarium/experiments/hierarchy_composite_division.py
+++ b/vivarium/experiments/hierarchy_composite_division.py
@@ -87,7 +87,7 @@ def test_hierarchy_update() -> None:
         emit_step=100.0)
 
     # run the experiment long enough to divide
-    hierarchy_experiment1.update(2000)
+    hierarchy_experiment1.update(3000)
 
     # check that the agents updated after division
     for n in ['processes', 'steps', 'topology']:  # TODO: add flow

--- a/vivarium/experiments/hierarchy_composite_division.py
+++ b/vivarium/experiments/hierarchy_composite_division.py
@@ -71,7 +71,7 @@ def test_hierarchy_update() -> None:
                 'Protein': {'X': 50 * units.mg / units.mL}}}}
 
     # make a txtl composite, embedded under an 'agents' store
-    txtl_composer = AgentDivision({})
+    txtl_composer = AgentDivision({'growth': {'default_growth_noise': 0}})
     txtl_composite1 = txtl_composer.generate(
         {'agent_id': agent_id},
         path=('agents', agent_id))
@@ -87,7 +87,7 @@ def test_hierarchy_update() -> None:
         emit_step=100.0)
 
     # run the experiment long enough to divide
-    hierarchy_experiment1.update(3000)
+    hierarchy_experiment1.update(2000)
 
     # check that the agents updated after division
     for n in ['processes', 'steps', 'topology']:  # TODO: add flow

--- a/vivarium/experiments/large_experiment.py
+++ b/vivarium/experiments/large_experiment.py
@@ -94,11 +94,11 @@ def test_large_emits():
     db = get_experiment_database()
     # check that configuration emit was split into sub-documents
     config_cursor = db.configuration.find({'experiment_id': experiment_id})
-    config_raw = [doc for doc in config_cursor]
+    config_raw = list(config_cursor)
     assert len(config_raw) > 1
     # check that sim emit was split into sub-documents (2 timesteps)
     history_cursor = db.history.find({'experiment_id': experiment_id})
-    history_raw = [doc for doc in history_cursor]
+    history_raw = list(history_cursor)
     assert len(history_raw) > 2
 
     # retrieve the data directly from database
@@ -108,7 +108,7 @@ def test_large_emits():
     processes = experiment_config['processes']
     assert len(processes) == config['number_of_processes']
     for proc in processes:
-        np.testing.assert_allclose(np.array(data[1.0]['store'][proc]), 
+        np.testing.assert_allclose(np.array(data[1.0]['store'][proc]),
             np.array(data[0.0]['store'][proc]) + 1)
 
     # delete the experiment
@@ -133,7 +133,7 @@ def test_query_db():
     experiment.update(10)
 
     db = get_experiment_database()
-    
+
     # test query
     query = [('store', 'process_0'), ('store', 'process_9')]
     data, _ = data_from_database(experiment.experiment_id, db, query)
@@ -147,9 +147,9 @@ def test_query_db():
                                  func_dict=func_dict)
     for emit_data in data.values():
         assert emit_data['store']['process_0'] == 3
-    
+
     # test start and end time
-    data, _ = data_from_database(experiment.experiment_id, db, 
+    data, _ = data_from_database(experiment.experiment_id, db,
                                  start_time=1, end_time=5)
     assert data.keys() == {1.0, 2.0, 3.0, 4.0, 5.0}
 
@@ -157,7 +157,7 @@ def test_query_db():
     data_multi, _ = data_from_database(experiment.experiment_id, db, cpus=2)
     data, _ = data_from_database(experiment.experiment_id, db)
     assert data_multi == data
-    
+
     delete_experiment_from_database(experiment.experiment_id)
 
 

--- a/vivarium/experiments/large_experiment.py
+++ b/vivarium/experiments/large_experiment.py
@@ -165,14 +165,14 @@ def test_data_to_database():
     delete_experiment_from_database('manual_insert')
     data = {
         '0.0': {'data': {'store': 1}, 
-                'experiment_id': 'manual_insert', 'assembly_id': 1},
+                'experiment_id': 'manual_insert'},
         '1.0': {'data': {'store': 2}, 
-                'experiment_id': 'manual_insert', 'assembly_id': 2},
+                'experiment_id': 'manual_insert'},
         '2.0': {'data': {'store': [3.5]}, 
-                'experiment_id': 'manual_insert', 'assembly_id': 3}
+                'experiment_id': 'manual_insert'}
     }
-    config = {'experiment_id': 'manual_insert', 
-              'data': {'store': 1}, 'assembly_id': 4}
+    config = {'experiment_id': 'manual_insert',
+              'data': {'store': 1}}
     db = get_experiment_database()
     data_to_database(data, config, db)
     retrieved_data, retrieved_config = data_from_database('manual_insert', db)

--- a/vivarium/experiments/large_experiment.py
+++ b/vivarium/experiments/large_experiment.py
@@ -12,6 +12,7 @@ from vivarium.core.composer import Composer
 from vivarium.core.emitter import (
     get_experiment_database,
     data_from_database,
+    data_to_database,
     delete_experiment_from_database)
 
 
@@ -157,10 +158,30 @@ def test_query_db():
     data_multi, _ = data_from_database(experiment.experiment_id, db, cpus=2)
     data, _ = data_from_database(experiment.experiment_id, db)
     assert data_multi == data
+    delete_experiment_from_database(experiment.experiment_id, cpus=2)
 
-    delete_experiment_from_database(experiment.experiment_id)
+
+def test_data_to_database():
+    delete_experiment_from_database('manual_insert')
+    data = {
+        '0.0': {'data': {'store': 1}, 
+                'experiment_id': 'manual_insert', 'assembly_id': 1},
+        '1.0': {'data': {'store': 2}, 
+                'experiment_id': 'manual_insert', 'assembly_id': 2},
+        '2.0': {'data': {'store': [3.5]}, 
+                'experiment_id': 'manual_insert', 'assembly_id': 3}
+    }
+    config = {'experiment_id': 'manual_insert', 
+              'data': {'store': 1}, 'assembly_id': 4}
+    db = get_experiment_database()
+    data_to_database(data, config, db)
+    retrieved_data, retrieved_config = data_from_database('manual_insert', db)
+    assert retrieved_data == {float(t): val['data'] for t, val in data.items()}
+    assert retrieved_config == config['data']
+    delete_experiment_from_database('manual_insert')
 
 
 if __name__ == '__main__':
     test_large_emits()
     test_query_db()
+    test_data_to_database()

--- a/vivarium/experiments/large_experiment.py
+++ b/vivarium/experiments/large_experiment.py
@@ -162,7 +162,6 @@ def test_query_db():
 
 
 def test_data_to_database():
-    delete_experiment_from_database('manual_insert')
     data = {
         '0.0': {'data': {'store': 1}, 
                 'experiment_id': 'manual_insert'},
@@ -179,6 +178,7 @@ def test_data_to_database():
     assert retrieved_data == {float(t): val['data'] for t, val in data.items()}
     assert retrieved_config == config['data']
     delete_experiment_from_database('manual_insert')
+    db.configuration.delete_many({'experiment_id': 'manual_insert'})
 
 
 if __name__ == '__main__':

--- a/vivarium/experiments/large_experiment.py
+++ b/vivarium/experiments/large_experiment.py
@@ -15,24 +15,28 @@ from vivarium.core.emitter import (
 
 class ManyParametersProcess(Process):
     defaults = {
-        'number_of_parameters': 100}
+        'number_of_parameters': 100,
+        'number_of_ports': 1}
     def __init__(self, parameters=None):
-        super().__init__(parameters)
         # make a bunch of parameters
         random_parameters = {
             key: random.random()
-            for key in range(self.parameters['number_of_parameters'])}
-        super().__init__(random_parameters)
+            for key in range(parameters['number_of_parameters'])}
+        super().__init__({**parameters, **random_parameters})
     def ports_schema(self):
-        return {'port': {'variable': {'_default': 0, '_emit': True}}}
+        return {'port': {
+            str(i): {'_default': 0, '_emit': True}
+            for i in range(self.parameters['number_of_ports'])}}
     def next_update(self, timestep, states):
-        return {'port': {'variable': 1}}
+        return {'port': {str(i): 1
+            for i in range(self.parameters['number_of_ports'])}}
 
 
 class ManyParametersComposite(Composer):
     defaults = {
         'number_of_processes': 10,
-        'number_of_parameters': 100}
+        'number_of_parameters': 100,
+        'number_of_ports': 1}
     def __init__(self, config=None):
         super().__init__(config)
         self.process_ids = [
@@ -43,7 +47,8 @@ class ManyParametersComposite(Composer):
         return {
             process_id: ManyParametersProcess({
                 'name': process_id,
-                'number_of_parameters': self.config['number_of_parameters']})
+                'number_of_parameters': self.config['number_of_parameters'],
+                'number_of_ports': self.config['number_of_ports']})
             for process_id in self.process_ids}
     def generate_topology(self, config):
         return {
@@ -51,16 +56,11 @@ class ManyParametersComposite(Composer):
             for process_id in self.process_ids}
 
 
-def run_large_initial_emit():
+def run_large_experiment(config):
     """
     This experiment runs a large experiment to test the database emitter.
     This requires MongoDB to be configured and running.
     """
-
-    config = {
-        'number_of_processes': 1000,
-        'number_of_parameters': 1000}
-
     composer = ManyParametersComposite(config)
     composite = composer.generate()
 
@@ -68,6 +68,7 @@ def run_large_initial_emit():
         'experiment_name': 'large database experiment',
         'experiment_id': f'large_{str(uuid.uuid4())}',
         'emitter': 'database',
+        'emit_config': True
     }
 
     experiment = Engine(**{
@@ -76,15 +77,14 @@ def run_large_initial_emit():
         **settings})
 
     # run the experiment
-    experiment.update(10)
+    experiment.update(1)
 
     # retrieve the data with data_from_database
     experiment_id = experiment.experiment_id
 
     # retrieve the data from emitter
     data = experiment.emitter.get_data()
-    assert list(data.keys()) == [
-        0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0]
+    assert list(data.keys()) == [0.0, 1.0]
 
     # retrieve the data directly from database
     db = get_experiment_database()
@@ -92,9 +92,33 @@ def run_large_initial_emit():
     assert 'processes' in experiment_config
     assert 0.0 in data
 
+    # check keys of emitted data
+    state = experiment_config['state']
+    store_names = set(str(i) for i in range(config['number_of_ports']))
+    store_values = set([1] * config['number_of_ports'])
+    assert state.keys() == set(composite.processes) | set(('store',))
+    for proc, stores in state['store'].items():
+        assert stores.keys() == store_names
+        assert set(data[1.0]['store'][proc].values()) == store_values
+
     # delete the experiment
     delete_experiment_from_database(experiment_id)
 
 
+def test_large_initial_emit():
+    run_large_experiment({
+        'number_of_processes': 1000,
+        'number_of_parameters': 1000,
+        'number_of_ports': 1})
+
+
+def test_large_sim_emit():
+    run_large_experiment({
+        'number_of_processes': 1000,
+        'number_of_parameters': 1,
+        'number_of_ports': 1000})
+
+
 if __name__ == '__main__':
-    run_large_initial_emit()
+    test_large_initial_emit()
+    test_large_sim_emit()


### PR DESCRIPTION
<!-- Here you should describe what this PR does and why. -->
Adding MongoDB to the test environment proved very straightforward thanks to [service containers](https://docs.github.com/en/actions/using-containerized-services/about-service-containers). I repurposed an existing script to test large emits, query capabilities, and manual insertion of documents. Along the way, I fixed three issues:

- `time` key was not being added to broken-down emits when `time` was 0
- Deleting configuration in `delete_experiment_from_database` failed when using multiple CPU processes
- Documents manually inserted using `data_to_database` were not retrievable by `data_from_database` unless a specific structure was adhered to

According to `pytest`, coverage of `emitter.py` went from 44% to 90% with this PR. Most of the remaining untested code is in the MongoDB Atlas functions.

<!-- DO NOT MODIFY ANYTHING BELOW THIS LINE -->
-----------------------------------------------------------------------

By creating this pull request, I agree to the Contributor License
Agreement, which is available in `CLA.md` at the top level of this
repository.
