### PR TITLE
correct emit_time for the global_time_precision

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -77,5 +77,5 @@ attr-rgx=^[a-z_][a-z0-9]*((_[a-z0-9]+)*)?$
 variable-rgx=^[a-z][a-z0-9]*((_[a-z0-9]+)*)?$
 argument-rgx=^[a-z][a-z0-9]*((_[a-z0-9]+)*)?$
 include-naming-hint=yes
-max-statements=65
+max-statements=70
 max-nested-blocks=6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v1.6.3
 * (#237) Add tests for MongoDB emitter and fix related bugs
+* (#238) apply `global_time_precision` to the `emit_time`
 
 ## v1.6.2
 * (#236) Add data key to breakdown documents if missing

--- a/vivarium/core/engine.py
+++ b/vivarium/core/engine.py
@@ -1027,7 +1027,8 @@ class Engine:
                         self._emit_store_data()
                         emit_time += self.emit_step
                         if self.global_time_precision is not None:
-                            emit_time = round(emit_time, self.global_time_precision)
+                            emit_time = round(emit_time,
+                                              self.global_time_precision)
 
             else:
                 # all processes have run past the interval

--- a/vivarium/core/engine.py
+++ b/vivarium/core/engine.py
@@ -922,6 +922,8 @@ class Engine:
         """
         end_time = self.global_time + interval
         emit_time = self.global_time + self.emit_step
+        if self.global_time_precision is not None:
+            emit_time = round(emit_time, self.global_time_precision)
 
         while self.global_time < end_time or force_complete:
             full_step = math.inf
@@ -1024,6 +1026,8 @@ class Engine:
                     while emit_time <= self.global_time:
                         self._emit_store_data()
                         emit_time += self.emit_step
+                        if self.global_time_precision is not None:
+                            emit_time = round(emit_time, self.global_time_precision)
 
             else:
                 # all processes have run past the interval


### PR DESCRIPTION

Thanks to @pmendes for reporting this bug to me. The `emit_time` was showing some floating point rounding errors, which were not corrected by `global_time_precision`. This fix checks for `global_time_precision` and corrects the `emit_time` accordingly

-----------------------------------------------------------------------

By creating this pull request, I agree to the Contributor License
Agreement, which is available in `CLA.md` at the top level of this
repository.
