### PR TITLE
fix Quantity import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v1.6.4
+* (#240) fix Pint Quantity import error by using more recent version.
+
 ## v1.6.3
 * (#237) Add tests for MongoDB emitter and fix related bugs
 * (#238) apply `global_time_precision` to the `emit_time`

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import re
 from setuptools import setup
 
 
-VERSION = '1.6.3'
+VERSION = '1.6.4'
 
 
 if __name__ == '__main__':

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ if __name__ == '__main__':
             'matplotlib>=3.5.1',
             'networkx>=2.6.3',
             'numpy>=1.22.1',
-            'Pint>=0.18',
+            'Pint>=0.23',
             'pymongo>=4.0.1',
             'scipy>=1.7.3',
             'pytest>=6.2.5',


### PR DESCRIPTION
I have heard reports that the `Quantity` import in `vivarium.library.units` is causing import errors. Trying to fix it with this PR.

-----------------------------------------------------------------------

By creating this pull request, I agree to the Contributor License
Agreement, which is available in `CLA.md` at the top level of this
repository.
